### PR TITLE
feat: add Babel preset

### DIFF
--- a/change/@griffel-babel-preset-dad049ef-1bbe-4037-8a92-968e897c86fb.json
+++ b/change/@griffel-babel-preset-dad049ef-1bbe-4037-8a92-968e897c86fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "initial release",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "nx affected:test"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.12.13",
     "@fluentui/bundle-size": "^1.1.4",
     "@nrwl/cli": "13.4.5",
     "@nrwl/eslint-plugin-nx": "13.4.5",
@@ -30,6 +31,7 @@
     "@testing-library/jest-dom": "5.16.1",
     "@testing-library/react": "12.1.2",
     "@testing-library/react-hooks": "7.0.2",
+    "@types/babel__helper-plugin-utils": "7.10.0",
     "@types/jest": "27.0.2",
     "@types/node": "14.14.33",
     "@types/react": "17.0.30",
@@ -39,6 +41,7 @@
     "@typescript-eslint/parser": "~5.3.0",
     "babel-jest": "27.2.3",
     "babel-plugin-annotate-pure-calls": "0.4.0",
+    "babel-plugin-tester": "10.0.0",
     "beachball": "^2.20.0",
     "eslint": "8.2.0",
     "eslint-config-prettier": "8.1.0",
@@ -57,7 +60,15 @@
     "typescript": "~4.4.3"
   },
   "dependencies": {
+    "@babel/core": "^7.12.13",
+    "@babel/generator": "^7.12.13",
+    "@babel/helper-plugin-utils": "^7.12.13",
+    "@babel/template": "^7.12.13",
+    "@babel/traverse": "^7.12.13",
     "@emotion/hash": "^0.8.0",
+    "@linaria/babel-preset": "^3.0.0-beta.14",
+    "@linaria/shaker": "^3.0.0-beta.14",
+    "ajv": "^8.4.0",
     "csstype": "^2.6.19",
     "rtl-css-js": "^1.15.0",
     "stylis": "^4.0.13",

--- a/packages/babel-preset/.eslintrc.json
+++ b/packages/babel-preset/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*", "__fixtures__/*/output.ts"],
+  "overrides": [
+    {
+      "files": ["__fixtures__/*/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    },
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -1,0 +1,179 @@
+# Babel preset for Griffel
+
+A Babel preset that performs build time transforms for [`@griffel/react`](../react).
+
+## Install
+
+```bash
+yarn add @griffel/babel-preset
+```
+
+## Usage
+
+`.babelrc`
+
+```json
+{
+  "presets": ["@griffel/babel"]
+}
+```
+
+### Importing Griffel from custom packages
+
+```js
+import { makeStyles } from 'custom-package';
+// 👇 custom import names are also supported
+import { createStyles } from 'custom-package';
+```
+
+By default, preset handles imports from `@griffel/react`, to handle imports from custom packages settings should be tweaked:
+
+```json
+{
+  "presets": [
+    [
+      "@griffel/babel",
+      {
+        "modules": [{ "moduleSource": "custom-package", "importName": "makeStyles" }]
+      }
+    ]
+  ]
+}
+```
+
+> **Note**: "custom-package" should re-export `__styles` function from `@griffel/react`
+
+### Configuring Babel settings
+
+If you need to specify custom Babel configuration, you can pass them to `babelOptions`. These options will be used by the preset when parsing and evaluating modules.
+
+```json
+{
+  "presets": [
+    [
+      "@griffel/babel",
+      {
+        "babelOptions": {
+          "plugins": ["@babel/plugin-proposal-class-static-block"],
+          "presets": ["@babel/preset-typescript"]
+        }
+      }
+    ]
+  ]
+}
+```
+
+### Configuring module evaluation
+
+```json
+{
+  "presets": [
+    [
+      "@griffel/babel",
+      {
+        "evaluationRules": []
+      }
+    ]
+  ]
+}
+```
+
+The set of rules that defines how the matched files will be transformed during the evaluation. `EvalRule` is an object with two fields:
+
+- test is a regular expression or a function `(path: string) => boolean`
+- action is an `Evaluator` function, "ignore" or a name of the module that exports `Evaluator` function as a **default** export
+
+_If `test` is omitted, the rule is applicable for all the files._
+
+The last matched rule is used for transformation. If the last matched action for a file is "ignore" the file will be evaluated as is, so that file must not contain any js code that cannot be executed in nodejs environment (it's usually true for any lib in `node_modules`).
+
+If you need to compile certain modules under `/node_modules/` (which can be the case in monorepo projects), it's recommended to do it on a module by module basis for faster transforms, e.g. ignore: `/node_modules[\/\\](?!some-module|other-module)/`.
+
+The default setup is:
+
+```js
+module.exports = {
+  presets: [
+    [
+      '@griffel/babel',
+      {
+        evaluationRules: [
+          {
+            action: require('@linaria/shaker').default,
+          },
+          {
+            test: /[/\\]node_modules[/\\]/,
+            action: 'ignore',
+          },
+        ],
+      },
+    ],
+  ],
+};
+```
+
+## Transforms
+
+This preset is designed to perform build time transforms for `@griffel/react`, it supports both ES modules and CommonJS thus can be used in post processing after TypeScript, for example.
+
+Transforms applied by this preset allow stripping runtime part of `makeStyles()` and improve performance.
+
+## Example
+
+Transforms
+
+```js
+import { makeStyles } from '@griffel/react';
+
+const useStyles = makeStyles({
+  root: { color: 'red' },
+});
+```
+
+roughly to
+
+```js
+import { __styles } from '@griffel/react';
+
+const useStyles = __styles(/* resolved styles */);
+```
+
+## Troubleshooting
+
+This section focuses mainly on troubleshooting this babel preset in the [microsoft/fluentui](https://github.com/microsoft/fluentui) repo.
+However, the concepts are not coupled to the repo setup.
+
+### Linaria
+
+The preset uses tools from [linaria](https://github.com/callstack/linaria) to evaluate runtime calls of `makeStyles`.
+[Linaria's debugging documentation can help here](https://github.com/callstack/linaria/blob/master/CONTRIBUTING.md#debugging-and-deep-dive-into-babel-plugin). Here are a few examples with building packages with linaria debug output.
+
+Directly from the package
+
+```sh
+$ DEBUG=linaria\* LINARIA_LOG=debug yarn build
+```
+
+Using Lage from the root of the repo
+
+```sh
+$ DEBUG=linaria\* LINARIA_LOG=debug yarn lage build --to <package-name>
+```
+
+Using `yarn workspace` from the root of the repo
+
+```sh
+$ DEBUG=linaria\* LINARIA_LOG=debug yarn workspace <package-name> build
+```
+
+On Windows it's required to set environment variables via [`set`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1) or you can use `cross-env`, for example:
+
+```sh
+$ yarn cross-env DEBUG=linaria\* LINARIA_LOG=debug yarn workspace <package-name> build
+```
+
+The debug output will include:
+
+- Transformed code
+- Evaluated code
+- AST that indicates what code has been shaken with `@linaria/shaker`

--- a/packages/babel-preset/__fixtures__/commonjs/code.ts
+++ b/packages/babel-preset/__fixtures__/commonjs/code.ts
@@ -1,0 +1,10 @@
+const react_make_styles_1 = require('@griffel/react');
+
+export const useStyles = react_make_styles_1.makeStyles({
+  root: {
+    fontSize: '14px',
+    lineHeight: 1,
+  },
+});
+
+console.log(useStyles);

--- a/packages/babel-preset/__fixtures__/commonjs/output.ts
+++ b/packages/babel-preset/__fixtures__/commonjs/output.ts
@@ -1,0 +1,14 @@
+const react_make_styles_1 = require('@griffel/react');
+
+export const useStyles = react_make_styles_1.__styles(
+  {
+    root: {
+      Be2twd7: 'fses1vf',
+      Bg96gwp: 'fp6vxd',
+    },
+  },
+  {
+    d: ['.fses1vf{font-size:14px;}', '.fp6vxd{line-height:1;}'],
+  },
+);
+console.log(useStyles);

--- a/packages/babel-preset/__fixtures__/config-babel-options/code.ts
+++ b/packages/babel-preset/__fixtures__/config-babel-options/code.ts
@@ -1,0 +1,13 @@
+import { makeStyles } from '@griffel/react';
+
+const func = () => {
+  // This assignment has no sense, but it will prevent us from evaluation in AST
+  // This fixture uses "colorRenamePlugin.js" in transformPlugin's config so input we should get a different color
+  const color = 'red';
+
+  return { color };
+};
+
+export const useStyles = makeStyles({
+  root: func(),
+});

--- a/packages/babel-preset/__fixtures__/config-babel-options/colorRenamePlugin.js
+++ b/packages/babel-preset/__fixtures__/config-babel-options/colorRenamePlugin.js
@@ -1,0 +1,17 @@
+// A small transformPlugin to test configuration options
+// Replaces all "red" strings with "blue" ones
+
+module.exports = function (babel) {
+  const { types: t } = babel;
+
+  return {
+    name: 'color-rename-transformPlugin',
+    visitor: {
+      StringLiteral(path) {
+        if (path.node.value === 'red') {
+          path.replaceWith(t.StringLiteral('blue'));
+        }
+      },
+    },
+  };
+};

--- a/packages/babel-preset/__fixtures__/config-babel-options/options.json
+++ b/packages/babel-preset/__fixtures__/config-babel-options/options.json
@@ -1,0 +1,5 @@
+{
+  "babelOptions": {
+    "plugins": ["./packages/babel-preset/__fixtures__/config-babel-options/colorRenamePlugin"]
+  }
+}

--- a/packages/babel-preset/__fixtures__/config-babel-options/output.ts
+++ b/packages/babel-preset/__fixtures__/config-babel-options/output.ts
@@ -1,0 +1,21 @@
+import { __styles } from '@griffel/react';
+
+const func = () => {
+  // This assignment has no sense, but it will prevent us from evaluation in AST
+  // This fixture uses "colorRenamePlugin.js" in transformPlugin's config so input we should get a different color
+  const color = 'red';
+  return {
+    color,
+  };
+};
+
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'f163i14w',
+    },
+  },
+  {
+    d: ['.f163i14w{color:blue;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/config-evaluation-rules/code.ts
+++ b/packages/babel-preset/__fixtures__/config-evaluation-rules/code.ts
@@ -1,0 +1,8 @@
+import { makeStyles } from '@griffel/react';
+import { colorRed } from './consts';
+
+export const useStyles = makeStyles({
+  // This import has no sense, but it will prevent us from evaluation in AST by Babel
+  // This fixture uses "sampleEvaluator.js" in transformPlugin's config so input we should get a different color
+  root: { color: colorRed },
+});

--- a/packages/babel-preset/__fixtures__/config-evaluation-rules/consts.ts
+++ b/packages/babel-preset/__fixtures__/config-evaluation-rules/consts.ts
@@ -1,0 +1,1 @@
+export const colorRed = 'red';

--- a/packages/babel-preset/__fixtures__/config-evaluation-rules/options.json
+++ b/packages/babel-preset/__fixtures__/config-evaluation-rules/options.json
@@ -1,0 +1,7 @@
+{
+  "evaluationRules": [
+    {
+      "action": "sampleEvaluator"
+    }
+  ]
+}

--- a/packages/babel-preset/__fixtures__/config-evaluation-rules/output.ts
+++ b/packages/babel-preset/__fixtures__/config-evaluation-rules/output.ts
@@ -1,0 +1,12 @@
+import { __styles } from '@griffel/react';
+import { colorRed } from './consts';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'f163i14w',
+    },
+  },
+  {
+    d: ['.f163i14w{color:blue;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/config-evaluation-rules/sampleEvaluator.js
+++ b/packages/babel-preset/__fixtures__/config-evaluation-rules/sampleEvaluator.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+/** @type {import("@linaria/babel-preset").Evaluator} */
+const sampleEvaluator = () => {
+  // Evaluators transform input code to something that will be evaluated by Node later. In evaluatePathsInVM() we expect
+  // that results will be available as "exports.__mkPreval", this evaluator mocks it
+  const result = `exports.__mkPreval = [{ root: { color: 'blue' } }]`;
+
+  return [result, null];
+};
+
+module.exports.default = sampleEvaluator;

--- a/packages/babel-preset/__fixtures__/error-argument-count/fixture.js
+++ b/packages/babel-preset/__fixtures__/error-argument-count/fixture.js
@@ -1,0 +1,4 @@
+import { makeStyles } from '@griffel/react';
+
+// This file is .js intentionally to avoid TS compiler errors
+export const useStyles = makeStyles({ root: { color: 'red' } }, 'foo');

--- a/packages/babel-preset/__fixtures__/error-argument-type/fixture.js
+++ b/packages/babel-preset/__fixtures__/error-argument-type/fixture.js
@@ -1,0 +1,4 @@
+import { makeStyles } from '@griffel/react';
+
+// This file is .js intentionally to avoid TS compiler errors
+export const useStyles = makeStyles([]);

--- a/packages/babel-preset/__fixtures__/error-config-babel-options/fixture.ts
+++ b/packages/babel-preset/__fixtures__/error-config-babel-options/fixture.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { color: 'red' },
+});

--- a/packages/babel-preset/__fixtures__/function-mixin/code.ts
+++ b/packages/babel-preset/__fixtures__/function-mixin/code.ts
@@ -1,0 +1,6 @@
+import { makeStyles } from '@griffel/react';
+import { createMixin } from './mixins';
+
+export const useStyles = makeStyles({
+  avatar: createMixin({ display: 'block', opacity: '0' }),
+});

--- a/packages/babel-preset/__fixtures__/function-mixin/mixins.ts
+++ b/packages/babel-preset/__fixtures__/function-mixin/mixins.ts
@@ -1,0 +1,7 @@
+import { GriffelStyle } from '@griffel/core';
+import { tokens } from './tokens';
+
+export const createMixin = (rule: GriffelStyle): GriffelStyle => ({
+  color: tokens.colorBrandBackground,
+  ...rule,
+});

--- a/packages/babel-preset/__fixtures__/function-mixin/output.ts
+++ b/packages/babel-preset/__fixtures__/function-mixin/output.ts
@@ -1,0 +1,14 @@
+import { __styles } from '@griffel/react';
+import { createMixin } from './mixins';
+export const useStyles = __styles(
+  {
+    avatar: {
+      sj55zd: 'f1817uup',
+      mc9l5x: 'ftgm304',
+      abs64n: 'fk73vx1',
+    },
+  },
+  {
+    d: ['.f1817uup{color:var(--colorBrandBackground);}', '.ftgm304{display:block;}', '.fk73vx1{opacity:0;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/function-mixin/tokens.ts
+++ b/packages/babel-preset/__fixtures__/function-mixin/tokens.ts
@@ -1,0 +1,3 @@
+export const tokens = {
+  colorBrandBackground: 'var(--colorBrandBackground)',
+};

--- a/packages/babel-preset/__fixtures__/import-alias/code.ts
+++ b/packages/babel-preset/__fixtures__/import-alias/code.ts
@@ -1,0 +1,5 @@
+import { makeStyles as createStyles } from '@griffel/react';
+
+export const useStyles = createStyles({
+  root: { color: 'red' },
+});

--- a/packages/babel-preset/__fixtures__/import-alias/output.ts
+++ b/packages/babel-preset/__fixtures__/import-alias/output.ts
@@ -1,0 +1,11 @@
+import { __styles } from '@griffel/react';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/import-custom-module/code.ts
+++ b/packages/babel-preset/__fixtures__/import-custom-module/code.ts
@@ -1,0 +1,6 @@
+// @ts-expect-error This module does not exist, but will be resolved via aliases
+import { makeStyles } from 'custom-package';
+
+export const useStyles = makeStyles({
+  root: { color: 'red' },
+});

--- a/packages/babel-preset/__fixtures__/import-custom-module/options.json
+++ b/packages/babel-preset/__fixtures__/import-custom-module/options.json
@@ -1,0 +1,3 @@
+{
+  "modules": [{ "moduleSource": "custom-package", "importName": "makeStyles" }]
+}

--- a/packages/babel-preset/__fixtures__/import-custom-module/output.ts
+++ b/packages/babel-preset/__fixtures__/import-custom-module/output.ts
@@ -1,0 +1,12 @@
+// @ts-expect-error This module does not exist, but will be resolved via aliases
+import { __styles } from 'custom-package';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/import-custom-name/code.ts
+++ b/packages/babel-preset/__fixtures__/import-custom-name/code.ts
@@ -1,0 +1,6 @@
+// @ts-expect-error This module does not exist, but will be resolved via aliases
+import { createStyles } from 'custom-package';
+
+export const useStyles = createStyles({
+  root: { color: 'red' },
+});

--- a/packages/babel-preset/__fixtures__/import-custom-name/options.json
+++ b/packages/babel-preset/__fixtures__/import-custom-name/options.json
@@ -1,0 +1,3 @@
+{
+  "modules": [{ "moduleSource": "custom-package", "importName": "createStyles" }]
+}

--- a/packages/babel-preset/__fixtures__/import-custom-name/output.ts
+++ b/packages/babel-preset/__fixtures__/import-custom-name/output.ts
@@ -1,0 +1,12 @@
+// @ts-expect-error This module does not exist, but will be resolved via aliases
+import { __styles } from 'custom-package';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/multiple-declarations/code.ts
+++ b/packages/babel-preset/__fixtures__/multiple-declarations/code.ts
@@ -1,0 +1,8 @@
+import { makeStyles } from '@griffel/react';
+
+export const useStyles1 = makeStyles({
+  root: { color: 'red' },
+});
+export const useStyles2 = makeStyles({
+  root: { color: 'green' },
+});

--- a/packages/babel-preset/__fixtures__/multiple-declarations/output.ts
+++ b/packages/babel-preset/__fixtures__/multiple-declarations/output.ts
@@ -1,0 +1,21 @@
+import { __styles } from '@griffel/react';
+export const useStyles1 = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+export const useStyles2 = __styles(
+  {
+    root: {
+      sj55zd: 'fka9v86',
+    },
+  },
+  {
+    d: ['.fka9v86{color:green;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/non-existing-module-call/code.tsx
+++ b/packages/babel-preset/__fixtures__/non-existing-module-call/code.tsx
@@ -1,0 +1,10 @@
+import { makeStyles } from '@griffel/react';
+import { createModule } from './module';
+
+export const useStyles = makeStyles({
+  container: {
+    color: 'red',
+  },
+});
+
+createModule().baz();

--- a/packages/babel-preset/__fixtures__/non-existing-module-call/module.ts
+++ b/packages/babel-preset/__fixtures__/non-existing-module-call/module.ts
@@ -1,0 +1,13 @@
+type FakeModule = {
+  foo: () => void;
+  bar: () => void;
+  baz: () => void;
+};
+
+export function createModule(): FakeModule {
+  return {
+    foo: () => {},
+    bar: () => {},
+    // this implementation intentionally missing "baz" property to throw on calls in runtime
+  } as unknown as FakeModule;
+}

--- a/packages/babel-preset/__fixtures__/non-existing-module-call/output.tsx
+++ b/packages/babel-preset/__fixtures__/non-existing-module-call/output.tsx
@@ -1,0 +1,13 @@
+import { __styles } from '@griffel/react';
+import { createModule } from './module';
+export const useStyles = __styles(
+  {
+    container: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+createModule().baz();

--- a/packages/babel-preset/__fixtures__/object-computed-keys/code.ts
+++ b/packages/babel-preset/__fixtures__/object-computed-keys/code.ts
@@ -1,0 +1,8 @@
+import { makeStyles } from '@griffel/react';
+
+const rootSlot = 'root';
+
+export const useStyles = makeStyles({
+  [rootSlot]: { color: 'red', paddingLeft: '4px' },
+  [rootSlot + 'primary']: { backgroundColor: 'green', marginLeft: '4px' },
+});

--- a/packages/babel-preset/__fixtures__/object-computed-keys/output.ts
+++ b/packages/babel-preset/__fixtures__/object-computed-keys/output.ts
@@ -1,0 +1,24 @@
+import { __styles } from '@griffel/react';
+const rootSlot = 'root';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+    rootprimary: {
+      De3pzq: 'fcnqdeg',
+      Frg6f3: ['fjf1xye', 'f8zmjen'],
+    },
+  },
+  {
+    d: [
+      '.fe3e8s9{color:red;}',
+      '.fycuoez{padding-left:4px;}',
+      '.f8wuabp{padding-right:4px;}',
+      '.fcnqdeg{background-color:green;}',
+      '.fjf1xye{margin-left:4px;}',
+      '.f8zmjen{margin-right:4px;}',
+    ],
+  },
+);

--- a/packages/babel-preset/__fixtures__/object-imported-keys/code.ts
+++ b/packages/babel-preset/__fixtures__/object-imported-keys/code.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@griffel/react';
+import { className, selector } from './consts';
+
+export const useStyles = makeStyles({
+  root: {
+    [selector]: { color: 'red' },
+    [`& .${className}`]: { color: 'blue' },
+  },
+});

--- a/packages/babel-preset/__fixtures__/object-imported-keys/consts.ts
+++ b/packages/babel-preset/__fixtures__/object-imported-keys/consts.ts
@@ -1,0 +1,2 @@
+export const className = 'component-foo';
+export const selector = '& .component-bar';

--- a/packages/babel-preset/__fixtures__/object-imported-keys/output.ts
+++ b/packages/babel-preset/__fixtures__/object-imported-keys/output.ts
@@ -1,0 +1,13 @@
+import { __styles } from '@griffel/react';
+import { className, selector } from './consts';
+export const useStyles = __styles(
+  {
+    root: {
+      B0egftl: 'f1wgwx3x',
+      qhv8v2: 'fglt6ox',
+    },
+  },
+  {
+    d: ['.f1wgwx3x .component-bar{color:red;}', '.fglt6ox .component-foo{color:blue;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/object-mixins/code.ts
+++ b/packages/babel-preset/__fixtures__/object-mixins/code.ts
@@ -1,0 +1,11 @@
+import { makeStyles } from '@griffel/react';
+import { flexStyles, gridStyles, typography } from './mixins';
+
+export const useStyles = makeStyles({
+  root: flexStyles,
+  label: typography.text,
+  header: typography.header,
+
+  icon: { ...flexStyles, color: 'red' },
+  image: { ...gridStyles('10px'), color: 'green' },
+});

--- a/packages/babel-preset/__fixtures__/object-mixins/mixins.ts
+++ b/packages/babel-preset/__fixtures__/object-mixins/mixins.ts
@@ -1,0 +1,17 @@
+import { GriffelStyle } from '@griffel/core';
+import { tokens } from './tokens';
+
+export const flexStyles: GriffelStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+export const gridStyles = (gridGap: string): GriffelStyle => ({
+  display: 'grid',
+  gridRowGap: gridGap,
+});
+
+export const typography: Record<'text' | 'header', GriffelStyle> = {
+  text: { fontWeight: tokens.fontWeightRegular },
+  header: { fontWeight: 'bold' },
+};

--- a/packages/babel-preset/__fixtures__/object-mixins/output.ts
+++ b/packages/babel-preset/__fixtures__/object-mixins/output.ts
@@ -1,0 +1,38 @@
+import { __styles } from '@griffel/react';
+import { flexStyles, gridStyles, typography } from './mixins';
+export const useStyles = __styles(
+  {
+    root: {
+      mc9l5x: 'f22iagw',
+      Beiy3e4: 'f1vx9l62',
+    },
+    label: {
+      Bhrd7zp: 'figsok6',
+    },
+    header: {
+      Bhrd7zp: 'f16wzh4i',
+    },
+    icon: {
+      mc9l5x: 'f22iagw',
+      Beiy3e4: 'f1vx9l62',
+      sj55zd: 'fe3e8s9',
+    },
+    image: {
+      mc9l5x: 'f13qh94s',
+      a6qtfi: 'f85kjgz',
+      sj55zd: 'fka9v86',
+    },
+  },
+  {
+    d: [
+      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
+      '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',
+      '.figsok6{font-weight:var(--fontWeightRegular);}',
+      '.f16wzh4i{font-weight:bold;}',
+      '.fe3e8s9{color:red;}',
+      '.f13qh94s{display:grid;}',
+      '.f85kjgz{grid-row-gap:10px;}',
+      '.fka9v86{color:green;}',
+    ],
+  },
+);

--- a/packages/babel-preset/__fixtures__/object-mixins/tokens.ts
+++ b/packages/babel-preset/__fixtures__/object-mixins/tokens.ts
@@ -1,0 +1,3 @@
+export const tokens = {
+  fontWeightRegular: 'var(--fontWeightRegular)',
+};

--- a/packages/babel-preset/__fixtures__/object-nesting/code.ts
+++ b/packages/babel-preset/__fixtures__/object-nesting/code.ts
@@ -1,0 +1,13 @@
+import { makeStyles } from '@griffel/react';
+import { colorBlue } from './consts';
+
+export const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+
+    ':hover': { color: 'red' },
+    ':focus': { ':hover': { color: colorBlue } },
+
+    '& .foo': { ':hover': { color: 'green' } },
+  },
+});

--- a/packages/babel-preset/__fixtures__/object-nesting/consts.ts
+++ b/packages/babel-preset/__fixtures__/object-nesting/consts.ts
@@ -1,0 +1,1 @@
+export const colorBlue = 'blue';

--- a/packages/babel-preset/__fixtures__/object-nesting/output.ts
+++ b/packages/babel-preset/__fixtures__/object-nesting/output.ts
@@ -1,0 +1,20 @@
+import { __styles } from '@griffel/react';
+import { colorBlue } from './consts';
+export const useStyles = __styles(
+  {
+    root: {
+      mc9l5x: 'f22iagw',
+      Bi91k9c: 'faf35ka',
+      Bb9khzn: 'f17t1d3d',
+      Btk3f3y: 'fh8e7tb',
+    },
+  },
+  {
+    d: [
+      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
+      '.fh8e7tb .foo:hover{color:green;}',
+    ],
+    h: ['.faf35ka:hover{color:red;}'],
+    f: ['.f17t1d3d:focus:hover{color:blue;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/object-sequence-expr/code.ts
+++ b/packages/babel-preset/__fixtures__/object-sequence-expr/code.ts
@@ -1,0 +1,15 @@
+import { makeStyles, MakeStylesStyle } from '@griffel/react';
+
+const switchClassName = 'fui-Switch';
+let _a: Record<string, MakeStylesStyle>;
+
+export const useStyles = makeStyles({
+  root:
+    ((_a = {}),
+    (_a[':hover .' + switchClassName] = {
+      ':before': {
+        backgroundColor: 'red',
+      },
+    }),
+    _a),
+});

--- a/packages/babel-preset/__fixtures__/object-sequence-expr/output.ts
+++ b/packages/babel-preset/__fixtures__/object-sequence-expr/output.ts
@@ -1,0 +1,15 @@
+import { __styles, MakeStylesStyle } from '@griffel/react';
+const switchClassName = 'fui-Switch';
+
+let _a: Record<string, MakeStylesStyle>;
+
+export const useStyles = __styles(
+  {
+    root: {
+      ozcac4: 'f1cm6cy7',
+    },
+  },
+  {
+    h: ['.f1cm6cy7:hover .fui-Switch:before{background-color:red;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/object-variables/code.ts
+++ b/packages/babel-preset/__fixtures__/object-variables/code.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@griffel/react';
+import { colorGreen, theme } from './vars';
+
+const colorRed = 'red';
+
+export const useStyles = makeStyles({
+  root: { color: colorRed, paddingLeft: '4px' },
+  icon: { color: theme.black, backgroundColor: colorGreen, marginLeft: '4px' },
+});

--- a/packages/babel-preset/__fixtures__/object-variables/output.ts
+++ b/packages/babel-preset/__fixtures__/object-variables/output.ts
@@ -1,0 +1,27 @@
+import { __styles } from '@griffel/react';
+import { colorGreen, theme } from './vars';
+const colorRed = 'red';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+    icon: {
+      sj55zd: 'fusgiwz',
+      De3pzq: 'fcnqdeg',
+      Frg6f3: ['fjf1xye', 'f8zmjen'],
+    },
+  },
+  {
+    d: [
+      '.fe3e8s9{color:red;}',
+      '.fycuoez{padding-left:4px;}',
+      '.f8wuabp{padding-right:4px;}',
+      '.fusgiwz{color:#000;}',
+      '.fcnqdeg{background-color:green;}',
+      '.fjf1xye{margin-left:4px;}',
+      '.f8zmjen{margin-right:4px;}',
+    ],
+  },
+);

--- a/packages/babel-preset/__fixtures__/object-variables/vars.ts
+++ b/packages/babel-preset/__fixtures__/object-variables/vars.ts
@@ -1,0 +1,5 @@
+export const colorGreen = 'green';
+
+export const theme = {
+  black: '#000',
+};

--- a/packages/babel-preset/__fixtures__/object/code.ts
+++ b/packages/babel-preset/__fixtures__/object/code.ts
@@ -1,0 +1,6 @@
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { color: 'red', paddingLeft: '4px' },
+  icon: { backgroundColor: 'green', marginLeft: '4px' },
+});

--- a/packages/babel-preset/__fixtures__/object/output.ts
+++ b/packages/babel-preset/__fixtures__/object/output.ts
@@ -1,0 +1,23 @@
+import { __styles } from '@griffel/react';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+    icon: {
+      De3pzq: 'fcnqdeg',
+      Frg6f3: ['fjf1xye', 'f8zmjen'],
+    },
+  },
+  {
+    d: [
+      '.fe3e8s9{color:red;}',
+      '.fycuoez{padding-left:4px;}',
+      '.f8wuabp{padding-right:4px;}',
+      '.fcnqdeg{background-color:green;}',
+      '.fjf1xye{margin-left:4px;}',
+      '.f8zmjen{margin-right:4px;}',
+    ],
+  },
+);

--- a/packages/babel-preset/__fixtures__/shared-mixins/code.ts
+++ b/packages/babel-preset/__fixtures__/shared-mixins/code.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@griffel/react';
+import { sharedStyles } from './mixins';
+
+export const useStyles = makeStyles({
+  ...sharedStyles,
+  icon: { color: 'red' },
+});

--- a/packages/babel-preset/__fixtures__/shared-mixins/mixins.ts
+++ b/packages/babel-preset/__fixtures__/shared-mixins/mixins.ts
@@ -1,0 +1,6 @@
+import { GriffelStyle } from '@griffel/core';
+
+export const sharedStyles: Record<string, GriffelStyle> = {
+  root: { display: 'flex' },
+  container: { display: 'grid' },
+};

--- a/packages/babel-preset/__fixtures__/shared-mixins/output.ts
+++ b/packages/babel-preset/__fixtures__/shared-mixins/output.ts
@@ -1,0 +1,22 @@
+import { __styles } from '@griffel/react';
+import { sharedStyles } from './mixins';
+export const useStyles = __styles(
+  {
+    root: {
+      mc9l5x: 'f22iagw',
+    },
+    container: {
+      mc9l5x: 'f13qh94s',
+    },
+    icon: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: [
+      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
+      '.f13qh94s{display:grid;}',
+      '.fe3e8s9{color:red;}',
+    ],
+  },
+);

--- a/packages/babel-preset/__fixtures__/tokens/code.ts
+++ b/packages/babel-preset/__fixtures__/tokens/code.ts
@@ -1,0 +1,11 @@
+import { makeStyles } from '@griffel/react';
+import { tokens } from './tokens';
+
+export const useStyles = makeStyles({
+  root: {
+    backgroundColor: 'black',
+    color: tokens.colorPaletteBlueBorder2,
+    display: 'flex',
+  },
+  rootPrimary: { color: tokens.colorBrandBackground },
+});

--- a/packages/babel-preset/__fixtures__/tokens/output.ts
+++ b/packages/babel-preset/__fixtures__/tokens/output.ts
@@ -1,0 +1,22 @@
+import { __styles } from '@griffel/react';
+import { tokens } from './tokens';
+export const useStyles = __styles(
+  {
+    root: {
+      De3pzq: 'f1734hy',
+      sj55zd: 'ff34w31',
+      mc9l5x: 'f22iagw',
+    },
+    rootPrimary: {
+      sj55zd: 'f1817uup',
+    },
+  },
+  {
+    d: [
+      '.f1734hy{background-color:black;}',
+      '.ff34w31{color:var(--colorPaletteBlueBorder2);}',
+      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
+      '.f1817uup{color:var(--colorBrandBackground);}',
+    ],
+  },
+);

--- a/packages/babel-preset/__fixtures__/tokens/tokens.ts
+++ b/packages/babel-preset/__fixtures__/tokens/tokens.ts
@@ -1,0 +1,4 @@
+export const tokens = {
+  colorPaletteBlueBorder2: 'var(--colorPaletteBlueBorder2)',
+  colorBrandBackground: 'var(--colorBrandBackground)',
+};

--- a/packages/babel-preset/jest.config.js
+++ b/packages/babel-preset/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  displayName: 'babel-preset',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^sampleEvaluator$': '<rootDir>/__fixtures__/config-evaluation-rules/sampleEvaluator.js',
+  },
+  coverageDirectory: '../../coverage/packages/babel-preset',
+};

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@griffel/babel-preset",
+  "version": "0.0.1",
+  "description": "Babel preset with build time transforms for Griffel",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/griffel"
+  },
+  "peerDependencies": {
+    "@griffel/core": "^1.0.7"
+  }
+}

--- a/packages/babel-preset/project.json
+++ b/packages/babel-preset/project.json
@@ -1,0 +1,42 @@
+{
+  "root": "packages/babel-preset",
+  "sourceRoot": "packages/babel-preset/src",
+  "projectType": "library",
+  "implicitDependencies": ["!@griffel/react"],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/babel-preset/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/babel-preset"],
+      "options": {
+        "jestConfig": "packages/babel-preset/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "build": {
+      "executor": "@nrwl/node:package",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/babel-preset",
+        "tsConfig": "packages/babel-preset/tsconfig.lib.json",
+        "packageJson": "packages/babel-preset/package.json",
+        "main": "packages/babel-preset/src/index.ts",
+        "assets": [
+          "packages/babel-preset/README.md",
+          {
+            "glob": "LICENSE.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -1,0 +1,15 @@
+import { transformPlugin } from './transformPlugin';
+
+import type { ConfigAPI } from '@babel/core';
+import type { BabelPluginOptions } from './types';
+
+export { configSchema } from './schema';
+
+export type { Evaluator, EvalRule } from '@linaria/babel-preset';
+export type { BabelPluginOptions };
+
+export default function linaria(babel: ConfigAPI, options: BabelPluginOptions) {
+  return {
+    plugins: [[transformPlugin, options]],
+  };
+}

--- a/packages/babel-preset/src/schema.ts
+++ b/packages/babel-preset/src/schema.ts
@@ -1,0 +1,50 @@
+import type { JSONSchema7 } from 'json-schema';
+
+export const configSchema: JSONSchema7 = {
+  $schema: 'http://json-schema.org/schema',
+  $id: 'babel-transformPlugin-options',
+
+  type: 'object',
+  properties: {
+    modules: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['moduleSource', 'importName'],
+        properties: {
+          moduleSource: {
+            type: 'string',
+          },
+          importName: {
+            type: 'string',
+          },
+        },
+      },
+    },
+    babelOptions: {
+      type: 'object',
+      properties: {
+        plugins: {
+          type: 'array',
+        },
+        presets: {
+          type: 'array',
+        },
+      },
+    },
+    evaluationRules: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['action'],
+        properties: {
+          action: {
+            anyOf: [{}, { type: 'string' }, { const: 'ignore' }],
+          },
+          test: {},
+        },
+      },
+    },
+  },
+  additionalProperties: false,
+};

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -1,0 +1,52 @@
+import pluginTester, { prettierFormatter } from 'babel-plugin-tester';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { transformPlugin } from './transformPlugin';
+
+const prettierConfig = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../.prettierrc'), { encoding: 'utf-8' }),
+);
+const fixturesDir = path.join(__dirname, '..', '__fixtures__');
+
+pluginTester({
+  babelOptions: {
+    parserOpts: {
+      plugins: ['typescript'],
+    },
+  },
+  formatResult: code =>
+    prettierFormatter(code, {
+      config: {
+        ...prettierConfig,
+        parser: 'typescript',
+      },
+    }),
+
+  fixtures: fixturesDir,
+  tests: [
+    {
+      title: 'errors: throws on invalid argument type',
+      fixture: path.resolve(fixturesDir, 'error-argument-type', 'fixture.js'),
+      error: /function accepts only an object as a param/,
+    },
+    {
+      title: 'errors: throws on invalid argument count',
+      fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
+      error: /function accepts only a single param/,
+    },
+    {
+      title: 'errors: throws on invalid config',
+      fixture: path.resolve(fixturesDir, 'error-config-babel-options', 'fixture.ts'),
+      pluginOptions: {
+        babelOptions: {
+          plugins: {},
+        },
+      },
+      error: /Validation failed for passed config/,
+    },
+  ],
+
+  plugin: transformPlugin,
+  pluginName: '@griffel/babel-plugin-transform',
+});

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -1,0 +1,265 @@
+import { NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
+import { declare } from '@babel/helper-plugin-utils';
+import { Module } from '@linaria/babel-preset';
+import shakerEvaluator from '@linaria/shaker';
+import { resolveStyleRulesForSlots, CSSRulesByBucket, StyleBucketName, GriffelStyle } from '@griffel/core';
+
+import { astify } from './utils/astify';
+import { evaluatePaths } from './utils/evaluatePaths';
+import { BabelPluginOptions } from './types';
+import { validateOptions } from './validateOptions';
+
+type BabelPluginState = PluginPass & {
+  importDeclarationPath?: NodePath<t.ImportDeclaration>;
+  requireDeclarationPath?: NodePath<t.VariableDeclarator>;
+
+  definitionPaths?: NodePath<t.ObjectExpression>[];
+  calleePaths?: NodePath<t.Identifier>[];
+};
+
+function getDefinitionPathFromMakeStylesCallExpression(
+  callExpression: NodePath<t.CallExpression>,
+): NodePath<t.ObjectExpression> {
+  const argumentPaths = callExpression.get('arguments') as NodePath<t.Node>[];
+  const hasValidArguments = Array.isArray(argumentPaths) && argumentPaths.length === 1;
+
+  if (!hasValidArguments) {
+    throw new Error('makeStyles() function accepts only a single param');
+  }
+
+  const definitionsPath = argumentPaths[0];
+
+  if (!definitionsPath.isObjectExpression()) {
+    throw definitionsPath.buildCodeFrameError('makeStyles() function accepts only an object as a param');
+  }
+
+  return definitionsPath;
+}
+
+/**
+ * Checks that passed callee imports makesStyles().
+ */
+function isMakeStylesCallee(
+  path: NodePath<t.Expression | t.V8IntrinsicIdentifier>,
+  modules: NonNullable<BabelPluginOptions['modules']>,
+): path is NodePath<t.Identifier> {
+  if (path.isIdentifier()) {
+    return Boolean(modules.find(module => path.referencesImport(module.moduleSource, module.importName)));
+  }
+
+  return false;
+}
+
+/**
+ * Checks if import statement import makeStyles().
+ */
+function hasMakeStylesImport(
+  path: NodePath<t.ImportDeclaration>,
+  modules: NonNullable<BabelPluginOptions['modules']>,
+): boolean {
+  return Boolean(modules.find(module => path.node.source.value === module.moduleSource));
+}
+
+/**
+ * Checks that passed declarator imports makesStyles().
+ *
+ * @example react_make_styles_1 = require('@griffel/react')
+ */
+function isRequireDeclarator(path: NodePath<t.VariableDeclarator>): boolean {
+  const initPath = path.get('init');
+
+  if (!initPath.isCallExpression()) {
+    return false;
+  }
+
+  if (initPath.get('callee').isIdentifier({ name: 'require' })) {
+    const args = initPath.get('arguments');
+
+    return Array.isArray(args) && args.length === 1 && args[0].isStringLiteral({ value: '@griffel/react' });
+  }
+
+  return false;
+}
+
+/**
+ * Rules that are returned by `resolveStyles()` are not deduplicated.
+ * It's critical to filter out duplicates for build-time transform to avoid duplicated rules in a bundle.
+ */
+function dedupeCSSRules(cssRules: CSSRulesByBucket): CSSRulesByBucket {
+  (Object.keys(cssRules) as StyleBucketName[]).forEach(styleBucketName => {
+    cssRules[styleBucketName] = cssRules[styleBucketName]!.filter(
+      (rule, index, rules) => rules.indexOf(rule) === index,
+    );
+  });
+
+  return cssRules;
+}
+
+export const transformPlugin = declare<Partial<BabelPluginOptions>, PluginObj<BabelPluginState>>((api, options) => {
+  api.assertVersion(7);
+
+  const pluginOptions: Required<BabelPluginOptions> = {
+    babelOptions: {
+      presets: ['@babel/preset-typescript'],
+    },
+    modules: [{ moduleSource: '@griffel/react', importName: 'makeStyles' }],
+    evaluationRules: [
+      { action: shakerEvaluator },
+      {
+        test: /[/\\]node_modules[/\\]/,
+        action: 'ignore',
+      },
+    ],
+
+    ...options,
+  };
+
+  validateOptions(pluginOptions);
+
+  return {
+    name: '@griffel/babel-plugin-transform',
+
+    pre() {
+      this.definitionPaths = [];
+      this.calleePaths = [];
+    },
+
+    visitor: {
+      Program: {
+        enter() {
+          // Invalidate cache for module evaluation to get fresh modules
+          Module.invalidate();
+        },
+
+        exit(path, state) {
+          if (!state.importDeclarationPath && !state.requireDeclarationPath) {
+            return;
+          }
+
+          if (state.definitionPaths) {
+            // Runs Babel AST processing or module evaluation for Node once for all arguments of makeStyles() calls once
+            evaluatePaths(path, state.file.opts.filename!, state.definitionPaths, pluginOptions);
+
+            state.definitionPaths.forEach(definitionPath => {
+              const callExpressionPath = definitionPath.findParent(parentPath =>
+                parentPath.isCallExpression(),
+              ) as NodePath<t.CallExpression>;
+              const evaluationResult = definitionPath.evaluate();
+
+              if (!evaluationResult.confident) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const deoptPath = (evaluationResult as any).deopt as NodePath | undefined;
+                throw (deoptPath || definitionPath).buildCodeFrameError(
+                  'Evaluation of a code fragment failed, this is a bug, please report it',
+                );
+              }
+
+              const stylesBySlots: Record<string /* slot */, GriffelStyle> = evaluationResult.value;
+              const [classnamesMapping, cssRules] = resolveStyleRulesForSlots(stylesBySlots);
+
+              // TODO: find a better way to replace arguments
+              callExpressionPath.node.arguments = [astify(classnamesMapping), astify(dedupeCSSRules(cssRules))];
+            });
+          }
+
+          if (state.importDeclarationPath) {
+            const specifiers = state.importDeclarationPath.get('specifiers');
+            const source = state.importDeclarationPath.get('source');
+
+            specifiers.forEach(specifier => {
+              if (specifier.isImportSpecifier()) {
+                // TODO: should use generated modifier to avoid collisions
+
+                const importedPath = specifier.get('imported');
+                const importIdentifierPath = pluginOptions.modules.find(module => {
+                  return (
+                    module.moduleSource === source.node.value &&
+                    // 👆 "moduleSource" should match "importDeclarationPath.source" to skip unrelated ".importName"
+                    importedPath.isIdentifier({ name: module.importName })
+                  );
+                });
+
+                if (importIdentifierPath) {
+                  specifier.replaceWith(t.identifier('__styles'));
+                }
+              }
+            });
+          }
+
+          if (state.calleePaths) {
+            state.calleePaths.forEach(calleePath => {
+              calleePath.replaceWith(t.identifier('__styles'));
+            });
+          }
+        },
+      },
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ImportDeclaration(path, state) {
+        if (hasMakeStylesImport(path, pluginOptions.modules)) {
+          state.importDeclarationPath = path;
+        }
+      },
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      VariableDeclarator(path, state) {
+        if (isRequireDeclarator(path)) {
+          state.requireDeclarationPath = path;
+        }
+      },
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      CallExpression(path, state) {
+        /**
+         * Handles case when `makeStyles()` is `CallExpression`.
+         *
+         * @example makeStyles({})
+         */
+        if (!state.importDeclarationPath) {
+          return;
+        }
+
+        const calleePath = path.get('callee');
+
+        if (!isMakeStylesCallee(calleePath, pluginOptions.modules)) {
+          return;
+        }
+
+        state.definitionPaths!.push(getDefinitionPathFromMakeStylesCallExpression(path));
+        state.calleePaths!.push(calleePath);
+      },
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      MemberExpression(expressionPath, state) {
+        /**
+         * Handles case when `makeStyles()` is inside `MemberExpression`.
+         *
+         * @example module.makeStyles({})
+         */
+        if (!state.requireDeclarationPath) {
+          return;
+        }
+
+        const objectPath = expressionPath.get('object');
+        const propertyPath = expressionPath.get('property');
+
+        const isMakeStylesCall =
+          objectPath.isIdentifier({ name: (state.requireDeclarationPath.node.id as t.Identifier).name }) &&
+          propertyPath.isIdentifier({ name: 'makeStyles' });
+
+        if (!isMakeStylesCall) {
+          return;
+        }
+
+        const parentPath = expressionPath.parentPath;
+
+        if (!parentPath.isCallExpression()) {
+          return;
+        }
+
+        state.definitionPaths!.push(getDefinitionPathFromMakeStylesCallExpression(parentPath));
+        state.calleePaths!.push(propertyPath as NodePath<t.Identifier>);
+      },
+    },
+  };
+});

--- a/packages/babel-preset/src/types.ts
+++ b/packages/babel-preset/src/types.ts
@@ -1,0 +1,16 @@
+import type { TransformOptions } from '@babel/core';
+import type { EvalRule } from '@linaria/babel-preset';
+
+export type BabelPluginOptions = {
+  /** Defines set of modules and imports handled by a transformPlugin. */
+  modules?: { moduleSource: string; importName: string }[];
+
+  /**
+   * If you need to specify custom Babel configuration, you can pass them here. These options will be used by the
+   * transformPlugin when parsing and evaluating modules.
+   */
+  babelOptions?: Pick<TransformOptions, 'plugins' | 'presets'>;
+
+  /** The set of rules that defines how the matched files will be transformed during the evaluation. */
+  evaluationRules?: EvalRule[];
+};

--- a/packages/babel-preset/src/utils/astify.ts
+++ b/packages/babel-preset/src/utils/astify.ts
@@ -1,0 +1,44 @@
+import { types as t } from '@babel/core';
+
+/**
+ * Transforms runtime literals into AST tree.
+ */
+export function astify<T>(
+  literal: T,
+):
+  | t.NullLiteral
+  | t.NumericLiteral
+  | t.StringLiteral
+  | t.BooleanLiteral
+  | t.UnaryExpression
+  | t.ArrayExpression
+  | t.ObjectExpression {
+  if (literal === null) {
+    return t.nullLiteral();
+  }
+
+  switch (typeof literal) {
+    case 'function':
+      throw new Error(
+        'We intentionally do not support serialization of functions, this branch should be never executed',
+      );
+    case 'number':
+      return t.numericLiteral(literal);
+    case 'string':
+      return t.stringLiteral(literal);
+    case 'boolean':
+      return t.booleanLiteral(literal);
+    case 'undefined':
+      return t.unaryExpression('void', t.numericLiteral(0), true);
+    default:
+      if (Array.isArray(literal)) {
+        return t.arrayExpression(literal.map(astify));
+      }
+
+      return t.objectExpression(
+        Object.keys(literal)
+          .filter(k => typeof (literal as Record<string, unknown>)[k] !== 'undefined')
+          .map(k => t.objectProperty(t.stringLiteral(k), astify((literal as Record<string, unknown>)[k]))),
+      );
+  }
+}

--- a/packages/babel-preset/src/utils/evaluatePaths.ts
+++ b/packages/babel-preset/src/utils/evaluatePaths.ts
@@ -1,0 +1,34 @@
+import { NodePath, types as t } from '@babel/core';
+
+import type { BabelPluginOptions } from '../types';
+import { evaluatePathsInVM } from './evaluatePathsInVM';
+
+/**
+ * Checks if passed paths can be evaluated by Babel, if no - fallbacks to Node evaluation.
+ * The goal there is to ensure that all paths are pure and can be safely evaluated later by Babel.
+ */
+export function evaluatePaths(
+  program: NodePath<t.Program>,
+  filename: string,
+  paths: NodePath<t.Expression | t.SpreadElement>[],
+  pluginOptions: Required<BabelPluginOptions>,
+): void {
+  const pathsToBeEvaluatedInVM: NodePath<t.Expression | t.SpreadElement>[] = [];
+
+  for (let i = 0; i < paths.length; i++) {
+    const result = paths[i].evaluate();
+
+    // Optimistic case, we were able to resolve a path without evaluation in Node environment 🎉
+    if (result.confident) {
+      // Heads up!
+      // We don't need to do any replacements there as after resolving all style objects will be evaluated again
+      continue;
+    }
+
+    pathsToBeEvaluatedInVM.push(paths[i]);
+  }
+
+  if (pathsToBeEvaluatedInVM.length > 0) {
+    evaluatePathsInVM(program, filename, pathsToBeEvaluatedInVM, pluginOptions);
+  }
+}

--- a/packages/babel-preset/src/utils/evaluatePathsInVM.test.ts
+++ b/packages/babel-preset/src/utils/evaluatePathsInVM.test.ts
@@ -1,0 +1,16 @@
+import * as Babel from '@babel/core';
+import generator from '@babel/generator';
+
+import { expressionTpl } from './evaluatePathsInVM';
+
+describe('expressionTpl', () => {
+  it('returns an expression based on a template', () => {
+    const expression = Babel.types.identifier('foo');
+
+    const result = expressionTpl({ expression, wrapName: 'wrap' });
+    const resultCode = generator(result).code;
+
+    expect(Babel.types.isCallExpression(result)).toBe(true);
+    expect(resultCode).toMatchInlineSnapshot(`"wrap(() => foo)"`);
+  });
+});

--- a/packages/babel-preset/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-preset/src/utils/evaluatePathsInVM.ts
@@ -1,0 +1,112 @@
+import { NodePath, types as t } from '@babel/core';
+import { Scope } from '@babel/traverse';
+import * as template from '@babel/template';
+import generator from '@babel/generator';
+import { Module, StrictOptions } from '@linaria/babel-preset';
+
+import type { BabelPluginOptions } from '../types';
+import { astify } from './astify';
+
+const EVAL_EXPORT_NAME = '__mkPreval';
+
+function evaluate(code: string, filename: string, pluginOptions: Required<BabelPluginOptions>) {
+  const options: StrictOptions = {
+    displayName: false,
+    evaluate: true,
+
+    rules: pluginOptions.evaluationRules,
+    babelOptions: {
+      ...pluginOptions.babelOptions,
+
+      // This instance of Babel should ignore all user's configs and apply only our transformPlugin
+      configFile: false,
+      babelrc: false,
+    },
+  };
+  const mod = new Module(filename, options);
+
+  mod.evaluate(code, [EVAL_EXPORT_NAME]);
+
+  return mod.exports[EVAL_EXPORT_NAME];
+}
+
+function findFreeName(scope: Scope, name: string): string {
+  // By default `name` is used as a name of the function …
+  let nextName = name;
+  let idx = 0;
+  while (scope.hasBinding(nextName, false)) {
+    // … but if there is an already defined variable with this name …
+    // … we are trying to use a name like wrap_N
+    idx += 1;
+    nextName = `wrap_${idx}`;
+  }
+
+  return nextName;
+}
+
+const expressionWrapperTpl = template.statement(`
+  const %%wrapName%% = (fn) => {
+    try {
+      return fn();
+    } catch (e) {
+      return e;
+    }
+  };
+`);
+
+export const expressionTpl = template.expression(`%%wrapName%%(() => %%expression%%)`);
+const exportsPrevalTpl = template.statement(`exports.${EVAL_EXPORT_NAME} = %%expressions%%`);
+
+/**
+ * Creates a new program that includes required imports and wrappers to return resolved values.
+ */
+function addPreval(path: NodePath<t.Program>, lazyDeps: Array<t.Expression | t.SpreadElement>): t.Program {
+  // Constant for "__mkPreval" with all dependencies
+  const wrapName = findFreeName(path.scope, '_wrap');
+  const programNode = path.node;
+
+  return t.program(
+    [
+      ...programNode.body,
+
+      expressionWrapperTpl({ wrapName }),
+      exportsPrevalTpl({
+        expressions: t.arrayExpression(lazyDeps.map(expression => expressionTpl({ expression, wrapName }))),
+      }),
+    ],
+    programNode.directives,
+    programNode.sourceType,
+    programNode.interpreter,
+  );
+}
+
+/**
+ * Evaluates passed paths in Node environment to resolve all lazy values.
+ */
+export function evaluatePathsInVM(
+  program: NodePath<t.Program>,
+  filename: string,
+  nodePaths: NodePath<t.Expression | t.SpreadElement>[],
+  pluginOptions: Required<BabelPluginOptions>,
+): void {
+  const pathsToEvaluate = nodePaths.map(nodePath => {
+    // spreads ("...fooBar") can't be executed directly, so they are wrapped with an object ("{...fooBar}")
+    if (nodePath.isSpreadElement()) {
+      return t.objectExpression([nodePath.node as t.SpreadElement]);
+    }
+
+    return nodePath.node;
+  });
+
+  // Linaria also performs hoisting of identifiers, we don't need this as all makeStyles() calls should be top level
+  const modifiedProgram = addPreval(program, pathsToEvaluate);
+
+  const { code } = generator(modifiedProgram);
+  const results = evaluate(code, filename, pluginOptions);
+
+  for (let i = 0; i < nodePaths.length; i++) {
+    const nodePath = nodePaths[i];
+
+    nodePath.replaceWith(astify(results[i]));
+  }
+}

--- a/packages/babel-preset/src/validateOptions.test.ts
+++ b/packages/babel-preset/src/validateOptions.test.ts
@@ -1,0 +1,71 @@
+import type { Evaluator } from '@linaria/babel-preset';
+
+import { validateOptions } from './validateOptions';
+import { BabelPluginOptions } from './types';
+
+describe('validateOptions', () => {
+  describe('modules', () => {
+    it('passes on valid options', () => {
+      const pluginOptions: BabelPluginOptions = {
+        modules: [{ moduleSource: 'react-make-styles', importName: 'makeStyles' }],
+      };
+
+      expect(() => validateOptions(pluginOptions)).not.toThrow();
+    });
+
+    it('throws on wrong options', () => {
+      const pluginOptions = { modules: {} };
+
+      // @ts-expect-error Invalid options are passed for testing purposes
+      expect(() => validateOptions(pluginOptions)).toThrowErrorMatchingInlineSnapshot(
+        `"Validation failed for passed config: data/modules must be array"`,
+      );
+    });
+  });
+
+  describe('babelOptions', () => {
+    it('passes on valid options', () => {
+      const pluginOptions: BabelPluginOptions = {
+        babelOptions: {
+          presets: ['@babel/preset'],
+          plugins: ['@babel/transformPlugin'],
+        },
+      };
+
+      expect(() => validateOptions(pluginOptions)).not.toThrow();
+    });
+
+    it('throws on wrong options', () => {
+      const pluginOptions = { babelOptions: [] };
+
+      // @ts-expect-error Invalid options are passed for testing purposes
+      expect(() => validateOptions(pluginOptions)).toThrowErrorMatchingInlineSnapshot(
+        `"Validation failed for passed config: data/babelOptions must be object"`,
+      );
+    });
+  });
+
+  describe('evaluationRules', () => {
+    it('passes on valid options', () => {
+      const noopEvaluator: Evaluator = () => ['foo', null];
+      const pluginOptions: BabelPluginOptions = {
+        evaluationRules: [
+          { action: noopEvaluator },
+          { action: noopEvaluator, test: () => true },
+          { action: 'ignore', test: /foo/ },
+        ],
+      };
+
+      expect(() => validateOptions(pluginOptions)).not.toThrow();
+    });
+
+    it('throws on wrong options', () => {
+      const pluginOptionsA = { evaluationRules: {} };
+
+      // @ts-expect-error Invalid options are passed for testing purposes
+      expect(() => validateOptions(pluginOptionsA)).toThrowErrorMatchingInlineSnapshot(
+        `"Validation failed for passed config: data/evaluationRules must be array"`,
+      );
+    });
+  });
+});

--- a/packages/babel-preset/src/validateOptions.ts
+++ b/packages/babel-preset/src/validateOptions.ts
@@ -1,0 +1,17 @@
+import Ajv from 'ajv';
+
+import { configSchema } from './schema';
+import { BabelPluginOptions } from './types';
+
+const ajv = new Ajv();
+
+/**
+ * Validates options for transformPlugin with a schema.
+ */
+export function validateOptions(pluginOptions: BabelPluginOptions): void {
+  const valid = ajv.validate(configSchema, pluginOptions);
+
+  if (!valid) {
+    throw new Error(`Validation failed for passed config: ${ajv.errorsText(ajv.errors)}`);
+  }
+}

--- a/packages/babel-preset/tsconfig.json
+++ b/packages/babel-preset/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/babel-preset/tsconfig.lib.json
+++ b/packages/babel-preset/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "environment"]
+  },
+  "exclude": ["__fixtures__/**/*", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/packages/babel-preset/tsconfig.spec.json
+++ b/packages/babel-preset/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node", "environment"]
+  },
+  "include": [
+    "__fixtures__/**/code.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@griffel/babel-preset": ["packages/babel-preset/src/index.ts"],
       "@griffel/core": ["packages/core/src/index.ts"],
       "@griffel/jest-serializer": ["packages/jest-serializer/src/index.ts"],
       "@griffel/react": ["packages/react/src/index.ts"]

--- a/workspace.json
+++ b/workspace.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "projects": {
+    "@griffel/babel-preset": "packages/babel-preset",
     "@griffel/core": "packages/core",
     "@griffel/react": "packages/react",
     "@griffel/jest-serializer": "packages/jest-serializer"

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,7 +135,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.1.0, @babel/core@npm:^7.10.4, @babel/core@npm:^7.12.3, @babel/core@npm:^7.15.0, @babel/core@npm:^7.15.5, @babel/core@npm:^7.7.2, @babel/core@npm:^7.7.5, @babel/core@npm:^7.8.0":
+"@babel/core@npm:^7.1.0, @babel/core@npm:^7.10.4, @babel/core@npm:^7.12.13, @babel/core@npm:^7.12.3, @babel/core@npm:^7.15.0, @babel/core@npm:^7.15.5, @babel/core@npm:^7.7.2, @babel/core@npm:^7.7.5, @babel/core@npm:^7.8.0":
   version: 7.16.10
   resolution: "@babel/core@npm:7.16.10"
   dependencies:
@@ -158,7 +158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.16.8, @babel/generator@npm:^7.7.2":
+"@babel/generator@npm:>=7, @babel/generator@npm:^7.12.13, @babel/generator@npm:^7.16.8, @babel/generator@npm:^7.7.2":
   version: 7.16.8
   resolution: "@babel/generator@npm:7.16.8"
   dependencies:
@@ -202,9 +202,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.16.7"
+"@babel/helper-create-class-features-plugin@npm:^7.16.10, @babel/helper-create-class-features-plugin@npm:^7.16.7":
+  version: 7.16.10
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.16.10"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.16.7
     "@babel/helper-environment-visitor": ^7.16.7
@@ -215,7 +215,7 @@ __metadata:
     "@babel/helper-split-export-declaration": ^7.16.7
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 55f4eccb93ce12c3a5d9acadf8176ed26a6f02db12d3b2d1a7337bb81139677c7b6fb54ddc01c160895e1f8134946b3bebe59428ef3a7cd9b62692bd3a2c654f
+  checksum: 2ab266aac7f94403311f63a17d32abb718ff040339bcae19880091de3fdb4e8d7196cb4e680f01a92924eb1a00a143364456e452c511c0b7b6e0b1a4b0e696da
   languageName: node
   linkType: hard
 
@@ -641,15 +641,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-private-methods@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/plugin-proposal-private-methods@npm:7.16.7"
+"@babel/plugin-proposal-private-methods@npm:^7.16.11":
+  version: 7.16.11
+  resolution: "@babel/plugin-proposal-private-methods@npm:7.16.11"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.16.7
+    "@babel/helper-create-class-features-plugin": ^7.16.10
     "@babel/helper-plugin-utils": ^7.16.7
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 1d3aef6f1818278d257ed6f1a90ec3b0cfe85e1b24cabf1bcd0d2a0033f8ae15f9cb36140ec2adc2a317f63fc78095ce0b5c154f73128e0f84480879a4b64269
+  checksum: b333e5aa91c265bb394a57b5f4ae1a34fc8ee73a8d75506b12df258d8b5342107cbd9261f95e606bd3264a5b023db77f1f95be30c2e526683916c57f793f7943
   languageName: node
   linkType: hard
 
@@ -734,7 +734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-dynamic-import@npm:^7.8.3":
+"@babel/plugin-syntax-dynamic-import@npm:>=7, @babel/plugin-syntax-dynamic-import@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/plugin-syntax-dynamic-import@npm:7.8.3"
   dependencies:
@@ -1247,7 +1247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.15.0":
+"@babel/plugin-transform-runtime@npm:>=7, @babel/plugin-transform-runtime@npm:^7.15.0":
   version: 7.16.10
   resolution: "@babel/plugin-transform-runtime@npm:7.16.10"
   dependencies:
@@ -1297,7 +1297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-template-literals@npm:^7.16.7":
+"@babel/plugin-transform-template-literals@npm:>=7, @babel/plugin-transform-template-literals@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-transform-template-literals@npm:7.16.7"
   dependencies:
@@ -1355,9 +1355,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.15.0, @babel/preset-env@npm:^7.15.6":
-  version: 7.16.10
-  resolution: "@babel/preset-env@npm:7.16.10"
+"@babel/preset-env@npm:>=7, @babel/preset-env@npm:^7.15.0, @babel/preset-env@npm:^7.15.6":
+  version: 7.16.11
+  resolution: "@babel/preset-env@npm:7.16.11"
   dependencies:
     "@babel/compat-data": ^7.16.8
     "@babel/helper-compilation-targets": ^7.16.7
@@ -1377,7 +1377,7 @@ __metadata:
     "@babel/plugin-proposal-object-rest-spread": ^7.16.7
     "@babel/plugin-proposal-optional-catch-binding": ^7.16.7
     "@babel/plugin-proposal-optional-chaining": ^7.16.7
-    "@babel/plugin-proposal-private-methods": ^7.16.7
+    "@babel/plugin-proposal-private-methods": ^7.16.11
     "@babel/plugin-proposal-private-property-in-object": ^7.16.7
     "@babel/plugin-proposal-unicode-property-regex": ^7.16.7
     "@babel/plugin-syntax-async-generators": ^7.8.4
@@ -1435,7 +1435,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: cd39d0c30a3b3d24f36ae4822e9368bc758c904039599ce26239932c0e0f537e8d3ec9b9e952ddb9f0a459d06254c138e71b89cee5be7709ef2a0890f503d915
+  checksum: c8029c272073df787309d983ae458dd094b57f87152b8ccad95c7c8b1e82b042c1077e169538aae5f98b7659de0632d10708d9c85acf21a5e9406d7dd3656d8c
   languageName: node
   linkType: hard
 
@@ -1470,7 +1470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.15.0":
+"@babel/preset-typescript@npm:^7.12.13, @babel/preset-typescript@npm:^7.15.0":
   version: 7.16.7
   resolution: "@babel/preset-typescript@npm:7.16.7"
   dependencies:
@@ -1502,7 +1502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
+"@babel/template@npm:>=7, @babel/template@npm:^7.12.13, @babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
   version: 7.16.7
   resolution: "@babel/template@npm:7.16.7"
   dependencies:
@@ -1513,7 +1513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.0, @babel/traverse@npm:^7.16.10, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.7.2":
+"@babel/traverse@npm:^7.12.13, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.0, @babel/traverse@npm:^7.16.10, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.7.2":
   version: 7.16.10
   resolution: "@babel/traverse@npm:7.16.10"
   dependencies:
@@ -1907,6 +1907,81 @@ __metadata:
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
   checksum: 1191022023e32763063cc1c8b1143fa316fb05db2f9698280a7bdbafcabd989e5fd64f8eb875b8a2e54c53f25dba45ed2eea8ced394d9e484da0fda674cd17a5
+  languageName: node
+  linkType: hard
+
+"@linaria/babel-preset@npm:^3.0.0-beta.14, @linaria/babel-preset@npm:^3.0.0-beta.17":
+  version: 3.0.0-beta.17
+  resolution: "@linaria/babel-preset@npm:3.0.0-beta.17"
+  dependencies:
+    "@babel/generator": ">=7"
+    "@babel/plugin-syntax-dynamic-import": ">=7"
+    "@babel/template": ">=7"
+    "@linaria/core": ^3.0.0-beta.15
+    "@linaria/logger": ^3.0.0-beta.15
+    "@linaria/utils": ^3.0.0-beta.15
+    cosmiconfig: ^5.1.0
+    source-map: ^0.7.3
+    stylis: ^3.5.4
+  peerDependencies:
+    "@babel/core": ">=7"
+  checksum: 7b581f1fda66ca441ecf13f45451c327791a2245d6a02bedd1f4c9fccf6dcd9a8ea12b3a2da0a419bdf551450768a06f052d55e76e5ce5ea3cd6cfd231316286
+  languageName: node
+  linkType: hard
+
+"@linaria/core@npm:^3.0.0-beta.15":
+  version: 3.0.0-beta.15
+  resolution: "@linaria/core@npm:3.0.0-beta.15"
+  dependencies:
+    "@linaria/utils": ^3.0.0-beta.15
+  checksum: 77b3763d10e73712a8126263b93fc063fb7075368aabd059bf37f04e6524a19213aeb5f66dabd509ad138decd0ae1ffe65ae0bf4e1a7c44422be43fd438765f8
+  languageName: node
+  linkType: hard
+
+"@linaria/logger@npm:^3.0.0-beta.15":
+  version: 3.0.0-beta.15
+  resolution: "@linaria/logger@npm:3.0.0-beta.15"
+  dependencies:
+    debug: ^4.1.1
+    picocolors: ^1.0.0
+  checksum: fd855f0bfe97f5629e00241f961862f192e64e7d2a7e6dce5d3ef631396d9434def88c699550a2d46a8c45278acea1a0059937cf8f265a98c95c1c8254ccd788
+  languageName: node
+  linkType: hard
+
+"@linaria/preeval@npm:^3.0.0-beta.17":
+  version: 3.0.0-beta.17
+  resolution: "@linaria/preeval@npm:3.0.0-beta.17"
+  dependencies:
+    "@linaria/babel-preset": ^3.0.0-beta.17
+  peerDependencies:
+    "@babel/core": ">=7"
+  checksum: 0cfcdb713af3cfc3012b29ca00523a3cf691a559b5deed730293fe84d23a24c0d442b317054ddb98573a68dc16d525efa3b1c5656035241db6080712121b1d83
+  languageName: node
+  linkType: hard
+
+"@linaria/shaker@npm:^3.0.0-beta.14":
+  version: 3.0.0-beta.17
+  resolution: "@linaria/shaker@npm:3.0.0-beta.17"
+  dependencies:
+    "@babel/generator": ">=7"
+    "@babel/plugin-transform-runtime": ">=7"
+    "@babel/plugin-transform-template-literals": ">=7"
+    "@babel/preset-env": ">=7"
+    "@linaria/babel-preset": ^3.0.0-beta.17
+    "@linaria/logger": ^3.0.0-beta.15
+    "@linaria/preeval": ^3.0.0-beta.17
+    babel-plugin-transform-react-remove-prop-types: ^0.4.24
+    ts-invariant: ^0.9.0
+  peerDependencies:
+    "@babel/core": ">=7"
+  checksum: a93cff47b266fca304ab4cfd76e6bd246a720c7eeff501b569344ef5d085a690c3903d4e1822d2ac80dcc06ecba95d3935dd5565d250306efca50a3d09a6a4a1
+  languageName: node
+  linkType: hard
+
+"@linaria/utils@npm:^3.0.0-beta.15":
+  version: 3.0.0-beta.15
+  resolution: "@linaria/utils@npm:3.0.0-beta.15"
+  checksum: 05f16972d91a396d3e356a310a037fe1ec4cd7b1ed63923cbb46e583dece687e2342ba77983aa392c4631d841d6df303c6d2883c5c2c484999c58ae4d2bc27a0
   languageName: node
   linkType: hard
 
@@ -2899,7 +2974,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.14":
+"@types/babel-plugin-tester@npm:^9.0.0":
+  version: 9.0.4
+  resolution: "@types/babel-plugin-tester@npm:9.0.4"
+  dependencies:
+    "@types/babel__core": "*"
+    "@types/prettier": "*"
+  checksum: ff34219d60212e4ec98868fdba13abcb9565f7be81fcd4a2b1944fc174b8784ab115df717675e3296c7e5dc572f9a422e351f3bfb064ed33ef6a0f7cb3d5791c
+  languageName: node
+  linkType: hard
+
+"@types/babel__core@npm:*, @types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.14":
   version: 7.1.18
   resolution: "@types/babel__core@npm:7.1.18"
   dependencies:
@@ -2918,6 +3003,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.0.0
   checksum: 20effbbb5f8a3a0211e95959d06ae70c097fb6191011b73b38fe86deebefad8e09ee014605e0fd3cdaedc73d158be555866810e9166e1f09e4cfd880b874dcb0
+  languageName: node
+  linkType: hard
+
+"@types/babel__helper-plugin-utils@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@types/babel__helper-plugin-utils@npm:7.10.0"
+  dependencies:
+    "@types/babel__core": "*"
+  checksum: 5a5fce5e8910b4728e2d0740d9fd72af86bbf6ce747d500ce82c8694200af63d45041f5c8101847f98e1cecddfeb5f13a447e592d5246cddaabbeccfcba4098e
   languageName: node
   linkType: hard
 
@@ -3173,7 +3267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prettier@npm:^2.1.5":
+"@types/prettier@npm:*, @types/prettier@npm:^2.1.5":
   version: 2.4.3
   resolution: "@types/prettier@npm:2.4.3"
   checksum: b240434daabac54700c862b0bb52a83fec396e0e9c847447119ba41fd8404d79aadfa174e6306fb094b29efadac586344b7606c3a71c286b71755ab2579d54df
@@ -4331,10 +4425,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-tester@npm:10.0.0":
+  version: 10.0.0
+  resolution: "babel-plugin-tester@npm:10.0.0"
+  dependencies:
+    "@types/babel-plugin-tester": ^9.0.0
+    lodash.mergewith: ^4.6.2
+    prettier: ^2.0.1
+    strip-indent: ^3.0.0
+  peerDependencies:
+    "@babel/core": ^7.11.6
+  checksum: 9a93dccee0347fe8953f2727da66a76fe27d9b4ead3ef86023d36d7fe6f6d85cfd4440b36134ceca317ae0700bf2a24997505be2c7c3f0c41ecf89b1fe7eb27d
+  languageName: node
+  linkType: hard
+
 "babel-plugin-transform-async-to-promises@npm:^0.8.15":
   version: 0.8.18
   resolution: "babel-plugin-transform-async-to-promises@npm:0.8.18"
   checksum: dcc345359eb33f55c42c49894166c9a5c65635e1a6e0518a00beef4f1ead7dec3409f5b3050844c1870470627b21248b0947ee884835881961b731b638156377
+  languageName: node
+  linkType: hard
+
+"babel-plugin-transform-react-remove-prop-types@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "babel-plugin-transform-react-remove-prop-types@npm:0.4.24"
+  checksum: 54afe56d67f0d118c9da23996f39948e502a152b3f582eb6e8f163fcb76c2c1ea4e0cdd4f9fac5c0ef050eab4fe0a950b0b74aae6237bcc0d31d8fc4cc808d1a
   languageName: node
   linkType: hard
 
@@ -4691,6 +4806,31 @@ __metadata:
     function-bind: ^1.1.1
     get-intrinsic: ^1.0.2
   checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
+  languageName: node
+  linkType: hard
+
+"caller-callsite@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "caller-callsite@npm:2.0.0"
+  dependencies:
+    callsites: ^2.0.0
+  checksum: b685e9d126d9247b320cfdfeb3bc8da0c4be28d8fb98c471a96bc51aab3130099898a2fe3bf0308f0fe048d64c37d6d09f563958b9afce1a1e5e63d879c128a2
+  languageName: node
+  linkType: hard
+
+"caller-path@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "caller-path@npm:2.0.0"
+  dependencies:
+    caller-callsite: ^2.0.0
+  checksum: 3e12ccd0c71ec10a057aac69e3ec175b721ca858c640df021ef0d25999e22f7c1d864934b596b7d47038e9b56b7ec315add042abbd15caac882998b50102fb12
+  languageName: node
+  linkType: hard
+
+"callsites@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "callsites@npm:2.0.0"
+  checksum: be2f67b247df913732b7dec1ec0bbfcdbaea263e5a95968b19ec7965affae9496b970e3024317e6d4baa8e28dc6ba0cec03f46fdddc2fdcc51396600e53c2623
   languageName: node
   linkType: hard
 
@@ -5226,6 +5366,18 @@ __metadata:
     parse-json: ^4.0.0
     require-from-string: ^2.0.1
   checksum: bf31256752138fedd4bef3195ca74731741e24978e0ccefeb91ebfff4b37d43648a791391106b048743015005acb614bf328b46b9a6ec55e52164f45af2959e8
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^5.1.0":
+  version: 5.2.1
+  resolution: "cosmiconfig@npm:5.2.1"
+  dependencies:
+    import-fresh: ^2.0.0
+    is-directory: ^0.3.1
+    js-yaml: ^3.13.1
+    parse-json: ^4.0.0
+  checksum: 8b6f1d3c8a5ffdf663a952f17af0761adf210b7a5933d0fe8988f3ca3a1f0e1e5cbbb74d5b419c15933dd2fdcaec31dbc5cc85cb8259a822342b93b529eff89c
   languageName: node
   linkType: hard
 
@@ -7285,8 +7437,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "griffel-repository@workspace:."
   dependencies:
+    "@babel/core": ^7.12.13
+    "@babel/generator": ^7.12.13
+    "@babel/helper-plugin-utils": ^7.12.13
+    "@babel/preset-typescript": ^7.12.13
+    "@babel/template": ^7.12.13
+    "@babel/traverse": ^7.12.13
     "@emotion/hash": ^0.8.0
     "@fluentui/bundle-size": ^1.1.4
+    "@linaria/babel-preset": ^3.0.0-beta.14
+    "@linaria/shaker": ^3.0.0-beta.14
     "@nrwl/cli": 13.4.5
     "@nrwl/eslint-plugin-nx": 13.4.5
     "@nrwl/jest": 13.4.5
@@ -7300,6 +7460,7 @@ __metadata:
     "@testing-library/jest-dom": 5.16.1
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
+    "@types/babel__helper-plugin-utils": 7.10.0
     "@types/jest": 27.0.2
     "@types/node": 14.14.33
     "@types/react": 17.0.30
@@ -7307,8 +7468,10 @@ __metadata:
     "@types/stylis": 4.0.2
     "@typescript-eslint/eslint-plugin": ~5.3.0
     "@typescript-eslint/parser": ~5.3.0
+    ajv: ^8.4.0
     babel-jest: 27.2.3
     babel-plugin-annotate-pure-calls: 0.4.0
+    babel-plugin-tester: 10.0.0
     beachball: ^2.20.0
     csstype: ^2.6.19
     eslint: 8.2.0
@@ -7723,6 +7886,16 @@ __metadata:
   dependencies:
     import-from: ^3.0.0
   checksum: f2c4230e8389605154a390124381f9136811306ae4ba1c8017398c3c6926bc5cf75cf89350372b4938f79792ea373776b4efabd27506440ec301ce34c4e867eb
+  languageName: node
+  linkType: hard
+
+"import-fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "import-fresh@npm:2.0.0"
+  dependencies:
+    caller-path: ^2.0.0
+    resolve-from: ^3.0.0
+  checksum: 610255f9753cc6775df00be08e9f43691aa39f7703e3636c45afe22346b8b545e600ccfe100c554607546fc8e861fa149a0d1da078c8adedeea30fff326eef79
   languageName: node
   linkType: hard
 
@@ -9364,6 +9537,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash.mergewith@npm:^4.6.2":
+  version: 4.6.2
+  resolution: "lodash.mergewith@npm:4.6.2"
+  checksum: a6db2a9339752411f21b956908c404ec1e088e783a65c8b29e30ae5b3b6384f82517662d6f425cc97c2070b546cc2c7daaa8d33f78db7b6e9be06cd834abdeb8
   languageName: node
   linkType: hard
 
@@ -11108,7 +11288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.2.1":
+"prettier@npm:^2.0.1, prettier@npm:^2.2.1":
   version: 2.5.1
   resolution: "prettier@npm:2.5.1"
   bin:
@@ -11618,6 +11798,13 @@ __metadata:
   dependencies:
     resolve-from: ^5.0.0
   checksum: 546e0816012d65778e580ad62b29e975a642989108d9a3c5beabfb2304192fa3c9f9146fbdfe213563c6ff51975ae41bac1d3c6e047dd9572c94863a057b4d81
+  languageName: node
+  linkType: hard
+
+"resolve-from@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "resolve-from@npm:3.0.0"
+  checksum: fff9819254d2d62b57f74e5c2ca9c0bdd425ca47287c4d801bc15f947533148d858229ded7793b0f59e61e49e782fffd6722048add12996e1bd4333c29669062
   languageName: node
   linkType: hard
 
@@ -12760,6 +12947,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stylis@npm:^3.5.4":
+  version: 3.5.4
+  resolution: "stylis@npm:3.5.4"
+  checksum: 3673a748ad236219bd77ca9c0a8730b8726812e612cbc844aa6f029f13666a10cf2825a5f8d41f05e8af02b5987d31b7d3ebe995e4b42e0255366fec23489b77
+  languageName: node
+  linkType: hard
+
 "stylis@npm:^4.0.13":
   version: 4.0.13
   resolution: "stylis@npm:4.0.13"
@@ -13114,6 +13308,15 @@ __metadata:
   bin:
     tree-kill: cli.js
   checksum: 49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
+  languageName: node
+  linkType: hard
+
+"ts-invariant@npm:^0.9.0":
+  version: 0.9.4
+  resolution: "ts-invariant@npm:0.9.4"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: c9e5726361fa266916966b2070605f8664b6dd1d8b0ef7565dbf056abb6a87be26195985ef62dd97aeb0894cf2f4ad5b7f0d89dadadc197eaa38e99222afa29c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds `@griffel/preset` package that it actually a copy of [`@fluentui/babel-make-styles`](https://github.com/microsoft/fluentui/tree/master/packages/babel-make-styles). The single difference is that instead of a plugin we are exporting a preset now. This will give us more flexibility with adding/managing plugins in future.

`README.md` was also updated to include proper package names.