### PR TITLE
chore: add explicit dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,19 @@
 {
   "root": true,
   "ignorePatterns": ["**/*"],
-  "plugins": ["@nrwl/nx"],
+  "plugins": ["@nrwl/nx", "import"],
+  "extends": ["plugin:import/typescript"],
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true,
+        "project": "./tsconfig.base.json"
+      }
+    }
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": false }]
+  },
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
@@ -33,6 +45,12 @@
       "files": ["*.js", "*.jsx"],
       "extends": ["plugin:@nrwl/nx/javascript"],
       "rules": {}
+    },
+    {
+      "files": ["**/__fixtures__/**/*", "**/*.stories.ts", "**/*.stories.tsx", "**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "import/no-extraneous-dependencies": "off"
+      }
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             yarn-cache-folder-
 
       - run: yarn install --frozen-lockfile
-      - run: yarn syncpack list -pP
+      - run: yarn check-dependencies
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=type-check --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             yarn-cache-folder-
 
       - run: yarn install --frozen-lockfile
+      - run: yarn check-dependencies
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=type-check --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
@@ -70,6 +71,7 @@ jobs:
             yarn-cache-folder-
 
       - run: yarn install --frozen-lockfile
+      - run: yarn syncpack list -pP
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=type-check --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3

--- a/change/@griffel-babel-preset-e46a4792-94be-4d91-a320-8385a6e87e90.json
+++ b/change/@griffel-babel-preset-e46a4792-94be-4d91-a320-8385a6e87e90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add dependencies explicitly to package.json",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-core-fa84ecb8-c2e6-4a70-b091-c7ce4d52b97a.json
+++ b/change/@griffel-core-fa84ecb8-c2e6-4a70-b091-c7ce4d52b97a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add dependencies explicitly to package.json",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-jest-serializer-195cd5ed-09a1-4465-b408-baf1527a1ec9.json
+++ b/change/@griffel-jest-serializer-195cd5ed-09a1-4465-b408-baf1527a1ec9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add dependencies explicitly to package.json",
+  "packageName": "@griffel/jest-serializer",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-react-700de188-ed33-42a1-a65f-025b0584f342.json
+++ b/change/@griffel-react-700de188-ed33-42a1-a65f-025b0584f342.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add dependencies explicitly to package.json",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-loader-201e829c-6c79-4c21-a383-2362f234dc8a.json
+++ b/change/@griffel-webpack-loader-201e829c-6c79-4c21-a383-2362f234dc8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add dependencies explicitly to package.json",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "nx affected:build",
     "change": "beachball change",
+    "check-dependencies": "syncpack list -pP",
     "lint": "nx affected:lint",
     "start": "nx run @griffel/website:serve",
     "storybook": "nx run @griffel/react:storybook",
@@ -79,6 +80,7 @@
     "react-dom": "17.0.2",
     "react-test-renderer": "17.0.2",
     "simple-git-hooks": "2.7.0",
+    "syncpack": "6.2.0",
     "tmp": "0.2.1",
     "ts-jest": "27.0.5",
     "typescript": "~4.4.3",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "beachball": "^2.20.0",
     "eslint": "8.2.0",
     "eslint-config-prettier": "8.1.0",
+    "eslint-import-resolver-typescript": "2.5.0",
     "eslint-plugin-import": "2.25.2",
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.27.0",

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -7,6 +7,17 @@
     "type": "git",
     "url": "https://github.com/microsoft/griffel"
   },
+  "dependencies": {
+    "@babel/core": "^7.12.13",
+    "@babel/generator": "^7.12.13",
+    "@babel/helper-plugin-utils": "^7.12.13",
+    "@babel/template": "^7.12.13",
+    "@babel/traverse": "^7.12.13",
+    "@linaria/babel-preset": "^3.0.0-beta.14",
+    "@linaria/shaker": "^3.0.0-beta.14",
+    "ajv": "^8.4.0",
+    "tslib": "^2.1.0"
+  },
   "peerDependencies": {
     "@griffel/core": "^1.1.0"
   }

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -13,6 +13,12 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["**/common/*"],
+      "rules": {
+        "import/no-extraneous-dependencies": "off"
+      }
     }
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@griffel/core",
+  "version": "1.1.0",
   "description": "DOM implementation of Atomic CSS-in-JS",
   "license": "MIT",
   "repository": {
@@ -7,5 +8,11 @@
     "url": "https://github.com/microsoft/griffel"
   },
   "sideEffects": false,
-  "version": "1.1.0"
+  "dependencies": {
+    "@emotion/hash": "^0.8.0",
+    "csstype": "^3.0.10",
+    "rtl-css-js": "^1.15.0",
+    "stylis": "^4.0.13",
+    "tslib": "^2.1.0"
+  }
 }

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/microsoft/griffel"
   },
+  "dependencies": {
+    "tslib": "^2.1.0"
+  },
   "peerDependencies": {
     "@griffel/core": "^1.1.0"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/microsoft/griffel"
   },
   "sideEffects": false,
+  "dependencies": {
+    "@griffel/core": "^1.1.0",
+    "tslib": "^2.1.0"
+  },
   "peerDependencies": {
     "react": ">=16.8.0 <18.0.0"
   }

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -7,7 +7,17 @@
     "type": "git",
     "url": "https://github.com/microsoft/griffel"
   },
+  "dependencies": {
+    "@babel/core": "^7.12.13",
+    "@griffel/babel-preset": "^1.1.0",
+    "@linaria/babel-preset": "^3.0.0-beta.14",
+    "enhanced-resolve": "^5.8.2",
+    "loader-utils": "^2.0.0",
+    "schema-utils": "^3.1.1",
+    "tslib": "^2.1.0"
+  },
   "peerDependencies": {
-    "@griffel/react": "^1.0.1"
+    "@griffel/react": "^1.0.1",
+    "webpack": "^5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11453,6 +11453,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-import-resolver-typescript@npm:2.5.0":
+  version: 2.5.0
+  resolution: "eslint-import-resolver-typescript@npm:2.5.0"
+  dependencies:
+    debug: ^4.3.1
+    glob: ^7.1.7
+    is-glob: ^4.0.1
+    resolve: ^1.20.0
+    tsconfig-paths: ^3.9.0
+  peerDependencies:
+    eslint: "*"
+    eslint-plugin-import: "*"
+  checksum: e507a0cb46a05f136b1416664c7cbe1b1178001417421ce5621f147e88c8973b5c9ee1554dbf0b79ae93f760d69f2796e1a880d562356a080e9e4ac1058206a3
+  languageName: node
+  linkType: hard
+
 "eslint-module-utils@npm:^2.7.0, eslint-module-utils@npm:^2.7.2":
   version: 2.7.2
   resolution: "eslint-module-utils@npm:2.7.2"
@@ -13005,7 +13021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:7.2.0, glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:7.2.0, glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -13240,6 +13256,7 @@ __metadata:
     enhanced-resolve: ^5.8.2
     eslint: 8.2.0
     eslint-config-prettier: 8.1.0
+    eslint-import-resolver-typescript: 2.5.0
     eslint-plugin-import: 2.25.2
     eslint-plugin-jsx-a11y: 6.5.1
     eslint-plugin-react: 7.27.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -8977,6 +8977,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.0.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -8995,16 +9005,6 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
   languageName: node
   linkType: hard
 
@@ -9497,6 +9497,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:8.3.0, commander@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.19.0, commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -9529,13 +9536,6 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
-  languageName: node
-  linkType: hard
-
-"commander@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "commander@npm:8.3.0"
-  checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
   languageName: node
   linkType: hard
 
@@ -9838,6 +9838,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:7.0.1, cosmiconfig@npm:^7.0.0, cosmiconfig@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "cosmiconfig@npm:7.0.1"
+  dependencies:
+    "@types/parse-json": ^4.0.0
+    import-fresh: ^3.2.1
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+    yaml: ^1.10.0
+  checksum: 4be63e7117955fd88333d7460e4c466a90f556df6ef34efd59034d2463484e339666c41f02b523d574a797ec61f4a91918c5b89a316db2ea2f834e0d2d09465b
+  languageName: node
+  linkType: hard
+
 "cosmiconfig@npm:^4.0.0":
   version: 4.0.0
   resolution: "cosmiconfig@npm:4.0.0"
@@ -9872,19 +9885,6 @@ __metadata:
     path-type: ^4.0.0
     yaml: ^1.7.2
   checksum: 8eed7c854b91643ecb820767d0deb038b50780ecc3d53b0b19e03ed8aabed4ae77271198d1ae3d49c3b110867edf679f5faad924820a8d1774144a87cb6f98fc
-  languageName: node
-  linkType: hard
-
-"cosmiconfig@npm:^7.0.0, cosmiconfig@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "cosmiconfig@npm:7.0.1"
-  dependencies:
-    "@types/parse-json": ^4.0.0
-    import-fresh: ^3.2.1
-    parse-json: ^5.0.0
-    path-type: ^4.0.0
-    yaml: ^1.10.0
-  checksum: 4be63e7117955fd88333d7460e4c466a90f556df6ef34efd59034d2463484e339666c41f02b523d574a797ec61f4a91918c5b89a316db2ea2f834e0d2d09465b
   languageName: node
   linkType: hard
 
@@ -11918,6 +11918,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect-more@npm:1.2.0":
+  version: 1.2.0
+  resolution: "expect-more@npm:1.2.0"
+  checksum: e98a1c17911ac8b6a71a35a5e4df6f0aadd7b81ba43f61eac711b4c688dd64dad557736cae0d9ae755401bc78d9af2c1cd5508a65e3b0aef9e851fa886583da2
+  languageName: node
+  linkType: hard
+
 "expect@npm:^27.4.6":
   version: 27.4.6
   resolution: "expect@npm:27.4.6"
@@ -12552,6 +12559,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fp-ts@npm:2.11.5":
+  version: 2.11.5
+  resolution: "fp-ts@npm:2.11.5"
+  checksum: 68a4884527abca782a2f664b13152cd797b92b6042538905af95fa0e9da2e884bc5b05bdfcfbb02fdabfe8536ae6a62a24159696545d8a263413e4c007326c4a
+  languageName: node
+  linkType: hard
+
 "fraction.js@npm:^4.1.2":
   version: 4.1.2
   resolution: "fraction.js@npm:4.1.2"
@@ -12585,6 +12599,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:10.0.0, fs-extra@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "fs-extra@npm:10.0.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 5285a3d8f34b917cf2b66af8c231a40c1623626e9d701a20051d3337be16c6d7cac94441c8b3732d47a92a2a027886ca93c69b6a4ae6aee3c89650d2a8880c0a
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:8.1.0, fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
@@ -12606,17 +12631,6 @@ __metadata:
     path-is-absolute: ^1.0.0
     rimraf: ^2.2.8
   checksum: 6edfd65fc813baa27f1603778c0f5ec11f8c5006a20b920437813ee2023eba18aeec8bef1c89b2e6c84f9fc90fdc7c916f4a700466c8c69d22a35d018f2570f0
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "fs-extra@npm:10.0.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^6.0.1
-    universalify: ^2.0.0
-  checksum: 5285a3d8f34b917cf2b66af8c231a40c1623626e9d701a20051d3337be16c6d7cac94441c8b3732d47a92a2a027886ca93c69b6a4ae6aee3c89650d2a8880c0a
   languageName: node
   linkType: hard
 
@@ -12991,7 +13005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:7.2.0, glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -13245,6 +13259,7 @@ __metadata:
     schema-utils: ^3.1.1
     simple-git-hooks: 2.7.0
     stylis: ^4.0.13
+    syncpack: 6.2.0
     tmp: 0.2.1
     ts-jest: 27.0.5
     tslib: ^2.1.0
@@ -20002,7 +20017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-yaml-file@npm:^2.0.0":
+"read-yaml-file@npm:2.1.0, read-yaml-file@npm:^2.0.0":
   version: 2.1.0
   resolution: "read-yaml-file@npm:2.1.0"
   dependencies:
@@ -21037,7 +21052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:7.3.5, semver@npm:7.x, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
@@ -22254,6 +22269,32 @@ __metadata:
   version: 2.0.15
   resolution: "synchronous-promise@npm:2.0.15"
   checksum: 6079a6acd37d02eb76f250dc7ce09009151744901b320a8cfbba056b015c3d7cbf4e7467458f2d27c6393634f68521b241ea9e35fd9640f8fb59342740550472
+  languageName: node
+  linkType: hard
+
+"syncpack@npm:6.2.0":
+  version: 6.2.0
+  resolution: "syncpack@npm:6.2.0"
+  dependencies:
+    chalk: 4.1.2
+    commander: 8.3.0
+    cosmiconfig: 7.0.1
+    expect-more: 1.2.0
+    fp-ts: 2.11.5
+    fs-extra: 10.0.0
+    glob: 7.2.0
+    minimatch: 3.0.4
+    read-yaml-file: 2.1.0
+    semver: 7.3.5
+  bin:
+    syncpack: dist/bin.js
+    syncpack-fix-mismatches: dist/bin-fix-mismatches/index.js
+    syncpack-format: dist/bin-format/index.js
+    syncpack-lint-semver-ranges: dist/bin-lint-semver-ranges/index.js
+    syncpack-list: dist/bin-list/index.js
+    syncpack-list-mismatches: dist/bin-list-mismatches/index.js
+    syncpack-set-semver-ranges: dist/bin-set-semver-ranges/index.js
+  checksum: 4ee3dd91b02d1874c5f73fbd690726c8e840b6ff4dedefeb00502aa8894902eb5e6079562b7e0cb57df8e7f0230a26372d1250eb4f1569aee0ee988e9457e51f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:
- adds dependencies for each package explicitly, this allows `beachball` (releasing tool) to properly populate & bump dependencies
- to ensure that all dependencies are declared I added `import/no-extraneous-dependencies`:
  ![image](https://user-images.githubusercontent.com/14183168/157224815-a9c6d1b1-7f68-406d-8462-9d4a031f775e.png)
- to ensure that dependencies are in sync I added `syncpack` check 