### PR TITLE
chore: init beachball

### DIFF
--- a/.yarn/patches/beachball-npm-2.20.0-a05e0aaaff
+++ b/.yarn/patches/beachball-npm-2.20.0-a05e0aaaff
@@ -1,0 +1,25 @@
+diff --git a/lib/packageManager/packagePublish.js b/lib/packageManager/packagePublish.js
+index 6848f4d9fa070cd5262de8dc19a0a305b0dc4b6d..fbae0aa2b196ed58bde8d086e9b5026f861e880c 100644
+--- a/lib/packageManager/packagePublish.js
++++ b/lib/packageManager/packagePublish.js
+@@ -9,6 +9,10 @@ const npm_1 = require("./npm");
+ function packagePublish(packageInfo, registry, token, access, authType, timeout) {
+     const packageOptions = packageInfo.combinedOptions;
+     const packagePath = path_1.default.dirname(packageInfo.packageJsonPath);
++
++    const packageDir = require('path').relative(packageInfo.combinedOptions.path, packagePath)
++    const artifactsPath = require('path').resolve(packageInfo.combinedOptions.path, 'dist', packageDir)
++
+     const args = [
+         'publish',
+         '--registry',
+@@ -24,7 +28,7 @@ function packagePublish(packageInfo, registry, token, access, authType, timeout)
+         args.push(access);
+     }
+     console.log(`publish command: ${args.join(' ')}`);
+-    return npm_1.npm(args, { cwd: packagePath, timeout });
++    return npm_1.npm(args, { cwd: artifactsPath, timeout });
+ }
+ exports.packagePublish = packagePublish;
+ //# sourceMappingURL=packagePublish.js.map
+\ No newline at end of file

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+/**
+ * @type {import('beachball').BeachballConfig}
+ */
+module.exports = {
+  gitTags: false,
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@typescript-eslint/parser": "~5.3.0",
     "babel-jest": "27.2.3",
     "babel-plugin-annotate-pure-calls": "0.4.0",
+    "beachball": "^2.20.0",
     "eslint": "8.2.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "2.25.2",
@@ -57,5 +58,8 @@
     "rtl-css-js": "^1.15.0",
     "stylis": "^4.0.13",
     "tslib": "^2.1.0"
+  },
+  "resolutions": {
+    "beachball@2.20.0": "patch:beachball@npm:2.20.0#.yarn/patches/beachball-npm-2.20.0-a05e0aaaff"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,6 +4366,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"beachball@npm:^2.20.0":
+  version: 2.21.0
+  resolution: "beachball@npm:2.21.0"
+  dependencies:
+    cosmiconfig: ^6.0.0
+    execa: ^4.0.3
+    fs-extra: ^8.0.1
+    git-url-parse: ^11.1.2
+    glob: ^7.1.4
+    human-id: ^2.0.1
+    lodash: ^4.17.15
+    minimatch: ^3.0.4
+    p-limit: ^3.0.2
+    prompts: ~2.1.0
+    semver: ^6.1.1
+    toposort: ^2.0.2
+    uuid: ^8.3.1
+    workspace-tools: ^0.16.2
+    yargs-parser: ^20.2.4
+  bin:
+    beachball: bin/beachball.js
+  checksum: 468f62b7aef67b03e2e3db8582e1a169851db2d8ebba6849a06720459a4d5d042a0741267760aec514c52b11cea5689d74cbfa062c050df8d398b3c18f641f47
+  languageName: node
+  linkType: hard
+
 "big.js@npm:^5.2.2":
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
@@ -5149,7 +5174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -5811,6 +5836,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"end-of-stream@npm:^1.1.0":
+  version: 1.4.4
+  resolution: "end-of-stream@npm:1.4.4"
+  dependencies:
+    once: ^1.4.0
+  checksum: 530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
+  languageName: node
+  linkType: hard
+
 "enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.7.0, enhanced-resolve@npm:^5.8.3":
   version: 5.8.3
   resolution: "enhanced-resolve@npm:5.8.3"
@@ -6347,6 +6381,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^4.0.3":
+  version: 4.1.0
+  resolution: "execa@npm:4.1.0"
+  dependencies:
+    cross-spawn: ^7.0.0
+    get-stream: ^5.0.0
+    human-signals: ^1.1.1
+    is-stream: ^2.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^4.0.0
+    onetime: ^5.1.0
+    signal-exit: ^3.0.2
+    strip-final-newline: ^2.0.0
+  checksum: e30d298934d9c52f90f3847704fd8224e849a081ab2b517bbc02f5f7732c24e56a21f14cb96a08256deffeb2d12b2b7cb7e2b014a12fb36f8d3357e06417ed55
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -6813,7 +6864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:8.1.0, fs-extra@npm:^8.1.0":
+"fs-extra@npm:8.1.0, fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
   dependencies:
@@ -6974,6 +7025,15 @@ __metadata:
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "get-stream@npm:5.2.0"
+  dependencies:
+    pump: ^3.0.0
+  checksum: 8bc1a23174a06b2b4ce600df38d6c98d2ef6d84e020c1ddad632ad75bac4e092eeb40e4c09e0761c35fc2dbc5e7fff5dab5e763a383582c4a167dd69a905bd12
   languageName: node
   linkType: hard
 
@@ -7152,6 +7212,7 @@ __metadata:
     "@typescript-eslint/parser": ~5.3.0
     babel-jest: 27.2.3
     babel-plugin-annotate-pure-calls: 0.4.0
+    beachball: ^2.20.0
     csstype: ^2.6.19
     eslint: 8.2.0
     eslint-config-prettier: 8.1.0
@@ -7453,6 +7514,20 @@ __metadata:
     agent-base: 6
     debug: 4
   checksum: 165bfb090bd26d47693597661298006841ab733d0c7383a8cb2f17373387a94c903a3ac687090aa739de05e379ab6f868bae84ab4eac288ad85c328cd1ec9e53
+  languageName: node
+  linkType: hard
+
+"human-id@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "human-id@npm:2.0.1"
+  checksum: 4e5b100dbea18dee65b33e62d5b9ac51d73644a5a5e74d09afeb935c57f267292d64c2dd980a1400f6dc431d3e1c9cea4b3c7617e2d666cb88ab4c606dab38c1
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "human-signals@npm:1.1.1"
+  checksum: d587647c9e8ec24e02821b6be7de5a0fc37f591f6c4e319b3054b43fd4c35a70a94c46fc74d8c1a43c47fde157d23acd7421f375e1c1365b09a16835b8300205
   languageName: node
   linkType: hard
 
@@ -8956,7 +9031,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kleur@npm:^3.0.3":
+"kleur@npm:^3.0.2, kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: df82cd1e172f957bae9c536286265a5cdbd5eeca487cb0a3b2a7b41ef959fc61f8e7c0e9aeea9c114ccf2c166b6a8dd45a46fd619c1c569d210ecd2765ad5169
@@ -9202,7 +9277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.x, lodash@npm:^4.17.14, lodash@npm:^4.17.20, lodash@npm:^4.7.0":
+"lodash@npm:4.x, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -9806,7 +9881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.1":
+"npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
   dependencies:
@@ -10022,7 +10097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -10031,7 +10106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.2":
+"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
@@ -11013,6 +11088,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prompts@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "prompts@npm:2.1.0"
+  dependencies:
+    kleur: ^3.0.2
+    sisteransi: ^1.0.0
+  checksum: f84fdae70dd332b7293e26659ae71c0db4a5fe87d9e40f07b4863996feeed1c88ad5c99d4eeb5362d3aec6ffee97c6ba5a9e2870f885a6a43952f4e079fb2226
+  languageName: node
+  linkType: hard
+
 "prop-types@npm:^15.7.2":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
@@ -11052,6 +11137,16 @@ __metadata:
   version: 1.8.0
   resolution: "psl@npm:1.8.0"
   checksum: 6150048ed2da3f919478bee8a82f3828303bc0fc730fb015a48f83c9977682c7b28c60ab01425a72d82a2891a1681627aa530a991d50c086b48a3be27744bde7
+  languageName: node
+  linkType: hard
+
+"pump@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pump@npm:3.0.0"
+  dependencies:
+    end-of-stream: ^1.1.0
+    once: ^1.3.1
+  checksum: e42e9229fba14732593a718b04cb5e1cfef8254544870997e0ecd9732b189a48e1256e4e5478148ecb47c8511dca2b09eae56b4d0aad8009e6fac8072923cfc9
   languageName: node
   linkType: hard
 
@@ -12025,7 +12120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sisteransi@npm:^1.0.5":
+"sisteransi@npm:^1.0.0, sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
   checksum: aba6438f46d2bfcef94cf112c835ab395172c75f67453fe05c340c770d3c402363018ae1ab4172a1026a90c47eaccf3af7b6ff6fa749a680c2929bd7fa2b37a4
@@ -12858,6 +12953,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"toposort@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "toposort@npm:2.0.2"
+  checksum: d64c74b570391c9432873f48e231b439ee56bc49f7cb9780b505cfdf5cb832f808d0bae072515d93834dd6bceca5bb34448b5b4b408335e4d4716eaf68195dcb
+  languageName: node
+  linkType: hard
+
 "tough-cookie@npm:^4.0.0":
   version: 4.0.0
   resolution: "tough-cookie@npm:4.0.0"
@@ -13302,7 +13404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
+"uuid@npm:^8.3.0, uuid@npm:^8.3.1, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
@@ -13825,7 +13927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:20.x, yargs-parser@npm:^20.2.2":
+"yargs-parser@npm:20.x, yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.4":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3


### PR DESCRIPTION
This PR adds [`beachball`](https://www.npmjs.com/package/beachball) as the releasing tool.
The included patch allows to use build output from NX. 