### PR TITLE
fix(babel-preset): remove implicit dependency on TypeScript preset

### DIFF
--- a/change/@griffel-babel-preset-66cba623-8b9a-422f-ba36-22ad7d7ebc69.json
+++ b/change/@griffel-babel-preset-66cba623-8b9a-422f-ba36-22ad7d7ebc69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove implicit dependency on TypeScript preset",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -15,6 +15,11 @@ pluginTester({
       plugins: ['typescript'],
     },
   },
+  pluginOptions: {
+    babelOptions: {
+      presets: ['@babel/typescript'],
+    },
+  },
   formatResult: code =>
     prettierFormatter(code, {
       config: {

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -99,9 +99,7 @@ export const transformPlugin = declare<Partial<BabelPluginOptions>, PluginObj<Ba
   api.assertVersion(7);
 
   const pluginOptions: Required<BabelPluginOptions> = {
-    babelOptions: {
-      presets: ['@babel/preset-typescript'],
-    },
+    babelOptions: {},
     modules: [{ moduleSource: '@griffel/react', importName: 'makeStyles' }],
     evaluationRules: [
       { action: shakerEvaluator },


### PR DESCRIPTION
This PR removes implicit dependency on `@babel/preset-typescript` for module evaluation.
If it's used - it should be specified obviously.