### PR TITLE
chore: add CNAME generation on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/apps/website
+          cname: griffel.js.org


### PR DESCRIPTION
Adds `CNAME` file generation.

References:
- https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname