### PR TITLE
fix: improve typings to solve TS issues

### DIFF
--- a/.github/workflows/ci-change.yml
+++ b/.github/workflows/ci-change.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands

--- a/change/@griffel-core-9687dcfc-600f-454e-8ae6-cd1267200313.json
+++ b/change/@griffel-core-9687dcfc-600f-454e-8ae6-cd1267200313.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: improve typings to solve TS issues",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/e2e/typescript/src/assets/fixture.ts
+++ b/e2e/typescript/src/assets/fixture.ts
@@ -9,6 +9,13 @@ function assertType(style: GriffelStyle): GriffelStyle {
 
 assertType({ flexShrink: 0 });
 assertType({ flexShrink: 1 });
+assertType({ zIndex: 0 });
+assertType({ zIndex: 1 });
+
+assertType({ fontWeight: 'var(--foo)' });
+assertType({ flexShrink: 'var(--bar)' });
+assertType({ opacity: 'var(--baz)' });
+assertType({ zIndex: 'var(--qux)' });
 
 assertType({ color: 'beige' });
 assertType({ paddingLeft: '5px' });
@@ -21,6 +28,15 @@ assertType({ '--color': 'red' });
 assertType({
   ':hover': { flexShrink: 0 },
   ':focus': { flexShrink: 'initial' },
+  ':active': { zIndex: 0 },
+  ':visited': { zIndex: 1 },
+});
+
+assertType({
+  ':hover': { fontWeight: 'var(--foo)' },
+  ':focus': { flexShrink: 'var(--bar)' },
+  ':active': { opacity: 'var(--bar)' },
+  ':visited': { zIndex: 'var(--qux)' },
 });
 
 assertType({
@@ -36,8 +52,17 @@ assertType({
 //
 
 assertType({
-  ':hover:focus': { flexShrink: 0 as const },
+  ':hover:focus': { flexShrink: 0 },
   ':hover:active': { flexShrink: 'initial' },
+  ':hover:visited': { zIndex: 0 },
+  ':hover:focus-visible': { zIndex: 1 },
+});
+
+assertType({
+  ':link:hover': { fontWeight: 'var(--foo)' },
+  ':link:focus': { flexShrink: 'var(--bar)' },
+  ':link:active': { opacity: 'var(--bar)' },
+  ':link:visited': { zIndex: 'var(--qux)' },
 });
 
 assertType({
@@ -54,8 +79,11 @@ assertType({
 
 assertType({
   '.foo': {
-    '.bar': { flexShrink: 0 as const },
+    '.bar': { flexShrink: 0 },
     '.baz': { flexShrink: 'initial' },
+    '.qux': { opacity: 0 },
+    '.fred': { zIndex: 0 },
+    '.thud': { zIndex: 1 },
   },
   '.bar': {
     '.baz': { color: 'beige' },
@@ -65,6 +93,10 @@ assertType({
     '.qux': {
       '--color': 'red',
     },
+  },
+  '.qux': {
+    '.bar': { flexShrink: 'var(--bar)' },
+    '.baz': { opacity: 'var(--baz)' },
   },
 });
 

--- a/e2e/typescript/src/test.mjs
+++ b/e2e/typescript/src/test.mjs
@@ -109,7 +109,7 @@ async function performTest(tsVersion) {
   }
 
   try {
-    await sh(`${tscBin} --noEmit`, tempDir);
+    await sh(`${tscBin} --noEmit --pretty`, tempDir);
 
     console.log(logSymbols.success, `Example project was successfully built with typescript@${tsVersion}`);
     console.log('');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,21 +30,31 @@ type GriffelStylesCSSPseudos = {
 // updated or removed.
 //
 
-type GriffelStylesCSSObjectCustomL1 = {
-  [Property: string]: GriffelStylesCSSValue | undefined | GriffelStylesCSSObjectCustomL2;
-} & GriffelStylesStrictCSSObject;
-type GriffelStylesCSSObjectCustomL2 = {
-  [Property: string]: GriffelStylesCSSValue | undefined | GriffelStylesCSSObjectCustomL3;
-} & GriffelStylesStrictCSSObject;
-type GriffelStylesCSSObjectCustomL3 = {
-  [Property: string]: GriffelStylesCSSValue | undefined | GriffelStylesCSSObjectCustomL4;
-} & GriffelStylesStrictCSSObject;
-type GriffelStylesCSSObjectCustomL4 = {
-  [Property: string]: GriffelStylesCSSValue | undefined | GriffelStylesCSSObjectCustomL5;
-} & GriffelStylesStrictCSSObject;
-type GriffelStylesCSSObjectCustomL5 = {
-  [Property: string]: GriffelStylesCSSValue | undefined;
-} & GriffelStylesStrictCSSObject;
+type GriffelStylesCSSObjectCustomL1 =
+  | ({
+      [Property: string]: string | undefined | GriffelStylesCSSObjectCustomL2;
+    } & Partial<GriffelStylesUnsupportedCSSProperties>)
+  | GriffelStylesStrictCSSObject;
+type GriffelStylesCSSObjectCustomL2 =
+  | ({
+      [Property: string]: string | undefined | GriffelStylesCSSObjectCustomL3;
+    } & Partial<GriffelStylesUnsupportedCSSProperties>)
+  | GriffelStylesStrictCSSObject;
+type GriffelStylesCSSObjectCustomL3 =
+  | ({
+      [Property: string]: string | undefined | GriffelStylesCSSObjectCustomL4;
+    } & Partial<GriffelStylesUnsupportedCSSProperties>)
+  | GriffelStylesStrictCSSObject;
+type GriffelStylesCSSObjectCustomL4 =
+  | ({
+      [Property: string]: string | undefined | GriffelStylesCSSObjectCustomL5;
+    } & Partial<GriffelStylesUnsupportedCSSProperties>)
+  | GriffelStylesStrictCSSObject;
+type GriffelStylesCSSObjectCustomL5 =
+  | ({
+      [Property: string]: string | undefined;
+    } & Partial<GriffelStylesUnsupportedCSSProperties>)
+  | GriffelStylesStrictCSSObject;
 
 export type GriffelAnimation = Record<'from' | 'to' | string, GriffelStylesCSSObjectCustomL1>;
 export type GriffelStyle = GriffelStylesStrictCSSObject | GriffelStylesCSSObjectCustomL1;


### PR DESCRIPTION
Fixes #49.

Changes are based on TypeScript behavior:

```ts
type A = { foo: number } | { [P: string]: string}
type B = { foo: number } & { [P: string]: string}

// ✅ Passing
const a: A = { foo: 1, bar: 'bar' }
// 🔴 "Type '{ foo: number; bar: string; }' is not assignable to type 'B'."
const b: B = { foo: 1, bar: 'bar' }
```

[TypeScript playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAglC8UDeUBmB7dAuKA7ArgLYBGEATlAL5QA+yUA2gAo4DOwZAlrgOYC6bDtx6UAUKEhQAQgnoZseIqQrUAZPWaCuvAVHbaRo0QGN0udlACGOOIhTycARgA0UYpbI4A5O7JeqJmYWxDgydmiYTq6+3r7+YoHm6AA2EAB0yeg8ABSW0QCUokA)