### PR TITLE
fix(webpack-loader): use this.cacheable() to improve performance

### DIFF
--- a/change/@griffel-webpack-loader-9ea1134d-1b02-4967-a5da-2225b4669f1d.json
+++ b/change/@griffel-webpack-loader-9ea1134d-1b02-4967-a5da-2225b4669f1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use this.cacheable() to improve performance",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -43,6 +43,10 @@ export function webpackLoader(
   sourceCode: WebpackLoaderParams[0],
   inputSourceMap: WebpackLoaderParams[1],
 ) {
+  // Loaders are cacheable by default, but in there edge cases/bugs when caching does not work until it's specified:
+  // https://github.com/webpack/webpack/issues/14946
+  this.cacheable();
+
   const options = getOptions(this) as WebpackLoaderOptions;
 
   validate(configSchema, options, {


### PR DESCRIPTION
Loaders in Webpack are cacheable by default (https://webpack.js.org/api/loaders/#thiscacheable). But in there edge cases/bugs when caching does not work until it's specified (https://github.com/webpack/webpack/issues/14946).

This PR unblocks integration to the product.

| Test                       |      Time |
| -------------------------- | --------: |
| With`this.cacheable()`     |   28038ms |
| Without `this.cacheable()` | 222428 ms |

Without `this.cacheable()` Webpack always shows the same times as a cold start.
