### PR TITLE
chore(storybook): Use @babel/typescript

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,7 @@ module.exports = {
   babel: async options => {
     return {
       ...options,
-      presets: [...options.presets, '@nrwl/react/babel'],
+      presets: [...options.presets, '@babel/typescript'],
     };
   },
 };


### PR DESCRIPTION
Use `@babel/typescript` to compile typescript in storybook.

`@nrwl/react/babel` transpiles the code too much (`for..in` transpiled to a function). That makes the code different to what we ship and also more difficult to debug.