### PR TITLE
chore: fix script check-dependencies script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "nx affected:build",
     "change": "beachball change",
-    "check-dependencies": "syncpack list -pP",
+    "check-dependencies": "syncpack list-mismatches --prod --peer",
     "lint": "nx affected:lint",
     "start": "nx run @griffel/website:serve",
     "storybook": "nx run @griffel/react:storybook",


### PR DESCRIPTION
A follow up for #66.

- use correct command for checking
- use long flags to make it clearer