### PR TITLE
chore: add NX patch to fix "implicitDependencies", rename workspaces

### DIFF
--- a/.yarn/patches/@nrwl-workspace-npm-13.4.5-233a3ec85c
+++ b/.yarn/patches/@nrwl-workspace-npm-13.4.5-233a3ec85c
@@ -1,3 +1,16 @@
+diff --git a/src/core/assert-workspace-validity.js b/src/core/assert-workspace-validity.js
+index 3671fe2f138d04b58add0bf6531e166141f2eb0a..32093dad6079d6c80df4a5636803e5e4cf68234c 100644
+--- a/src/core/assert-workspace-validity.js
++++ b/src/core/assert-workspace-validity.js
+@@ -59,7 +59,7 @@ function assertWorkspaceValidity(workspaceJson, nxJson) {
+ }
+ exports.assertWorkspaceValidity = assertWorkspaceValidity;
+ function detectAndSetInvalidProjectValues(map, sourceName, desiredProjectNames, validProjects) {
+-    const invalidProjects = desiredProjectNames.filter((projectName) => !validProjects[projectName]);
++    const invalidProjects = desiredProjectNames.filter((projectName) => !validProjects[projectName.replace('!', '')]);
+     if (invalidProjects.length > 0) {
+         map.set(sourceName, invalidProjects);
+     }
 diff --git a/src/utilities/buildable-libs-utils.js b/src/utilities/buildable-libs-utils.js
 index a3b897ae1a0f493f0d2a37598f988a6a78955f62..b22cddbcd84eca7d061b2396911b2f367307b951 100644
 --- a/src/utilities/buildable-libs-utils.js

--- a/workspace.json
+++ b/workspace.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "projects": {
-    "core": "packages/core",
-    "react": "packages/react"
+    "@griffel/core": "packages/core",
+    "@griffel/react": "packages/react"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2379,7 +2379,7 @@ __metadata:
 
 "@nrwl/workspace@patch:@nrwl/workspace@npm:13.4.5#.yarn/patches/@nrwl-workspace-npm-13.4.5-233a3ec85c::locator=griffel-repository%40workspace%3A.":
   version: 13.4.5
-  resolution: "@nrwl/workspace@patch:@nrwl/workspace@npm%3A13.4.5#.yarn/patches/@nrwl-workspace-npm-13.4.5-233a3ec85c::version=13.4.5&hash=4872e0&locator=griffel-repository%40workspace%3A."
+  resolution: "@nrwl/workspace@patch:@nrwl/workspace@npm%3A13.4.5#.yarn/patches/@nrwl-workspace-npm-13.4.5-233a3ec85c::version=13.4.5&hash=499941&locator=griffel-repository%40workspace%3A."
   dependencies:
     "@nrwl/cli": 13.4.5
     "@nrwl/devkit": 13.4.5
@@ -2412,7 +2412,7 @@ __metadata:
   peerDependenciesMeta:
     prettier:
       optional: true
-  checksum: 7c22cbfc206d51f0b2b41a835540211ca5ce2d8555a623a833397b9d81bdffa56bae6a0ae521d4f5a92413d068c19b73c3ae454d924618eab64c856ddfbe1265
+  checksum: 4e5b0cb5d4436c888d37a1163ab6568a747b95e4e0a418b1e5cd05787ed38e9c798d2bc6623d9d2d6bb4d3e2e2d32be0d94aba1bfe258b22fe518459e7e0b72f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Adds NX patch to workaround nrwl/nx#8322, patches are tracked in #15
- Renames packages in workspace as @Hotell suggested. It's not a big problem, but adds confusion in Nx configs:

  ```json
  { "implicitDependencies": ["react"] }
  ```
  _vs._
  ```json
  { "implicitDependencies": ["@griffel/react"] }
  ```