### PR TITLE
chore: output sourcemaps with Rollup

### DIFF
--- a/change/@griffel-core-71ab0a7a-1391-4c59-9712-7048e84fa2b5.json
+++ b/change/@griffel-core-71ab0a7a-1391-4c59-9712-7048e84fa2b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add sourcemaps to dist files",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-react-da0ae3ee-1d28-4610-a9e1-d2decfba295a.json
+++ b/change/@griffel-react-da0ae3ee-1d28-4610-a9e1-d2decfba295a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add sourcemaps to dist files",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/getRollupOptions.js
+++ b/tools/getRollupOptions.js
@@ -8,6 +8,7 @@ function getRollupOptions(/** @type {import('rollup').RollupOptions} */ options)
       o.preserveModules = true;
       o.preserveModulesRoot = 'src';
       o.interop = false;
+      o.sourcemap = true;
     });
   } else {
     options.output = {
@@ -15,6 +16,7 @@ function getRollupOptions(/** @type {import('rollup').RollupOptions} */ options)
       preserveModules: true,
       preserveModulesRoot: 'src',
       interop: false,
+      sourcemap: true,
     };
   }
 


### PR DESCRIPTION
Fixes #34.

The problem affects only packages bundled for web (`@griffel/core` & `@griffel/react`). This PR adds sourcemaps for these packages:

![image](https://user-images.githubusercontent.com/14183168/154813615-b1a575c3-f3be-4042-af79-5b3398cb78b1.png)


_It seems that `@nrwl/web:rollup` does not generate sourcemaps and it's not configurable (while it's just the Rollup option). I will trigger an issue for them if it's true._