### PR TITLE
docs: show real inserted styles should be used in playground

### DIFF
--- a/apps/website/src/components/Playground/code/app.js
+++ b/apps/website/src/components/Playground/code/app.js
@@ -11,18 +11,32 @@ export default function App() {
   const ref = React.useRef(null);
 
   React.useEffect(() => {
+    const styleTag = document.createElement('style');
+    document.head.append(styleTag);
+
     /** @type import('@griffel/core').GriffelRenderer */
     const playgroundRenderer = {
       id: 'playground',
       insertCSSRules(cssRules) {
-        const raw = Object.values(cssRules)
-          .reduce(
-            (acc, bucketRules) =>
-              acc.concat(bucketRules.map(cssRule => (Array.isArray(cssRule) ? cssRule[0] : cssRule))),
-            [],
-          )
-          .join('\n');
+        Object.values(cssRules)
+          .flatMap(rules => rules)
+          .forEach(cssRuleWithMeta => {
+            const cssRule = Array.isArray(cssRuleWithMeta) ? cssRuleWithMeta[0] : cssRuleWithMeta;
 
+            styleTag.sheet?.insertRule(cssRule);
+          });
+
+        if (!styleTag.sheet) {
+          return;
+        }
+
+        const raw = [
+          ...new Set(
+            Array.from(styleTag.sheet.cssRules)
+              .reverse()
+              .map(cssRule => cssRule.cssText),
+          ),
+        ].join('\n');
         const prettified = beautify.css_beautify(raw, { indent_size: 2 });
         setRules(prettified);
       },
@@ -35,6 +49,10 @@ export default function App() {
       dir: 'ltr',
       renderer: playgroundRenderer,
     });
+
+    return () => {
+      styleTag.remove();
+    };
   }, []);
 
   React.useEffect(() => {

--- a/apps/website/src/components/Playground/code/styles.js
+++ b/apps/website/src/components/Playground/code/styles.js
@@ -4,7 +4,7 @@ export default makeStyles({
   root: {
     backgroundColor: 'red',
     paddingLeft: '10px',
-    '@media(forced-colors: active):': {
+    '@media(forced-colors: active)': {
       ...shorthands.borderColor('transparent'),
     },
   },

--- a/apps/website/src/components/Playground/code/templates/selectors.js
+++ b/apps/website/src/components/Playground/code/templates/selectors.js
@@ -9,19 +9,19 @@ export default makeStyles({
 
   attribute: {
     '&[data-attribute]': {
-      color: 'red',
+      color: 'magenta',
     },
   },
 
   class: {
-    '&. child-class': {
-      color: 'red',
+    '&.my-class': {
+      color: 'olive',
     },
   },
 
   childClass: {
-    '&.my-class': {
-      color: 'red',
+    '& .my-class': {
+      color: 'pink',
     },
   },
 });

--- a/apps/website/src/components/Playground/index.tsx
+++ b/apps/website/src/components/Playground/index.tsx
@@ -31,7 +31,11 @@ export default function Playground() {
     <SandpackProvider
       template="react"
       customSetup={{
-        dependencies: { '@griffel/core': 'latest', 'highlight.js': 'latest', 'js-beautify': 'latest' },
+        dependencies: {
+          '@griffel/core': 'latest',
+          'highlight.js': 'latest',
+          'js-beautify': 'latest',
+        },
         files: {
           '/App.js': {
             // "AppCode" is a string as it's processed by "raw-loader", see "webpackLoader.js"

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -6,6 +6,7 @@
     "checkJs": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
+    "lib": ["es2019", "dom", "DOM.Iterable"],
     "outDir": "../../dist/out-tsc",
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
Modifies the playground so that it inserts all the css rules into a style tag, and then outputs the real styles.

Obviously validation would be great, but a bit more complicated since [`stylis`](https://github.com/thysultan/stylis) already strips most invalid css styles. I'll try to tackle this in another PR. My idea would be to use this maybe [w3c-css-validator](https://www.npmjs.com/package/w3c-css-validator)

Currently, invalid CSS is just inserted as an empty rule, it's some validation but should be improved.