### PR TITLE
chore: add possibility to run "deploy" workflow manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    branches:
+      - main
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.head_commit.message, 'applying package updates') }}
+    if: ${{ contains(github.event.head_commit.message, 'applying package updates') || github.event_name == 'workflow_dispatch' }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds possibility to run "deploy" workflow manually without running releases.

References:
- https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
- https://www.techiediaries.com/github-actions-workflow-manual-http-post-triggers-workflow_dispatch-repository_dispatch/