### PR TITLE
chore: enable "lint" in CI checks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "excludedFiles": "*.fixture.js",
       "rules": {
         "@nrwl/nx/enforce-module-boundaries": [
           "error",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,6 @@ jobs:
             yarn-cache-folder-
 
       - run: yarn install --frozen-lockfile
+      - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
       - run: yarn nx affected --target=test --parallel --max-parallel=2

--- a/change/@griffel-react-158feffa-02ae-4f23-b7a9-ad115833d5a8.json
+++ b/change/@griffel-react-158feffa-02ae-4f23-b7a9-ad115833d5a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix lint issues",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/src/RendererContext.tsx
+++ b/packages/react/src/RendererContext.tsx
@@ -16,14 +16,7 @@ export interface RendererProviderProps {
  * Verifies if an application can use DOM.
  */
 function canUseDOM(): boolean {
-  return (
-    typeof window !== 'undefined' &&
-    !!(
-      window.document &&
-      // eslint-disable-next-line deprecation/deprecation
-      window.document.createElement
-    )
-  );
+  return typeof window !== 'undefined' && !!(window.document && window.document.createElement);
 }
 
 /**

--- a/packages/react/src/makeStaticStyles.ts
+++ b/packages/react/src/makeStaticStyles.ts
@@ -3,7 +3,7 @@ import { makeStaticStyles as vanillaMakeStaticStyles } from '@griffel/core';
 import { useRenderer } from './RendererContext';
 import type { GriffelStaticStyles, MakeStaticStylesOptions } from '@griffel/core';
 
-export function makeStaticStyles<Selectors>(styles: GriffelStaticStyles | GriffelStaticStyles[]) {
+export function makeStaticStyles(styles: GriffelStaticStyles | GriffelStaticStyles[]) {
   const getStyles = vanillaMakeStaticStyles(styles);
 
   if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
This PR enables `lint` command (or target in terms of NX) in CI pipelines.
Don't know how I overlooked it initially.