### PR TITLE
fix: introduce modern typings for TS >4

### DIFF
--- a/change/@griffel-style-types-88cd8fa1-371b-4c2e-bb29-0d88568c620d.json
+++ b/change/@griffel-style-types-88cd8fa1-371b-4c2e-bb29-0d88568c620d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: resolve recursive typings issue",
+  "packageName": "@griffel/style-types",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/e2e/typescript/src/assets/fixture.ts
+++ b/e2e/typescript/src/assets/fixture.ts
@@ -62,6 +62,13 @@ assertType({
   ':hover': { '--color': 'red' },
 });
 
+assertType({
+  ':hover': { content: "'foo'" },
+});
+assertType({
+  ':hover': { animationName: { from: {}, to: {} } },
+});
+
 // Custom selectors
 //
 
@@ -86,6 +93,9 @@ assertType({
 
 assertType({
   '.bar': { '--color': 'red' },
+});
+assertType({
+  '.bar': { animationName: { from: {}, to: {} } },
 });
 
 // Nested custom selectors
@@ -192,7 +202,6 @@ assertType({
   '@media screen and (max-width: 992px)': {
     ...typedMixin,
   },
-  // @ts-expect-error FIXME - this is supposed to pass!
   '@media(forced-colors: active)': {
     ...typedMixin,
     color: 'var(--customColor)',
@@ -201,6 +210,13 @@ assertType({
     ...typedMixin,
   },
   ':before': {
+    ...typedMixin,
+    color: 'var(--customColor)',
+  },
+  '& .foo': {
+    ...typedMixin,
+  },
+  '& .bar': {
     ...typedMixin,
     color: 'var(--customColor)',
   },
@@ -231,31 +247,32 @@ assertType({
 //
 
 assertType({
-  // @ts-expect-error "1" is invalid value for "overflowX"
   ':hover:focus': {
+    // @ts-expect-error "1" is invalid value for "overflowX"
     overflowX: '1',
   },
 });
 
 assertType({
-  // @ts-expect-error "padding" is banned
   ':hover:focus': {
+    // @ts-expect-error "padding" is banned
     padding: 0,
   },
 });
 
 assertType({
-  // @ts-expect-error "paddingLeft" cannot be numeric value
   ':hover:focus': {
+    // @ts-expect-error "5" is an invalid value for paddingLeft
     paddingLeft: 5,
   },
 });
 
 assertType({
-  // @ts-expect-error "1" is invalid value for "overflowX", padding is banned, paddingLeft cannot be a numeric value
   ':hover:focus': {
     overflowX: 'scroll',
+    // @ts-expect-error "padding" is banned
     padding: 0,
+    // @ts-expect-error "5" is an invalid value for paddingLeft
     paddingLeft: 5,
   },
 });
@@ -264,12 +281,14 @@ assertType({
   ':hover:focus': {
     // @ts-expect-error Object is not assignable to CSS property
     zIndex: { color: 'red' },
-    opacity: { color: 'red' }, // < no error here, TS only reports the first error in this case
+    // @ts-expect-error Object is not assignable to CSS property
+    opacity: { color: 'red' },
   },
   ':hover:active': {
     // @ts-expect-error Object is not assignable to CSS property
     opacity: { color: 'red' },
-    zIndex: { color: 'red' }, // < no error here, TS only reports the first error in this case
+    // @ts-expect-error Object is not assignable to CSS property
+    zIndex: { color: 'red' },
   },
 });
 
@@ -277,33 +296,37 @@ assertType({
 //
 
 assertType({
-  // @ts-expect-error "1" is invalid value for "overflowX", padding is banned, paddingLeft cannot be a numeric value
   '.foo': {
     '.baz': {
+      // @ts-expect-error outline-box is an invalid value for box-sizing
       overflowX: '1',
+      // @ts-expect-error "padding" is banned
       padding: 0,
+      // @ts-expect-error "5" is an invalid value for paddingLeft
       paddingLeft: 5,
     },
   },
 });
 assertType({
-  // @ts-expect-error outline-box is an invalid value for box-sizing
   '.foo': {
+    // @ts-expect-error outline-box is an invalid value for box-sizing
     boxSizing: 'outline-box',
 
     '.bar': {
-      boxSizing: 'outline-box', // < no error here, TS only reports the error for the whole object
+      // @ts-expect-error outline-box is an invalid value for box-sizing
+      boxSizing: 'outline-box',
     },
   },
 });
 assertType({
-  // @ts-expect-error outline-box is an invalid value for box-sizing
   '.foo': {
+    // @ts-expect-error outline-box is an invalid value for box-sizing
     boxSizing: 'outline-box',
     zIndex: 1,
 
     '.bar': {
-      boxSizing: 'outline-box', // < no error here, TS only reports the error for the whole object
+      // @ts-expect-error outline-box is an invalid value for box-sizing
+      boxSizing: 'outline-box',
       zIndex: 1,
     },
   },
@@ -312,11 +335,14 @@ assertType({
   '.foo': {
     // @ts-expect-error Object is not assignable to CSS property
     zIndex: { color: 'red' },
-    opacity: { color: 'red' }, // < no error here, TS only reports the first error in this case
+    // @ts-expect-error Object is not assignable to CSS property
+    opacity: { color: 'red' },
 
     '.bar': {
-      zIndex: { color: 'red' }, // < no error here, TS only reports the first error in this case
-      opacity: { color: 'red' }, // < no error here, TS only reports the first error in this case
+      // @ts-expect-error Object is not assignable to CSS property
+      zIndex: { color: 'red' },
+      // @ts-expect-error Object is not assignable to CSS property
+      opacity: { color: 'red' },
     },
   },
 });
@@ -342,8 +368,11 @@ assertType({
     2,
     '2px',
   ],
-  // @ts-expect-error "paddingLeft" cannot be numeric value
   ':hover:active': {
-    paddingLeft: ['2px', 2],
+    paddingLeft: [
+      '2px',
+      // @ts-expect-error "paddingLeft" cannot be numeric value
+      2,
+    ],
   },
 });

--- a/e2e/typescript/src/assets/legacy/fixture-reset.ts
+++ b/e2e/typescript/src/assets/legacy/fixture-reset.ts
@@ -65,13 +65,6 @@ assertType({
   ':hover': { '--color': 'red' },
 });
 
-assertType({
-  ':hover': { content: "'foo'" },
-});
-assertType({
-  ':hover': { animationName: { from: {}, to: {} } },
-});
-
 // Custom selectors
 //
 
@@ -97,9 +90,6 @@ assertType({
 
 assertType({
   '.bar': { '--color': 'red' },
-});
-assertType({
-  '.bar': { animationName: { from: {}, to: {} } },
 });
 
 // Nested custom selectors
@@ -199,24 +189,6 @@ assertType({
   '@media screen and (max-width: 992px)': {
     ...typedMixin,
   },
-  '@media(forced-colors: active)': {
-    ...typedMixin,
-    color: 'var(--customColor)',
-  },
-  ':after': {
-    ...typedMixin,
-  },
-  ':before': {
-    ...typedMixin,
-    color: 'var(--customColor)',
-  },
-  '& .foo': {
-    ...typedMixin,
-  },
-  '& .bar': {
-    ...typedMixin,
-    color: 'var(--customColor)',
-  },
 });
 
 // Strict selectors
@@ -242,25 +214,24 @@ assertType({
 //
 
 assertType({
+  // @ts-expect-error "1" is invalid value for "overflowX"
   ':hover:focus': {
-    // @ts-expect-error "1" is invalid value for "overflowX"
     overflowX: '1',
   },
 });
 
 assertType({
+  // @ts-expect-error "paddingLeft" cannot be numeric value
   ':hover:focus': {
-    // @ts-expect-error "paddingLeft" cannot be numeric value
     paddingLeft: 5,
   },
 });
 
 assertType({
+  // @ts-expect-error "1" is invalid value for "overflowX", padding is banned, paddingLeft cannot be a numeric value
   ':hover:focus': {
-    // @ts-expect-error "1" is invalid value for "overflowX"
-    overflowX: '1',
+    overflowX: 'scroll',
     padding: 0,
-    // @ts-expect-error paddingLeft cannot be a numeric value
     paddingLeft: 5,
   },
 });
@@ -269,14 +240,12 @@ assertType({
   ':hover:focus': {
     // @ts-expect-error Object is not assignable to CSS property
     zIndex: { color: 'red' },
-    // @ts-expect-error Object is not assignable to CSS property
-    opacity: { color: 'red' },
+    opacity: { color: 'red' }, // < no error here, TS only reports the first error in this case
   },
   ':hover:active': {
     // @ts-expect-error Object is not assignable to CSS property
     opacity: { color: 'red' },
-    // @ts-expect-error Object is not assignable to CSS property
-    zIndex: { color: 'red' },
+    zIndex: { color: 'red' }, // < no error here, TS only reports the first error in this case
   },
 });
 
@@ -284,36 +253,33 @@ assertType({
 //
 
 assertType({
+  // @ts-expect-error "1" is invalid value for "overflowX", padding is banned, paddingLeft cannot be a numeric value
   '.foo': {
     '.baz': {
-      // @ts-expect-error "1" is invalid value for "overflowX"
       overflowX: '1',
       padding: 0,
-      // @ts-expect-error paddingLeft cannot be a numeric value
       paddingLeft: 5,
     },
   },
 });
 assertType({
+  // @ts-expect-error outline-box is an invalid value for box-sizing
   '.foo': {
-    // @ts-expect-error outline-box is an invalid value for box-sizing
     boxSizing: 'outline-box',
 
     '.bar': {
-      // @ts-expect-error outline-box is an invalid value for box-sizing
       boxSizing: 'outline-box', // < no error here, TS only reports the error for the whole object
     },
   },
 });
 assertType({
+  // @ts-expect-error outline-box is an invalid value for box-sizing
   '.foo': {
-    // @ts-expect-error outline-box is an invalid value for box-sizing
     boxSizing: 'outline-box',
     zIndex: 1,
 
     '.bar': {
-      // @ts-expect-error outline-box is an invalid value for box-sizing
-      boxSizing: 'outline-box',
+      boxSizing: 'outline-box', // < no error here, TS only reports the error for the whole object
       zIndex: 1,
     },
   },
@@ -322,14 +288,11 @@ assertType({
   '.foo': {
     // @ts-expect-error Object is not assignable to CSS property
     zIndex: { color: 'red' },
-    // @ts-expect-error Object is not assignable to CSS property
-    opacity: { color: 'red' },
+    opacity: { color: 'red' }, // < no error here, TS only reports the first error in this case
 
     '.bar': {
-      // @ts-expect-error Object is not assignable to CSS property
-      zIndex: { color: 'red' },
-      // @ts-expect-error Object is not assignable to CSS property
-      opacity: { color: 'red' },
+      zIndex: { color: 'red' }, // < no error here, TS only reports the first error in this case
+      opacity: { color: 'red' }, // < no error here, TS only reports the first error in this case
     },
   },
 });
@@ -356,11 +319,8 @@ assertType({
     2,
     '2px',
   ],
+  // @ts-expect-error "paddingLeft" cannot be numeric value
   ':hover:active': {
-    paddingLeft: [
-      '2px',
-      // @ts-expect-error "paddingLeft" cannot be numeric value
-      2,
-    ],
+    paddingLeft: ['2px', 2],
   },
 });

--- a/e2e/typescript/src/assets/legacy/tsconfig.fixture.json
+++ b/e2e/typescript/src/assets/legacy/tsconfig.fixture.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2019", "dom"],
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/e2e/typescript/src/test.ts
+++ b/e2e/typescript/src/test.ts
@@ -2,17 +2,24 @@ import { configureYarn, copyAssets, createTempDir, installPackages, packLocalPac
 import * as logSymbols from 'log-symbols';
 import * as path from 'path';
 
-async function performTest(tsVersion: string) {
+async function performTest(tsVersion: string, options: { mode?: 'legacy' | 'modern' } = {}) {
   let tempDir: string;
   let tscBin: string;
 
+  const { mode = 'modern' } = options;
+
   try {
     const rootDir = path.resolve(__dirname, '..', '..', '..');
+    const assetsPath = path.resolve(__dirname, 'assets', mode === 'legacy' ? 'legacy' : '');
 
     tempDir = createTempDir('typescript');
 
+    if (mode === 'legacy') {
+      console.log(logSymbols.info, 'Using legacy mode...');
+    }
+
     await copyAssets({
-      assetsPath: path.resolve(__dirname, 'assets'),
+      assetsPath: assetsPath,
       tempDir,
       renames: { 'tsconfig.fixture.json': 'tsconfig.json' },
     });
@@ -43,7 +50,10 @@ async function performTest(tsVersion: string) {
   }
 
   try {
-    await sh(`node ${tscBin} --noEmit --pretty`, tempDir);
+    const command = `node ${tscBin} --noEmit --pretty`;
+
+    console.log(logSymbols.info, 'Running', command);
+    await sh(command, tempDir);
 
     console.log(logSymbols.success, `Example project was successfully built with typescript@${tsVersion}`);
     console.log('');
@@ -65,7 +75,7 @@ async function performTest(tsVersion: string) {
 }
 
 (async () => {
-  await performTest('3.9');
+  await performTest('3.9', { mode: 'legacy' });
   await performTest('4.1');
   await performTest('4.4');
   await performTest('4.9');

--- a/e2e/typescript/tsconfig.lib.json
+++ b/e2e/typescript/tsconfig.lib.json
@@ -4,5 +4,6 @@
     "outDir": "../../dist/out-tsc",
     "types": ["node", "environment"]
   },
-  "include": ["**/*.ts", "**/*.js"]
+  "include": ["**/*.ts", "**/*.js"],
+  "exclude": ["src/assets/legacy/*"]
 }

--- a/e2e/utils/src/createTempDir.ts
+++ b/e2e/utils/src/createTempDir.ts
@@ -3,7 +3,7 @@ import * as logSymbols from 'log-symbols';
 
 export function createTempDir(prefix: string) {
   // "Unsafe" means delete even if it still has files inside (our desired behavior)
-  const tempDir = tmp.dirSync({ prefix: 'nextjs', unsafeCleanup: true }).name;
+  const tempDir = tmp.dirSync({ prefix, unsafeCleanup: true }).name;
   console.log(logSymbols.success, `Temporary directory created under ${tempDir}`);
 
   return tempDir;

--- a/packages/style-types/package.json
+++ b/packages/style-types/package.json
@@ -10,5 +10,12 @@
   "sideEffects": false,
   "dependencies": {
     "csstype": "^3.1.2"
+  },
+  "typesVersions": {
+    "<4.1": {
+      "src/index.d.ts": [
+        "src/legacy/index.d.ts"
+      ]
+    }
   }
 }

--- a/packages/style-types/src/legacy/README.md
+++ b/packages/style-types/src/legacy/README.md
@@ -1,0 +1,1 @@
+This folder contains types for legacy version of TypeScript (TS <4).

--- a/packages/style-types/src/legacy/index.ts
+++ b/packages/style-types/src/legacy/index.ts
@@ -1,0 +1,6 @@
+export type { GriffelAnimation, GriffelStyle } from './makeStyles';
+export type { GriffelResetStyle } from './makeResetStyles';
+export type { GriffelStaticStyle, GriffelStaticStyles } from './makeStaticStyles';
+
+export type { GriffelStylesCSSValue, ValueOrArray } from '../shared';
+export type { GriffelStylesUnsupportedCSSProperties } from '../unsupported-properties';

--- a/packages/style-types/src/legacy/makeResetStyles.ts
+++ b/packages/style-types/src/legacy/makeResetStyles.ts
@@ -1,0 +1,51 @@
+import * as CSS from 'csstype';
+import type { GriffelStylesCSSValue, ValueOrArray } from '../shared';
+
+//
+// Types for makeResetStyles()
+// ---
+//
+
+type GriffelResetStylesCSSProperties = Omit<
+  CSS.PropertiesFallback<ValueOrArray<GriffelStylesCSSValue>>,
+  // We have custom definition for "animationName"
+  'animationName'
+>;
+
+type GriffelResetStylesStrictCSSObject = GriffelResetStylesCSSProperties &
+  GriffelResetStylesCSSPseudos & {
+    animationName?: GriffelResetAnimation | GriffelResetAnimation[] | CSS.Property.Animation;
+  };
+
+type GriffelResetStylesCSSPseudos = {
+  [Property in CSS.Pseudos]?:
+    | (GriffelResetStylesStrictCSSObject & { content?: string | string[] })
+    | (GriffelResetStylesCSSObjectCustomL1 & { content?: string | string[] });
+};
+
+//
+// "GriffelStylesCSSObjectCustom*" is a workaround to avoid circular references in types that are breaking TS <4.
+//
+
+type GriffelResetStylesCSSObjectCustomL1 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL2;
+} & GriffelResetStylesStrictCSSObject;
+
+type GriffelResetStylesCSSObjectCustomL2 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL3;
+} & GriffelResetStylesStrictCSSObject;
+
+type GriffelResetStylesCSSObjectCustomL3 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL4;
+} & GriffelResetStylesStrictCSSObject;
+
+type GriffelResetStylesCSSObjectCustomL4 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL5;
+} & GriffelResetStylesStrictCSSObject;
+
+type GriffelResetStylesCSSObjectCustomL5 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesStrictCSSObject;
+} & GriffelResetStylesStrictCSSObject;
+
+export type GriffelResetStyle = GriffelResetStylesStrictCSSObject | GriffelResetStylesCSSObjectCustomL1;
+export type GriffelResetAnimation = Record<'from' | 'to' | string, GriffelResetStyle>;

--- a/packages/style-types/src/legacy/makeStaticStyles.ts
+++ b/packages/style-types/src/legacy/makeStaticStyles.ts
@@ -1,0 +1,27 @@
+import * as CSS from 'csstype';
+
+//
+// Types for makeStaticStyles()
+// ---
+//
+
+export type GriffelStaticStyle = {
+  [key: string]: CSS.Properties &
+    // TODO Questionable: how else would users target their own children?
+    Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+} & {
+  '@font-face'?: {
+    fontFamily: string;
+    src: string;
+
+    fontFeatureSettings?: string;
+    fontStretch?: string;
+    fontStyle?: string;
+    fontVariant?: string;
+    fontVariationSettings?: string;
+    fontWeight?: number | string;
+
+    unicodeRange?: string;
+  };
+};
+export type GriffelStaticStyles = GriffelStaticStyle | string;

--- a/packages/style-types/src/legacy/makeStyles.ts
+++ b/packages/style-types/src/legacy/makeStyles.ts
@@ -1,0 +1,54 @@
+import * as CSS from 'csstype';
+
+import type { GriffelStylesCSSValue } from '../shared';
+import type { GriffelStylesUnsupportedCSSProperties } from '../unsupported-properties';
+
+//
+// Types for makeStyles()
+// ---
+//
+
+type GriffelStylesCSSProperties = Omit<
+  CSS.PropertiesFallback<GriffelStylesCSSValue>,
+  // We have custom definition for "animationName"
+  'animationName'
+> &
+  Partial<GriffelStylesUnsupportedCSSProperties>;
+
+export type GriffelStylesStrictCSSObject = GriffelStylesCSSProperties &
+  GriffelStylesCSSPseudos & {
+    animationName?: GriffelAnimation | GriffelAnimation[] | CSS.Property.Animation;
+  };
+
+type GriffelStylesCSSPseudos = {
+  [Property in CSS.Pseudos]?:
+    | (GriffelStylesStrictCSSObject & { content?: string | string[] })
+    | (GriffelStylesCSSObjectCustomL1 & { content?: string | string[] });
+};
+
+//
+// "GriffelStylesCSSObjectCustom*" is a workaround to avoid circular references in types that are breaking TS <4.
+//
+
+type GriffelStylesCSSObjectCustomL1 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL2;
+} & GriffelStylesStrictCSSObject;
+
+type GriffelStylesCSSObjectCustomL2 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL3;
+} & GriffelStylesStrictCSSObject;
+
+type GriffelStylesCSSObjectCustomL3 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL4;
+} & GriffelStylesStrictCSSObject;
+
+type GriffelStylesCSSObjectCustomL4 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL5;
+} & GriffelStylesStrictCSSObject;
+
+type GriffelStylesCSSObjectCustomL5 = {
+  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesStrictCSSObject;
+} & GriffelStylesStrictCSSObject;
+
+export type GriffelStyle = GriffelStylesStrictCSSObject | GriffelStylesCSSObjectCustomL1;
+export type GriffelAnimation = Record<'from' | 'to' | string, GriffelStylesCSSObjectCustomL1>;

--- a/packages/style-types/src/makeResetStyles.ts
+++ b/packages/style-types/src/makeResetStyles.ts
@@ -1,5 +1,5 @@
 import * as CSS from 'csstype';
-import type { GriffelStylesCSSValue, ValueOrArray } from './shared';
+import type { GriffelStylesCSSValue } from './shared';
 
 //
 // Types for makeResetStyles()
@@ -7,45 +7,21 @@ import type { GriffelStylesCSSValue, ValueOrArray } from './shared';
 //
 
 type GriffelResetStylesCSSProperties = Omit<
-  CSS.PropertiesFallback<ValueOrArray<GriffelStylesCSSValue>>,
+  CSS.PropertiesFallback<GriffelStylesCSSValue>,
   // We have custom definition for "animationName"
   'animationName'
 >;
 
-type GriffelResetStylesStrictCSSObject = GriffelResetStylesCSSProperties &
-  GriffelResetStylesCSSPseudos & {
-    animationName?: GriffelResetAnimation | GriffelResetAnimation[] | CSS.Property.Animation;
-  };
+export type GriffelResetStylesStrictCSSObject = GriffelResetStylesCSSProperties &
+  GriffelCSSPseudos & { animationName?: GriffelResetAnimation | GriffelResetAnimation[] | string };
 
-type GriffelResetStylesCSSPseudos = {
-  [Property in CSS.Pseudos]?:
-    | (GriffelResetStylesStrictCSSObject & { content?: string | string[] })
-    | (GriffelResetStylesCSSObjectCustomL1 & { content?: string | string[] });
+type GriffelCSSObjectCustom = {
+  [Property: string]: GriffelResetStyle | GriffelStylesCSSValue;
+} & GriffelResetStylesStrictCSSObject;
+
+type GriffelCSSPseudos = {
+  [Property in CSS.Pseudos]?: GriffelResetStylesStrictCSSObject | GriffelCSSObjectCustom;
 };
 
-//
-// "GriffelStylesCSSObjectCustom*" is a workaround to avoid circular references in types that are breaking TS <4.
-//
-
-type GriffelResetStylesCSSObjectCustomL1 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL2;
-} & GriffelResetStylesStrictCSSObject;
-
-type GriffelResetStylesCSSObjectCustomL2 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL3;
-} & GriffelResetStylesStrictCSSObject;
-
-type GriffelResetStylesCSSObjectCustomL3 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL4;
-} & GriffelResetStylesStrictCSSObject;
-
-type GriffelResetStylesCSSObjectCustomL4 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesCSSObjectCustomL5;
-} & GriffelResetStylesStrictCSSObject;
-
-type GriffelResetStylesCSSObjectCustomL5 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelResetStylesStrictCSSObject;
-} & GriffelResetStylesStrictCSSObject;
-
-export type GriffelResetStyle = GriffelResetStylesStrictCSSObject | GriffelResetStylesCSSObjectCustomL1;
-export type GriffelResetAnimation = Record<'from' | 'to' | string, GriffelResetStyle>;
+export type GriffelResetAnimation = Record<'from' | 'to' | string, GriffelCSSObjectCustom>;
+export type GriffelResetStyle = GriffelResetStylesStrictCSSObject | GriffelCSSObjectCustom;

--- a/packages/style-types/src/makeStyles.ts
+++ b/packages/style-types/src/makeStyles.ts
@@ -12,43 +12,17 @@ type GriffelStylesCSSProperties = Omit<
   CSS.PropertiesFallback<GriffelStylesCSSValue>,
   // We have custom definition for "animationName"
   'animationName'
-> &
-  Partial<GriffelStylesUnsupportedCSSProperties>;
+> & { animationName?: GriffelAnimation | GriffelAnimation[] | string } & Partial<GriffelStylesUnsupportedCSSProperties>;
 
-export type GriffelStylesStrictCSSObject = GriffelStylesCSSProperties &
-  GriffelStylesCSSPseudos & {
-    animationName?: GriffelAnimation | GriffelAnimation[] | CSS.Property.Animation;
-  };
+export type GriffelStylesStrictCSSObject = GriffelStylesCSSProperties & GriffelCSSPseudos;
 
-type GriffelStylesCSSPseudos = {
-  [Property in CSS.Pseudos]?:
-    | (GriffelStylesStrictCSSObject & { content?: string | string[] })
-    | (GriffelStylesCSSObjectCustomL1 & { content?: string | string[] });
+type GriffelCSSObjectCustom = {
+  [Property: string]: GriffelStyle | GriffelStylesCSSValue;
+} & GriffelStylesStrictCSSObject;
+
+type GriffelCSSPseudos = {
+  [Property in CSS.Pseudos]?: GriffelStylesStrictCSSObject | GriffelCSSObjectCustom;
 };
 
-//
-// "GriffelStylesCSSObjectCustom*" is a workaround to avoid circular references in types that are breaking TS <4.
-//
-
-type GriffelStylesCSSObjectCustomL1 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL2;
-} & GriffelStylesStrictCSSObject;
-
-type GriffelStylesCSSObjectCustomL2 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL3;
-} & GriffelStylesStrictCSSObject;
-
-type GriffelStylesCSSObjectCustomL3 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL4;
-} & GriffelStylesStrictCSSObject;
-
-type GriffelStylesCSSObjectCustomL4 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesCSSObjectCustomL5;
-} & GriffelStylesStrictCSSObject;
-
-type GriffelStylesCSSObjectCustomL5 = {
-  [Property: string]: string | number | (string | number)[] | undefined | GriffelStylesStrictCSSObject;
-} & GriffelStylesStrictCSSObject;
-
-export type GriffelStyle = GriffelStylesStrictCSSObject | GriffelStylesCSSObjectCustomL1;
-export type GriffelAnimation = Record<'from' | 'to' | string, GriffelStylesCSSObjectCustomL1>;
+export type GriffelAnimation = Record<'from' | 'to' | string, GriffelCSSObjectCustom>;
+export type GriffelStyle = GriffelStylesStrictCSSObject | GriffelCSSObjectCustom;


### PR DESCRIPTION
Fixes #378.

This PR introduces modern typings for TypeScript 4.1 and higher as this version supports recursive types references. This allow to simplify typings and remove weird workarounds. Also newer typings make TS errors more precise (check changes in the fixtures) 👍 

To keep compatibility with older versions of TS older typings are kept as legacy. To resolve them `typesVersions` field is used.