### PR TITLE
chore: add proper type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,10 @@ jobs:
             yarn-cache-folder-
 
       - run: yarn install --frozen-lockfile
+      - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
       - run: yarn nx affected --target=test --parallel --max-parallel=2
+      - run: yarn nx affected --target=type-check --parallel --max-parallel=3
 
   pr:
     runs-on: ubuntu-latest
@@ -73,3 +75,4 @@ jobs:
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
       - run: yarn nx affected --target=test --parallel --max-parallel=2
+      - run: yarn nx affected --target=type-check --parallel --max-parallel=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
+      - run: yarn nx affected --target=type-check --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
       - run: yarn nx affected --target=test --parallel --max-parallel=2
-      - run: yarn nx affected --target=type-check --parallel --max-parallel=3
 
   pr:
     runs-on: ubuntu-latest
@@ -73,6 +73,6 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
+      - run: yarn nx affected --target=type-check --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
       - run: yarn nx affected --target=test --parallel --max-parallel=2
-      - run: yarn nx affected --target=type-check --parallel --max-parallel=3

--- a/apps/website/project.json
+++ b/apps/website/project.json
@@ -7,7 +7,8 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "cwd": "apps/website",
-        "commands": [{ "command": "docusaurus build --out-dir ../../dist/apps/website" }]
+        "commands": [{ "command": "docusaurus build --out-dir ../../dist/apps/website" }],
+        "outputPath": ["dist/apps/website"]
       }
     },
     "serve": {

--- a/change/@griffel-babel-preset-ade2cc60-0637-4df7-a5f6-4697bfc5397d.json
+++ b/change/@griffel-babel-preset-ade2cc60-0637-4df7-a5f6-4697bfc5397d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add \"type-check\" target to project.json ",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-core-7c61bf65-d1cd-439b-8a52-173551bad483.json
+++ b/change/@griffel-core-7c61bf65-d1cd-439b-8a52-173551bad483.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add \"type-check\" target to project.json ",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-jest-serializer-9655a39c-cd7c-4675-97e1-0e531f048be4.json
+++ b/change/@griffel-jest-serializer-9655a39c-cd7c-4675-97e1-0e531f048be4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add \"type-check\" target to project.json ",
+  "packageName": "@griffel/jest-serializer",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-react-2d4f8065-f777-4025-aa0a-f0ebbf63c697.json
+++ b/change/@griffel-react-2d4f8065-f777-4025-aa0a-f0ebbf63c697.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add \"type-check\" target to project.json ",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-loader-f6e64b6c-4bfd-47fe-acfb-a84c769ae14a.json
+++ b/change/@griffel-webpack-loader-f6e64b6c-4bfd-47fe-acfb-a84c769ae14a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add \"type-check\" target to project.json ",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/nx.json
+++ b/nx.json
@@ -11,7 +11,7 @@
     "default": {
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e", "build-storybook"]
+        "cacheableOperations": ["build", "lint", "test", "e2e", "build-storybook", "type-check"]
       }
     }
   },

--- a/packages/babel-preset/__fixtures__/object-sequence-expr/code.ts
+++ b/packages/babel-preset/__fixtures__/object-sequence-expr/code.ts
@@ -1,7 +1,7 @@
-import { makeStyles, MakeStylesStyle } from '@griffel/react';
+import { makeStyles, GriffelStyle } from '@griffel/react';
 
 const switchClassName = 'fui-Switch';
-let _a: Record<string, MakeStylesStyle>;
+let _a: Record<string, GriffelStyle>;
 
 export const useStyles = makeStyles({
   root:

--- a/packages/babel-preset/__fixtures__/object-sequence-expr/output.ts
+++ b/packages/babel-preset/__fixtures__/object-sequence-expr/output.ts
@@ -1,7 +1,7 @@
-import { __styles, MakeStylesStyle } from '@griffel/react';
+import { __styles, GriffelStyle } from '@griffel/react';
 const switchClassName = 'fui-Switch';
 
-let _a: Record<string, MakeStylesStyle>;
+let _a: Record<string, GriffelStyle>;
 
 export const useStyles = __styles(
   {

--- a/packages/babel-preset/project.json
+++ b/packages/babel-preset/project.json
@@ -42,7 +42,8 @@
       "options": {
         "cwd": "packages/babel-preset",
         "color": true,
-        "commands": [{ "command": "tsc -b" }]
+        "commands": [{ "command": "tsc -b" }],
+        "outputPath": []
       }
     }
   },

--- a/packages/babel-preset/project.json
+++ b/packages/babel-preset/project.json
@@ -36,6 +36,14 @@
           }
         ]
       }
+    },
+    "type-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "packages/babel-preset",
+        "color": true,
+        "commands": [{ "command": "tsc -b" }]
+      }
     }
   },
   "tags": []

--- a/packages/babel-preset/tsconfig.spec.json
+++ b/packages/babel-preset/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node", "environment"]

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -53,6 +53,14 @@
         "cwd": "packages/core",
         "commands": [{ "command": "bundle-size measure" }]
       }
+    },
+    "type-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "packages/core",
+        "color": true,
+        "commands": [{ "command": "tsc -b tsconfig.json" }]
+      }
     }
   }
 }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -59,7 +59,8 @@
       "options": {
         "cwd": "packages/core",
         "color": true,
-        "commands": [{ "command": "tsc -b tsconfig.json" }]
+        "commands": [{ "command": "tsc -b" }],
+        "outputPath": []
       }
     }
   }

--- a/packages/jest-serializer/project.json
+++ b/packages/jest-serializer/project.json
@@ -29,6 +29,14 @@
         "main": "packages/jest-serializer/src/index.ts",
         "assets": ["packages/jest-serializer/*.md"]
       }
+    },
+    "type-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "packages/jest-serializer",
+        "color": true,
+        "commands": [{ "command": "tsc -b" }]
+      }
     }
   },
   "tags": []

--- a/packages/jest-serializer/project.json
+++ b/packages/jest-serializer/project.json
@@ -35,7 +35,8 @@
       "options": {
         "cwd": "packages/jest-serializer",
         "color": true,
-        "commands": [{ "command": "tsc -b" }]
+        "commands": [{ "command": "tsc -b" }],
+        "outputPath": []
       }
     }
   },

--- a/packages/react/.storybook/tsconfig.json
+++ b/packages/react/.storybook/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true,
+    "noEmit": true,
     "outDir": ""
   },
   "files": [

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -92,6 +92,14 @@
           "quiet": true
         }
       }
+    },
+    "type-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "packages/react",
+        "color": true,
+        "commands": [{ "command": "tsc -b" }]
+      }
     }
   }
 }

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -98,7 +98,8 @@
       "options": {
         "cwd": "packages/react",
         "color": true,
-        "commands": [{ "command": "tsc -b" }]
+        "commands": [{ "command": "tsc -b" }],
+        "outputPath": []
       }
     }
   }

--- a/packages/webpack-loader/project.json
+++ b/packages/webpack-loader/project.json
@@ -29,6 +29,14 @@
         "main": "packages/webpack-loader/src/index.ts",
         "assets": ["packages/webpack-loader/*.md"]
       }
+    },
+    "type-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "packages/webpack-loader",
+        "color": true,
+        "commands": [{ "command": "tsc -b" }]
+      }
     }
   },
   "tags": []

--- a/packages/webpack-loader/project.json
+++ b/packages/webpack-loader/project.json
@@ -35,7 +35,8 @@
       "options": {
         "cwd": "packages/webpack-loader",
         "color": true,
-        "commands": [{ "command": "tsc -b" }]
+        "commands": [{ "command": "tsc -b" }],
+        "outputPath": []
       }
     }
   },

--- a/packages/webpack-loader/tsconfig.spec.json
+++ b/packages/webpack-loader/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node", "environment"]


### PR DESCRIPTION
This PR implements new Nx target called `type-check` to have proper checks for TypeScript.

Motivation:
- broken type checks during build, https://github.com/nrwl/nx/issues/9053
- broken type checks in fixtures, for example `packages/babel-preset/__fixtures__/object-sequence-expr/output.ts` in this PR