### PR TITLE
fix: enable interop back in Rollup

### DIFF
--- a/tools/getRollupOptions.js
+++ b/tools/getRollupOptions.js
@@ -1,13 +1,12 @@
 function getRollupOptions(/** @type {import('rollup').RollupOptions} */ options) {
   // Following options are overridden:
   // - `preserveModules` & `preserveModulesRoot` to stop bundling to a single file and prevent bundle size issues
-  // - `interop` to not include interop for `import * as` syntax
+  // - `sourcemap` to enable sourcemaps
 
   if (Array.isArray(options.output)) {
     options.output.forEach(o => {
       o.preserveModules = true;
       o.preserveModulesRoot = 'src';
-      o.interop = false;
       o.sourcemap = true;
     });
   } else {
@@ -15,7 +14,6 @@ function getRollupOptions(/** @type {import('rollup').RollupOptions} */ options)
       ...options.output,
       preserveModules: true,
       preserveModulesRoot: 'src',
-      interop: false,
       sourcemap: true,
     };
   }


### PR DESCRIPTION
> Do not touch things if they work

> Controls how Rollup handles default, namespace and dynamic imports from external dependencies in formats like CommonJS that do not natively support these concepts.
> https://rollupjs.org/guide/en/#outputinterop

This PR enables it back. It affects only CommonJS output and is required to work properly.