### PR TITLE
chore: improve React 18 support

### DIFF
--- a/change/@griffel-react-13bf5fac-a88b-41ad-98fc-a8df3be96e6d.json
+++ b/change/@griffel-react-13bf5fac-a88b-41ad-98fc-a8df3be96e6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: improve React 18 support by using useInsertionEffect",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/RendererContext.tsx
+++ b/packages/react/src/RendererContext.tsx
@@ -1,6 +1,8 @@
 import { createDOMRenderer, rehydrateRendererCache } from '@griffel/core';
-import * as React from 'react';
 import type { GriffelRenderer } from '@griffel/core';
+import * as React from 'react';
+
+import { canUseDOM } from './utils/canUseDOM';
 
 export interface RendererProviderProps {
   /** An instance of Griffel renderer. */
@@ -15,13 +17,6 @@ export interface RendererProviderProps {
    * Content wrapped by the RendererProvider
    */
   children: React.ReactNode;
-}
-
-/**
- * Verifies if an application can use DOM.
- */
-function canUseDOM(): boolean {
-  return typeof window !== 'undefined' && !!(window.document && window.document.createElement);
 }
 
 /**

--- a/packages/react/src/__resetStyles.ts
+++ b/packages/react/src/__resetStyles.ts
@@ -1,6 +1,7 @@
 import { __resetStyles as vanillaResetStyles } from '@griffel/core';
 import type { CSSRulesByBucket } from '@griffel/core';
 
+import { insertionFactory } from './insertionFactory';
 import { useRenderer } from './RendererContext';
 import { useTextDirection } from './TextDirectionContext';
 
@@ -15,7 +16,7 @@ export function __resetStyles(
   rtlClassName: string | null,
   cssRules: CSSRulesByBucket | string[],
 ) {
-  const getStyles = vanillaResetStyles(ltrClassName, rtlClassName, cssRules);
+  const getStyles = vanillaResetStyles(ltrClassName, rtlClassName, cssRules, insertionFactory);
 
   return function useClasses(): string {
     const dir = useTextDirection();

--- a/packages/react/src/__styles.ts
+++ b/packages/react/src/__styles.ts
@@ -1,6 +1,7 @@
 import { __styles as vanillaStyles } from '@griffel/core';
 import type { CSSClassesMapBySlot, CSSRulesByBucket } from '@griffel/core';
 
+import { insertionFactory } from './insertionFactory';
 import { useRenderer } from './RendererContext';
 import { useTextDirection } from './TextDirectionContext';
 
@@ -14,7 +15,7 @@ export function __styles<Slots extends string>(
   classesMapBySlot: CSSClassesMapBySlot<Slots>,
   cssRules: CSSRulesByBucket,
 ) {
-  const getStyles = vanillaStyles(classesMapBySlot, cssRules);
+  const getStyles = vanillaStyles(classesMapBySlot, cssRules, insertionFactory);
 
   return function useClasses(): Record<Slots, string> {
     const dir = useTextDirection();

--- a/packages/react/src/insertionFactory-node.test.ts
+++ b/packages/react/src/insertionFactory-node.test.ts
@@ -1,0 +1,24 @@
+/*
+ * @jest-environment node
+ */
+
+// 👆 this is intentionally to test in SSR like environment
+
+import type { GriffelRenderer } from '@griffel/core';
+import * as React from 'react';
+
+import { insertionFactory } from './insertionFactory';
+
+describe('insertionFactory (node)', () => {
+  it('does not use insertionEffect', () => {
+    const useInsertionEffect = jest.spyOn(React, 'useInsertionEffect');
+
+    const renderer: Partial<GriffelRenderer> = { id: 'a', insertCSSRules: jest.fn() };
+    const insertStyles = insertionFactory();
+
+    insertStyles(renderer as GriffelRenderer, { d: ['a'] });
+
+    expect(useInsertionEffect).not.toHaveBeenCalled();
+    expect(renderer.insertCSSRules).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/insertionFactory.test.ts
+++ b/packages/react/src/insertionFactory.test.ts
@@ -1,0 +1,27 @@
+import type { GriffelRenderer } from '@griffel/core';
+
+import { insertionFactory } from './insertionFactory';
+import { useInsertionEffect as _useInsertionEffect } from './useInsertionEffect';
+import * as React from 'react';
+
+jest.mock('./useInsertionEffect', () => ({
+  useInsertionEffect: jest.fn().mockImplementation(fn => fn()),
+}));
+
+const useInsertionEffect = _useInsertionEffect as jest.MockedFunction<typeof React.useInsertionEffect>;
+
+describe('canUseDOM', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses "useInsertionEffect" when available', () => {
+    const renderer: Partial<GriffelRenderer> = { insertCSSRules: jest.fn() };
+    const insertStyles = insertionFactory();
+
+    insertStyles(renderer as GriffelRenderer, { d: ['a'] });
+
+    expect(useInsertionEffect).toHaveBeenCalledTimes(1);
+    expect(renderer.insertCSSRules).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/insertionFactory.ts
+++ b/packages/react/src/insertionFactory.ts
@@ -7,16 +7,14 @@ export const insertionFactory: GriffelInsertionFactory = () => {
   const insertionCache: Record<string, boolean> = {};
 
   return function insert(renderer: GriffelRenderer, cssRules: CSSRulesByBucket) {
-    if (useInsertionEffect) {
-      // Even if `useInsertionEffect` is available, we can't use it in SSR as it will not be executed
-      if (canUseDOM()) {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        useInsertionEffect(() => {
-          renderer.insertCSSRules(cssRules!);
-        }, [renderer, cssRules]);
+    // Even if `useInsertionEffect` is available, we can use it on a client only as it will not be executed in SSR
+    if (useInsertionEffect && canUseDOM()) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useInsertionEffect(() => {
+        renderer.insertCSSRules(cssRules!);
+      }, [renderer, cssRules]);
 
-        return;
-      }
+      return;
     }
 
     if (insertionCache[renderer.id] === undefined) {

--- a/packages/react/src/insertionFactory.ts
+++ b/packages/react/src/insertionFactory.ts
@@ -1,0 +1,27 @@
+import type { CSSRulesByBucket, GriffelInsertionFactory, GriffelRenderer } from '@griffel/core';
+
+import { canUseDOM } from './utils/canUseDOM';
+import { useInsertionEffect } from './useInsertionEffect';
+
+export const insertionFactory: GriffelInsertionFactory = () => {
+  const insertionCache: Record<string, boolean> = {};
+
+  return function insert(renderer: GriffelRenderer, cssRules: CSSRulesByBucket) {
+    if (useInsertionEffect) {
+      // Even if `useInsertionEffect` is available, we can't use it in SSR as it will not be executed
+      if (canUseDOM()) {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useInsertionEffect(() => {
+          renderer.insertCSSRules(cssRules!);
+        }, [renderer, cssRules]);
+
+        return;
+      }
+    }
+
+    if (insertionCache[renderer.id] === undefined) {
+      renderer.insertCSSRules(cssRules!);
+      insertionCache[renderer.id] = true;
+    }
+  };
+};

--- a/packages/react/src/makeResetStyles.ts
+++ b/packages/react/src/makeResetStyles.ts
@@ -1,12 +1,13 @@
 import { makeResetStyles as vanillaMakeResetStyles } from '@griffel/core';
 import type { GriffelResetStyle } from '@griffel/core';
 
-import { isInsideComponent } from './utils/isInsideComponent';
+import { insertionFactory } from './insertionFactory';
 import { useRenderer } from './RendererContext';
 import { useTextDirection } from './TextDirectionContext';
+import { isInsideComponent } from './utils/isInsideComponent';
 
 export function makeResetStyles(styles: GriffelResetStyle) {
-  const getStyles = vanillaMakeResetStyles(styles);
+  const getStyles = vanillaMakeResetStyles(styles, insertionFactory);
 
   if (process.env.NODE_ENV !== 'production') {
     if (isInsideComponent()) {

--- a/packages/react/src/makeStaticStyles.ts
+++ b/packages/react/src/makeStaticStyles.ts
@@ -1,10 +1,11 @@
 import { makeStaticStyles as vanillaMakeStaticStyles } from '@griffel/core';
-
-import { useRenderer } from './RendererContext';
 import type { GriffelStaticStyles, MakeStaticStylesOptions } from '@griffel/core';
 
+import { insertionFactory } from './insertionFactory';
+import { useRenderer } from './RendererContext';
+
 export function makeStaticStyles(styles: GriffelStaticStyles | GriffelStaticStyles[]) {
-  const getStyles = vanillaMakeStaticStyles(styles);
+  const getStyles = vanillaMakeStaticStyles(styles, insertionFactory);
 
   if (process.env.NODE_ENV === 'test') {
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/react/src/makeStyles.ts
+++ b/packages/react/src/makeStyles.ts
@@ -1,12 +1,13 @@
 import { makeStyles as vanillaMakeStyles } from '@griffel/core';
 import type { GriffelStyle } from '@griffel/core';
 
-import { isInsideComponent } from './utils/isInsideComponent';
+import { insertionFactory } from './insertionFactory';
 import { useRenderer } from './RendererContext';
 import { useTextDirection } from './TextDirectionContext';
+import { isInsideComponent } from './utils/isInsideComponent';
 
 export function makeStyles<Slots extends string | number>(stylesBySlots: Record<Slots, GriffelStyle>) {
-  const getStyles = vanillaMakeStyles(stylesBySlots);
+  const getStyles = vanillaMakeStyles(stylesBySlots, insertionFactory);
 
   if (process.env.NODE_ENV !== 'production') {
     if (isInsideComponent()) {

--- a/packages/react/src/useInsertionEffect.ts
+++ b/packages/react/src/useInsertionEffect.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export const useInsertionEffect: typeof React.useInsertionEffect | undefined =
+  // @ts-expect-error Hack to make sure that `useInsertionEffect` will not cause bundling issues in older React versions
+  // eslint-disable-next-line no-useless-concat
+  React['useInsertion' + 'Effect'] ? React['useInsertion' + 'Effect'] : undefined;

--- a/packages/react/src/utils/canUseDOM-node.test.ts
+++ b/packages/react/src/utils/canUseDOM-node.test.ts
@@ -1,0 +1,13 @@
+/*
+ * @jest-environment node
+ */
+
+// 👆 this is intentionally to test in SSR like environment
+
+import { canUseDOM } from './canUseDOM';
+
+describe('canUseDOM (node)', () => {
+  it('returns "false"', () => {
+    expect(canUseDOM()).toBe(false);
+  });
+});

--- a/packages/react/src/utils/canUseDOM.test.tsx
+++ b/packages/react/src/utils/canUseDOM.test.tsx
@@ -1,0 +1,7 @@
+import { canUseDOM } from './canUseDOM';
+
+describe('canUseDOM', () => {
+  it('returns "true"', () => {
+    expect(canUseDOM()).toBe(true);
+  });
+});

--- a/packages/react/src/utils/canUseDOM.ts
+++ b/packages/react/src/utils/canUseDOM.ts
@@ -1,0 +1,6 @@
+/**
+ * Verifies if an application can use DOM.
+ */
+export function canUseDOM(): boolean {
+  return typeof window !== 'undefined' && !!(window.document && window.document.createElement);
+}


### PR DESCRIPTION
Fixes #40.

This PR improves compatibility of `@griffel/react` by using a custom insertion factory that uses [`useInsertionEffect`](https://react.dev/reference/react/useInsertionEffect) when it's available. 