### PR TITLE
fix: rename types to proper names

### DIFF
--- a/change/@griffel-core-2a8ca2c5-72f7-4897-bf39-77720651d3cc.json
+++ b/change/@griffel-core-2a8ca2c5-72f7-4897-bf39-77720651d3cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: rename types to proper names",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/__styles.ts
+++ b/packages/core/src/__styles.ts
@@ -1,5 +1,5 @@
 import { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
-import { GriffelStylesOptions, CSSClassesMapBySlot, CSSRulesByBucket } from './types';
+import { MakeStylesOptions, CSSClassesMapBySlot, CSSRulesByBucket } from './types';
 
 /**
  * A version of makeStyles() that accepts build output as an input and skips all runtime transforms.
@@ -15,7 +15,7 @@ export function __styles<Slots extends string>(
   let ltrClassNamesForSlots: Record<Slots, string> | null = null;
   let rtlClassNamesForSlots: Record<Slots, string> | null = null;
 
-  function computeClasses(options: Pick<GriffelStylesOptions, 'dir' | 'renderer'>): Record<Slots, string> {
+  function computeClasses(options: Pick<MakeStylesOptions, 'dir' | 'renderer'>): Record<Slots, string> {
     const { dir, renderer } = options;
 
     const isLTR = dir === 'ltr';

--- a/packages/core/src/common/snapshotSerializers.ts
+++ b/packages/core/src/common/snapshotSerializers.ts
@@ -3,7 +3,7 @@
 import * as prettier from 'prettier';
 
 import { resolveStyleRules } from '../runtime/resolveStyleRules';
-import type { GriffelStylesRenderer } from '../types';
+import type { GriffelRenderer } from '../types';
 
 // eslint-disable-next-line eqeqeq
 const isObject = (value: unknown) => value != null && !Array.isArray(value) && typeof value === 'object';
@@ -16,7 +16,7 @@ export const griffelRendererSerializer: jest.SnapshotSerializerPlugin = {
     /**
      * test function makes sure that value is the guarded type
      */
-    const _value = value as GriffelStylesRenderer;
+    const _value = value as GriffelRenderer;
 
     const styleElementsKeys = Object.keys(_value.styleElements) as (keyof typeof _value['styleElements'])[];
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,18 +49,18 @@ export { __styles } from './__styles';
 export * from './constants';
 export type {
   // Static styles
-  GriffelStaticStylesStyle,
+  GriffelStaticStyle,
   GriffelStaticStyles,
   // Styles
-  GriffelStylesAnimation,
-  GriffelStylesStyle,
+  GriffelAnimation,
+  GriffelStyle,
   // Internal types
   CSSClasses,
   CSSClassesMapBySlot,
   CSSRulesByBucket,
   StyleBucketName,
   // Util
-  GriffelStaticStylesOptions,
-  GriffelStylesOptions,
-  GriffelStylesRenderer,
+  MakeStaticStylesOptions,
+  MakeStylesOptions,
+  GriffelRenderer,
 } from './types';

--- a/packages/core/src/makeStaticStyles.test.ts
+++ b/packages/core/src/makeStaticStyles.test.ts
@@ -2,12 +2,12 @@ import { createDOMRenderer } from './renderer/createDOMRenderer';
 import { griffelRendererSerializer } from './common/snapshotSerializers';
 import { makeStaticStyles } from './makeStaticStyles';
 import { makeStyles } from './makeStyles';
-import { GriffelStylesRenderer } from './types';
+import { GriffelRenderer } from './types';
 
 expect.addSnapshotSerializer(griffelRendererSerializer);
 
 describe('makeStaticStyles', () => {
-  let renderer: GriffelStylesRenderer;
+  let renderer: GriffelRenderer;
 
   beforeEach(() => {
     renderer = createDOMRenderer(document);

--- a/packages/core/src/makeStaticStyles.ts
+++ b/packages/core/src/makeStaticStyles.ts
@@ -1,5 +1,5 @@
 import { resolveStaticStyleRules } from './runtime/resolveStaticStyleRules';
-import { GriffelStaticStylesOptions, GriffelStaticStyles } from './types';
+import { MakeStaticStylesOptions, GriffelStaticStyles } from './types';
 
 /**
  * Register static css.
@@ -9,7 +9,7 @@ export function makeStaticStyles(styles: GriffelStaticStyles | GriffelStaticStyl
   const styleCache: Record<string, true> = {};
   const stylesSet: GriffelStaticStyles[] = Array.isArray(styles) ? styles : [styles];
 
-  function useStaticStyles(options: GriffelStaticStylesOptions): void {
+  function useStaticStyles(options: MakeStaticStylesOptions): void {
     const cacheKey = options.renderer.id;
     if (styleCache[cacheKey]) {
       return;

--- a/packages/core/src/makeStyles.test.ts
+++ b/packages/core/src/makeStyles.test.ts
@@ -1,12 +1,12 @@
 import { createDOMRenderer } from './renderer/createDOMRenderer';
 import { griffelRendererSerializer } from './common/snapshotSerializers';
 import { makeStyles } from './makeStyles';
-import { GriffelStylesRenderer } from './types';
+import { GriffelRenderer } from './types';
 
 expect.addSnapshotSerializer(griffelRendererSerializer);
 
 describe('makeStyles', () => {
-  let renderer: GriffelStylesRenderer;
+  let renderer: GriffelRenderer;
 
   beforeEach(() => {
     renderer = createDOMRenderer(document);

--- a/packages/core/src/makeStyles.ts
+++ b/packages/core/src/makeStyles.ts
@@ -1,6 +1,6 @@
 import { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
 import { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
-import { CSSClassesMapBySlot, CSSRulesByBucket, GriffelStylesOptions, StylesBySlots } from './types';
+import { CSSClassesMapBySlot, CSSRulesByBucket, MakeStylesOptions, StylesBySlots } from './types';
 
 export function makeStyles<Slots extends string | number>(stylesBySlots: StylesBySlots<Slots>) {
   const insertionCache: Record<string, boolean> = {};
@@ -11,7 +11,7 @@ export function makeStyles<Slots extends string | number>(stylesBySlots: StylesB
   let ltrClassNamesForSlots: Record<Slots, string> | null = null;
   let rtlClassNamesForSlots: Record<Slots, string> | null = null;
 
-  function computeClasses(options: GriffelStylesOptions): Record<Slots, string> {
+  function computeClasses(options: MakeStylesOptions): Record<Slots, string> {
     const { dir, renderer } = options;
 
     if (classesMapBySlot === null) {

--- a/packages/core/src/mergeClasses.test.ts
+++ b/packages/core/src/mergeClasses.test.ts
@@ -1,10 +1,10 @@
 import { mergeClasses } from './mergeClasses';
 import { makeStyles } from './makeStyles';
 import { createDOMRenderer } from './renderer/createDOMRenderer';
-import { GriffelStylesOptions } from './types';
+import { MakeStylesOptions } from './types';
 import { SEQUENCE_PREFIX } from './constants';
 
-const options: GriffelStylesOptions = {
+const options: MakeStylesOptions = {
   dir: 'ltr',
   renderer: createDOMRenderer(document),
 };

--- a/packages/core/src/renderer/createDOMRenderer.ts
+++ b/packages/core/src/renderer/createDOMRenderer.ts
@@ -1,4 +1,4 @@
-import { GriffelStylesRenderer, StyleBucketName } from '../types';
+import { GriffelRenderer, StyleBucketName } from '../types';
 import { getStyleSheetForBucket } from './getStyleSheetForBucket';
 
 let lastIndex = 0;
@@ -23,9 +23,9 @@ export interface CreateDOMRendererOptions {
 export function createDOMRenderer(
   target: Document | undefined = typeof document === 'undefined' ? undefined : document,
   options: CreateDOMRendererOptions = {},
-): GriffelStylesRenderer {
+): GriffelRenderer {
   const { unstable_filterCSSRule } = options;
-  const renderer: GriffelStylesRenderer = {
+  const renderer: GriffelRenderer = {
     insertionCache: {},
     styleElements: {},
 

--- a/packages/core/src/renderer/getStyleSheetForBucket.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.ts
@@ -1,4 +1,4 @@
-import { GriffelStylesRenderer, StyleBucketName } from '../types';
+import { GriffelRenderer, StyleBucketName } from '../types';
 
 /**
  * Ordered style buckets using their short pseudo name.
@@ -34,7 +34,7 @@ export const styleBucketOrdering: StyleBucketName[] = [
 export function getStyleSheetForBucket(
   bucketName: StyleBucketName,
   target: Document,
-  renderer: GriffelStylesRenderer,
+  renderer: GriffelRenderer,
 ): CSSStyleSheet {
   if (!renderer.styleElements[bucketName]) {
     let currentBucketIndex = styleBucketOrdering.indexOf(bucketName) + 1;

--- a/packages/core/src/renderer/rehydrateRendererCache.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.ts
@@ -1,4 +1,4 @@
-import { GriffelStylesRenderer, StyleBucketName } from '../types';
+import { GriffelRenderer, StyleBucketName } from '../types';
 
 // Regexps to extract names of classes and animations
 // https://github.com/styletron/styletron/blob/e0fcae826744eb00ce679ac613a1b10d44256660/packages/styletron-engine-atomic/src/client/client.js#L8
@@ -18,7 +18,7 @@ const regexps: Partial<Record<StyleBucketName, RegExp>> = {
  * @public
  */
 export function rehydrateRendererCache(
-  renderer: GriffelStylesRenderer,
+  renderer: GriffelRenderer,
   target: Document | undefined = typeof document === 'undefined' ? undefined : document,
 ) {
   if (target) {

--- a/packages/core/src/resolveStyleRulesForSlots.ts
+++ b/packages/core/src/resolveStyleRulesForSlots.ts
@@ -1,5 +1,5 @@
 import { resolveStyleRules } from './runtime/resolveStyleRules';
-import { CSSClassesMapBySlot, CSSRulesByBucket, GriffelStylesStyle, StyleBucketName, StylesBySlots } from './types';
+import { CSSClassesMapBySlot, CSSRulesByBucket, GriffelStyle, StyleBucketName, StylesBySlots } from './types';
 
 /**
  * Calls resolveStyleRules() for each slot, is also used by build time transform.
@@ -16,7 +16,7 @@ export function resolveStyleRulesForSlots<Slots extends string | number>(
 
   // eslint-disable-next-line guard-for-in
   for (const slotName in stylesBySlots) {
-    const slotStyles: GriffelStylesStyle = stylesBySlots[slotName];
+    const slotStyles: GriffelStyle = stylesBySlots[slotName];
     const [cssClassMap, cssRulesByBucket] = resolveStyleRules(slotStyles);
 
     classesMapBySlot[slotName] = cssClassMap;

--- a/packages/core/src/runtime/compileKeyframeCSS.test.ts
+++ b/packages/core/src/runtime/compileKeyframeCSS.test.ts
@@ -1,9 +1,9 @@
 import { compileKeyframeRule, compileKeyframesCSS } from './compileKeyframeCSS';
-import { GriffelStylesAnimation } from '../types';
+import { GriffelAnimation } from '../types';
 
 describe('compileKeyframeRule', () => {
   it('stringifies an object with keyframes', () => {
-    const keyframes: GriffelStylesAnimation = {
+    const keyframes: GriffelAnimation = {
       from: {
         transform: 'rotate(0deg)',
       },
@@ -19,7 +19,7 @@ describe('compileKeyframeRule', () => {
 
 describe('compileKeyframeCSS', () => {
   it('creates CSS from strings with keyframes', () => {
-    const keyframes: GriffelStylesAnimation = {
+    const keyframes: GriffelAnimation = {
       from: {
         height: '10px',
       },

--- a/packages/core/src/runtime/compileKeyframeCSS.ts
+++ b/packages/core/src/runtime/compileKeyframeCSS.ts
@@ -1,8 +1,8 @@
-import { GriffelStylesAnimation } from '../types';
+import { GriffelAnimation } from '../types';
 import { compile, middleware, serialize, rulesheet, stringify, prefixer } from 'stylis';
 import { cssifyObject } from './utils/cssifyObject';
 
-export function compileKeyframeRule(keyframeObject: GriffelStylesAnimation): string {
+export function compileKeyframeRule(keyframeObject: GriffelAnimation): string {
   let css = '';
 
   // eslint-disable-next-line guard-for-in

--- a/packages/core/src/runtime/compileStaticCSS.ts
+++ b/packages/core/src/runtime/compileStaticCSS.ts
@@ -1,8 +1,8 @@
-import { GriffelStaticStylesStyle } from '../types';
+import { GriffelStaticStyle } from '../types';
 import { compileCSSRules } from './compileCSS';
 import { cssifyObject } from './utils/cssifyObject';
 
-export function compileStaticCSS(property: string, value: GriffelStaticStylesStyle): string {
+export function compileStaticCSS(property: string, value: GriffelStaticStyle): string {
   const cssRule = `${property} {${cssifyObject(value)}}`;
   return compileCSSRules(cssRule)[0];
 }

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -2,7 +2,7 @@ import hashString from '@emotion/hash';
 import { convert, convertProperty } from 'rtl-css-js/core';
 
 import { HASH_PREFIX } from '../constants';
-import { GriffelStylesStyle, CSSClassesMap, CSSRulesByBucket, StyleBucketName, GriffelStylesAnimation } from '../types';
+import { GriffelStyle, CSSClassesMap, CSSRulesByBucket, StyleBucketName, GriffelAnimation } from '../types';
 import { compileCSS, CompileCSSOptions } from './compileCSS';
 import { compileKeyframeRule, compileKeyframesCSS } from './compileKeyframeCSS';
 import { generateCombinedQuery } from './utils/generateCombinedMediaQuery';
@@ -44,7 +44,7 @@ function pushToCSSRules(
  * @internal
  */
 export function resolveStyleRules(
-  styles: GriffelStylesStyle,
+  styles: GriffelStyle,
   pseudo = '',
   media = '',
   support = '',
@@ -54,7 +54,7 @@ export function resolveStyleRules(
 ): [CSSClassesMap, CSSRulesByBucket] {
   // eslint-disable-next-line guard-for-in
   for (const property in styles) {
-    const value = styles[property as keyof GriffelStylesStyle];
+    const value = styles[property as keyof GriffelStyle];
 
     // eslint-disable-next-line eqeqeq
     if (value == null) {
@@ -106,9 +106,7 @@ export function resolveStyleRules(
       pushToClassesMap(cssClassesMap, key, className, rtlClassName);
       pushToCSSRules(cssRulesByBucket, styleBucketName, ltrCSS, rtlCSS);
     } else if (property === 'animationName') {
-      const animationNameValue = Array.isArray(value)
-        ? (value as GriffelStylesAnimation[])
-        : [value as GriffelStylesAnimation];
+      const animationNameValue = Array.isArray(value) ? (value as GriffelAnimation[]) : [value as GriffelAnimation];
 
       const animationNames: string[] = [];
       const rtlAnimationNames: string[] = [];
@@ -157,7 +155,7 @@ export function resolveStyleRules(
     } else if (isObject(value)) {
       if (isNestedSelector(property)) {
         resolveStyleRules(
-          value as GriffelStylesStyle,
+          value as GriffelStyle,
           pseudo + normalizeNestedProperty(property),
           media,
           support,
@@ -167,25 +165,11 @@ export function resolveStyleRules(
       } else if (isMediaQuerySelector(property)) {
         const combinedMediaQuery = generateCombinedQuery(media, property.slice(6).trim());
 
-        resolveStyleRules(
-          value as GriffelStylesStyle,
-          pseudo,
-          combinedMediaQuery,
-          support,
-          cssClassesMap,
-          cssRulesByBucket,
-        );
+        resolveStyleRules(value as GriffelStyle, pseudo, combinedMediaQuery, support, cssClassesMap, cssRulesByBucket);
       } else if (isSupportQuerySelector(property)) {
         const combinedSupportQuery = generateCombinedQuery(support, property.slice(9).trim());
 
-        resolveStyleRules(
-          value as GriffelStylesStyle,
-          pseudo,
-          media,
-          combinedSupportQuery,
-          cssClassesMap,
-          cssRulesByBucket,
-        );
+        resolveStyleRules(value as GriffelStyle, pseudo, media, combinedSupportQuery, cssClassesMap, cssRulesByBucket);
       } else {
         if (process.env.NODE_ENV !== 'production') {
           // eslint-disable-next-line no-console

--- a/packages/core/src/runtime/utils/cssifyObject.ts
+++ b/packages/core/src/runtime/utils/cssifyObject.ts
@@ -1,12 +1,12 @@
-import { GriffelStaticStylesStyle, GriffelStylesStyle } from '../../types';
+import { GriffelStaticStyle, GriffelStyle } from '../../types';
 import { hyphenateProperty } from './hyphenateProperty';
 
-export function cssifyObject(style: GriffelStylesStyle | GriffelStaticStylesStyle) {
+export function cssifyObject(style: GriffelStyle | GriffelStaticStyle) {
   let css = '';
 
   // eslint-disable-next-line guard-for-in
   for (const property in style) {
-    const value = style[property as keyof GriffelStylesStyle];
+    const value = style[property as keyof GriffelStyle];
 
     if (typeof value !== 'string' && typeof value !== 'number') {
       continue;

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,6 +1,6 @@
-import { GriffelStylesStyle } from './types';
+import { GriffelStyle } from './types';
 
-function assertType(style: GriffelStylesStyle): GriffelStylesStyle {
+function assertType(style: GriffelStyle): GriffelStyle {
   return style;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -56,7 +56,7 @@ type GriffelStylesCSSProperties = Omit<
 
 export type GriffelStylesStrictCSSObject = GriffelStylesCSSProperties &
   GriffelStylesCSSPseudos & {
-    animationName?: GriffelStylesAnimation | GriffelStylesAnimation[] | CSS.AnimationProperty;
+    animationName?: GriffelAnimation | GriffelAnimation[] | CSS.AnimationProperty;
     fontWeight?: CSS.Properties['fontWeight'] | string;
   };
 
@@ -88,15 +88,15 @@ type GriffelStylesCSSObjectCustomL5 = {
   [Property: string]: GriffelStylesCSSValue | undefined;
 } & GriffelStylesStrictCSSObject;
 
-export type GriffelStylesAnimation = Record<'from' | 'to' | string, GriffelStylesCSSObjectCustomL1>;
-export type GriffelStylesStyle = GriffelStylesStrictCSSObject | GriffelStylesCSSObjectCustomL1;
+export type GriffelAnimation = Record<'from' | 'to' | string, GriffelStylesCSSObjectCustomL1>;
+export type GriffelStyle = GriffelStylesStrictCSSObject | GriffelStylesCSSObjectCustomL1;
 
-export interface GriffelStylesOptions {
+export interface MakeStylesOptions {
   dir: 'ltr' | 'rtl';
-  renderer: GriffelStylesRenderer;
+  renderer: GriffelRenderer;
 }
 
-export type GriffelStaticStylesStyle = {
+export type GriffelStaticStyle = {
   [key: string]: CSS.Properties &
     // TODO Questionable: how else would users target their own children?
     Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -115,13 +115,13 @@ export type GriffelStaticStylesStyle = {
     unicodeRange?: string;
   };
 };
-export type GriffelStaticStyles = GriffelStaticStylesStyle | string;
+export type GriffelStaticStyles = GriffelStaticStyle | string;
 
-export interface GriffelStaticStylesOptions {
-  renderer: GriffelStylesRenderer;
+export interface MakeStaticStylesOptions {
+  renderer: GriffelRenderer;
 }
 
-export interface GriffelStylesRenderer {
+export interface GriffelRenderer {
   id: string;
 
   /**
@@ -175,6 +175,6 @@ export type CSSClassesMapBySlot<Slots extends string | number> = Record<Slots, C
 
 export type CSSRulesByBucket = Partial<Record<StyleBucketName, string[]>>;
 
-export type StylesBySlots<Slots extends string | number> = Record<Slots, GriffelStylesStyle>;
+export type StylesBySlots<Slots extends string | number> = Record<Slots, GriffelStyle>;
 
 export type LookupItem = [/* definitions */ CSSClassesMap, /* dir */ 'rtl' | 'ltr'];


### PR DESCRIPTION
This PR renames types that had wrong names during initial push:

- `GriffelStaticStylesStyle` => `GriffelStaticStyle`
-  `GriffelStylesAnimation` => `GriffelAnimation`
-  `GriffelStylesStyle` => `GriffelStyle`
- `GriffelStaticStylesOptions` => `MakeStaticStylesOptions`
- `GriffelStylesOptions` => `MakeStylesOptions`
- `GriffelStylesRenderer` => `GriffelRenderer`