### PR TITLE
fix false positive warning in mergeClasses()

### DIFF
--- a/change/@griffel-core-ae835232-8a2a-48df-a1d2-6a524f897338.json
+++ b/change/@griffel-core-ae835232-8a2a-48df-a1d2-6a524f897338.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix false positive warning in mergeClasses()",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/mergeClasses.ts
+++ b/packages/core/src/mergeClasses.ts
@@ -98,30 +98,33 @@ export function mergeClasses(): string {
 
   for (let i = 0; i < arguments.length; i++) {
     const sequenceId = sequencesIds[i];
-    const sequenceMapping = sequenceId ? DEFINITION_LOOKUP_TABLE[sequenceId] : undefined;
 
-    if (sequenceMapping) {
-      sequenceMappings.push(sequenceMapping[LOOKUP_DEFINITIONS_INDEX]);
+    if (sequenceId) {
+      const sequenceMapping = DEFINITION_LOOKUP_TABLE[sequenceId];
 
-      if (process.env.NODE_ENV !== 'production') {
-        if (dir !== null && dir !== sequenceMapping[LOOKUP_DIR_INDEX]) {
+      if (sequenceMapping) {
+        sequenceMappings.push(sequenceMapping[LOOKUP_DEFINITIONS_INDEX]);
+
+        if (process.env.NODE_ENV !== 'production') {
+          if (dir !== null && dir !== sequenceMapping[LOOKUP_DIR_INDEX]) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `mergeClasses(): a passed string contains an identifier (${sequenceId}) that has different direction ` +
+                `(dir="${sequenceMapping[1] ? 'rtl' : 'ltr'}") setting than other classes. This is not supported. ` +
+                `Source string: ${arguments[i]}`,
+            );
+          }
+        }
+
+        dir = sequenceMapping[LOOKUP_DIR_INDEX];
+      } else {
+        if (process.env.NODE_ENV !== 'production') {
           // eslint-disable-next-line no-console
           console.error(
-            `mergeClasses(): a passed string contains an identifier (${sequenceId}) that has different direction ` +
-              `(dir="${sequenceMapping[1] ? 'rtl' : 'ltr'}") setting than other classes. This is not supported. ` +
-              `Source string: ${arguments[i]}`,
+            `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry ` +
+              `in cache. Source string: ${arguments[i]}`,
           );
         }
-      }
-
-      dir = sequenceMapping[LOOKUP_DIR_INDEX];
-    } else {
-      if (process.env.NODE_ENV !== 'production') {
-        // eslint-disable-next-line no-console
-        console.error(
-          `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry ` +
-            `in cache. Source string: ${arguments[i]}`,
-        );
       }
     }
   }


### PR DESCRIPTION
This PR fixes a bug with false positive warning, the regression was introduced in https://github.com/microsoft/fluentui/pull/21288.

The warning should be emitted only when `DEFINITION_LOOKUP_TABLE[sequenceId]` does not exist. But existing condition also triggered it when `sequencesIds[i]` is `undefined` while `sequencesIds[i]` can be `undefined`, it's okay.