### PR TITLE
feat: add CSS extraction

### DIFF
--- a/change/@griffel-core-136e2d80-22ac-475b-b95d-7608a762fa81.json
+++ b/change/@griffel-core-136e2d80-22ac-475b-b95d-7608a762fa81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: export getStyleBucketName function",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-core-136e2d80-22ac-475b-b95d-7608a762fa81.json
+++ b/change/@griffel-core-136e2d80-22ac-475b-b95d-7608a762fa81.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: export getStyleBucketName function",
+  "comment": "chore: export getStyleBucketName & normalizeCSSBucketEntry functions for internal usage",
   "packageName": "@griffel/core",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,6 @@ export const shorthands = {
 
 export { createDOMRenderer } from './renderer/createDOMRenderer';
 export type { CreateDOMRendererOptions } from './renderer/createDOMRenderer';
-export { styleBucketOrdering } from './renderer/getStyleSheetForBucket';
 export { rehydrateRendererCache } from './renderer/rehydrateRendererCache';
 
 export { mergeClasses } from './mergeClasses';
@@ -48,8 +47,11 @@ export { makeStaticStyles } from './makeStaticStyles';
 export { makeStyles } from './makeStyles';
 export { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
 
-// Private exports, are used by build time transforms
+// Private exports, are used by build time transforms or other tools
 export { __css } from './__css';
+export { styleBucketOrdering } from './renderer/getStyleSheetForBucket';
+export { defaultCompareMediaQueries } from './renderer/createDOMRenderer';
+export { getStyleBucketName } from './runtime/getStyleBucketName';
 export { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
 export { resolveStyleRules } from './runtime/resolveStyleRules';
 export { __styles } from './__styles';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
 
 // Private exports, are used by build time transforms or other tools
 export { __css } from './__css';
+export { normalizeCSSBucketEntry } from './runtime/utils/normalizeCSSBucketEntry';
 export { styleBucketOrdering } from './renderer/getStyleSheetForBucket';
 export { defaultCompareMediaQueries } from './renderer/createDOMRenderer';
 export { getStyleBucketName } from './runtime/getStyleBucketName';

--- a/packages/core/src/renderer/createDOMRenderer.ts
+++ b/packages/core/src/renderer/createDOMRenderer.ts
@@ -31,7 +31,8 @@ export interface CreateDOMRendererOptions {
   compareMediaQueries?: (a: string, b: string) => number;
 }
 
-const defaultCompareMediaQueries = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+/** @internal */
+export const defaultCompareMediaQueries = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
 
 /**
  * Creates a new instances of a renderer.

--- a/packages/core/src/renderer/getStyleSheetForBucket.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.ts
@@ -5,7 +5,7 @@ import { createIsomorphicStyleSheet } from './createIsomorphicStyleSheet';
 /**
  * Ordered style buckets using their short pseudo name.
  *
- * @private
+ * @internal
  */
 export const styleBucketOrdering: StyleBucketName[] = [
   // catch-all

--- a/packages/core/src/runtime/getStyleBucketName.ts
+++ b/packages/core/src/runtime/getStyleBucketName.ts
@@ -39,6 +39,8 @@ const pseudosMap: Record<string, StyleBucketName | undefined> = {
  * "h"
  * "f"
  * ```
+ *
+ * @internal
  */
 export function getStyleBucketName(pseudo: string, layer: string, media: string, support: string): StyleBucketName {
   if (media) {

--- a/packages/core/src/runtime/reduceToClassNameForSlots.ts
+++ b/packages/core/src/runtime/reduceToClassNameForSlots.ts
@@ -32,7 +32,7 @@ export function reduceToClassName(classMap: CSSClassesMap, dir: 'ltr' | 'rtl'): 
  * Reduces classname maps for slots to classname strings. Registers them in a definition cache to be used by
  * `mergeClasses()`.
  *
- * @private
+ * @internal
  */
 export function reduceToClassNameForSlots<Slots extends string | number>(
   classesMapBySlot: CSSClassesMapBySlot<Slots>,

--- a/packages/core/src/runtime/utils/normalizeCSSBucketEntry.ts
+++ b/packages/core/src/runtime/utils/normalizeCSSBucketEntry.ts
@@ -1,6 +1,8 @@
 import { CSSBucketEntry } from '../../types';
 
 /**
+ * @internal
+ *
  * @param entry - CSS bucket entry that can be either a string or an array
  * @returns An array where the first element is the CSS rule
  */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -138,7 +138,7 @@ export type CSSClasses = /* ltrClassName */ string | [/* ltrClassName */ string,
 export type CSSClassesMap = Record<PropertyHash, CSSClasses>;
 export type CSSClassesMapBySlot<Slots extends string | number> = Record<Slots, CSSClassesMap>;
 
-export interface CSSRulesByBucket {
+export type CSSRulesByBucket = {
   // default
   d?: CSSBucketEntry[];
   // link
@@ -161,7 +161,7 @@ export interface CSSRulesByBucket {
   t?: CSSBucketEntry[];
   // @media rules
   m?: CSSBucketEntry[];
-}
+};
 
 export type CSSBucketEntry = string | [string, Record<string, unknown>];
 

--- a/packages/webpack-extraction-plugin/.eslintrc.json
+++ b/packages/webpack-extraction-plugin/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*", "__fixtures__/*/output.ts"],
+  "ignorePatterns": ["!**/*", "__fixtures__/**/*/output.ts"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.css
@@ -1,0 +1,6 @@
+.fe3e8s9 {
+  color: red;
+}
+.fcnqdeg {
+  background-color: green;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/code.ts
@@ -1,0 +1,27 @@
+import { __styles } from '@griffel/react';
+
+const styles1 = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}', '.fcnqdeg{background-color:green;}'],
+  },
+);
+
+const styles2 = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}', '.fcnqdeg{background-color:green;}'],
+  },
+);
+
+console.log(styles1, styles2);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/output.css
@@ -1,0 +1,6 @@
+.fe3e8s9 {
+  color: red;
+}
+.fcnqdeg {
+  background-color: green;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
@@ -13,7 +13,14 @@ const styles = __styles(
     h: ['.color-yellow:hover { color: yellow; }'],
     a: ['.color-black:active { color: black; }'],
     k: ['@keyframes foo { from{ transform:rotate(0deg); } to { transform:rotate(360deg); } }'],
-    t: ['@media (forced-colors: active) { .color-magenta { color:magenta; } }'],
+    m: [
+      [
+        '@media (forced-colors: active) { .color-magenta { color: magenta; } }',
+        {
+          m: '(forced-colors: active)',
+        },
+      ],
+    ],
   },
 );
 

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
@@ -1,0 +1,20 @@
+import { __styles } from '@griffel/react';
+
+const styles = __styles(
+  {},
+  // Classes in this test are intentionally not realistic to simplify snapshots
+  {
+    d: ['.color-red { color: red; }', '.animation-name { animation-name: foo; }'],
+    l: ['.color-orange:link { color: orange; }'],
+    v: ['.color-purple:visited { color: purple; }'],
+    w: ['.color-pink:focus-within { color: pink; }'],
+    f: ['.color-blue:focus { color: blue; }'],
+    i: ['.color-light-blue:focus-visible { color: salmon; }'],
+    h: ['.color-yellow:hover { color: yellow; }'],
+    a: ['.color-black:active { color: black; }'],
+    k: ['@keyframes foo { from{ transform:rotate(0deg); } to { transform:rotate(360deg); } }'],
+    t: ['@media (forced-colors: active) { .color-magenta { color:magenta; } }'],
+  },
+);
+
+console.log(styles);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/output.css
@@ -1,0 +1,40 @@
+.color-red {
+  color: red;
+}
+.animation-name {
+  animation-name: foo;
+}
+.color-orange:link {
+  color: orange;
+}
+.color-purple:visited {
+  color: purple;
+}
+.color-pink:focus-within {
+  color: pink;
+}
+.color-blue:focus {
+  color: blue;
+}
+.color-light-blue:focus-visible {
+  color: salmon;
+}
+.color-yellow:hover {
+  color: yellow;
+}
+.color-black:active {
+  color: black;
+}
+@keyframes foo {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (forced-colors: active) {
+  .color-magenta {
+    color: magenta;
+  }
+}

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -13,6 +13,7 @@
     "@babel/helper-plugin-utils": "^7.12.13",
     "loader-utils": "^2.0.0",
     "schema-utils": "^3.1.1",
+    "stylis": "^4.0.13",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -196,4 +196,13 @@ function testFixture(fixtureName: string, options: CompileOptions = {}) {
 describe('webpackLoader', () => {
   // Basic assertions
   testFixture('basic-rules');
+
+  // Multiple calls of __styles
+  testFixture('multiple');
+
+  // Deduplicate rules in stylesheet
+  testFixture('rules-deduplication');
+
+  // Sorting rules by buckets
+  testFixture('style-buckets');
 });

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
@@ -1,6 +1,6 @@
 import { NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
-import type { CSSRulesByBucket } from '@griffel/core';
+import { CSSRulesByBucket, normalizeCSSBucketEntry } from '@griffel/core';
 
 type StripRuntimeBabelPluginOptions = never;
 
@@ -93,7 +93,13 @@ export const babelPluginStripGriffelRuntime = declare<
 
               const cssRulesByBucket = evaluationResult.value as CSSRulesByBucket;
 
-              Object.values(cssRulesByBucket).forEach(cssRules => {
+              Object.values(cssRulesByBucket).forEach(cssBucketEntries => {
+                const cssRules = cssBucketEntries.map(cssBucketEntry => {
+                  const [cssRule] = normalizeCSSBucketEntry(cssBucketEntry);
+
+                  return cssRule;
+                });
+
                 state.cssRules!.push(...cssRules);
               });
 

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -1,0 +1,138 @@
+import { GriffelRenderer } from '@griffel/core';
+import * as prettier from 'prettier';
+import { compile } from 'stylis';
+
+import { getElementReference, getElementMetadata, sortCSSRules } from './sortCSSRules';
+
+export const cssSerializer: jest.SnapshotSerializerPlugin = {
+  test(value) {
+    return typeof value === 'string';
+  },
+  print(value) {
+    /**
+     * test function makes sure that value is the guarded type
+     */
+    const _value = value as string;
+
+    return prettier.format(_value, { parser: 'css' }).trim();
+  },
+};
+
+expect.addSnapshotSerializer(cssSerializer);
+
+describe('getElementReference', () => {
+  it.each`
+    css                                                                                       | reference
+    ${'.foo { color: red; }'}                                                                 | ${'.foo'}
+    ${'.foo:hover { color: red; }'}                                                           | ${'.foo:hover'}
+    ${'@media (max-width: 2px) { .foo { color: blue; } }'}                                    | ${'.foo@media (max-width: 2px)'}
+    ${'@keyframes foo { from { transform:rotate(0deg); } to { transform:rotate(360deg); } }'} | ${'@keyframes foo'}
+  `('returns "$reference" for "$css"', ({ css, reference }: { css: string; reference: string }) => {
+    const element = compile(css)[0];
+
+    expect(getElementReference(element)).toBe(reference);
+  });
+});
+
+describe('getMetadata', () => {
+  it.each`
+    css                                                    | metadata
+    ${'.foo { color: red; }'}                              | ${''}
+    ${'.foo:hover { color: red; }'}                        | ${''}
+    ${'@media (max-width: 2px) { .foo { color: blue; } }'} | ${'(max-width: 2px)'}
+  `('returns "$reference" for "$css"', ({ css, metadata }: { css: string; metadata: string }) => {
+    const element = compile(css)[0];
+
+    expect(getElementMetadata(element)).toBe(metadata);
+  });
+});
+
+describe('sortCSSRules', () => {
+  it('removes duplicate rules', () => {
+    const css = `
+      .baz { color: orange; }
+      .foo { color: red; }
+      .baz { color: orange; }
+
+      @media (max-width: 2px) { .foo { color: blue; } }
+      @media (max-width: 2px) { .yellow { color: blue; } }
+    `;
+
+    expect(sortCSSRules(css, () => 0)).toMatchInlineSnapshot(`
+      .baz {
+        color: orange;
+      }
+      .foo {
+        color: red;
+      }
+      @media (max-width: 2px) {
+        .foo {
+          color: blue;
+        }
+      }
+      @media (max-width: 2px) {
+        .yellow {
+          color: blue;
+        }
+      }
+    `);
+  });
+
+  it('sorts rules by buckets order', () => {
+    const css = `
+      .foo:focus { color: pink; }
+      .baz { color: orange; }
+      .foo:hover { color: yellow; }
+      .foo { color: red; }
+    `;
+
+    expect(sortCSSRules(css, () => 0)).toMatchInlineSnapshot(`
+      .baz {
+        color: orange;
+      }
+      .foo {
+        color: red;
+      }
+      .foo:focus {
+        color: pink;
+      }
+      .foo:hover {
+        color: yellow;
+      }
+    `);
+  });
+
+  it('sorts media queries', () => {
+    const css = `
+      @media (max-width: 2px) { .foo { color: blue; } }
+      @media (max-width: 1px) { .foo { color: red; } }
+      @media (max-width: 3px) { .foo { color: red; } }
+      .foo { color: green; }
+    `;
+
+    const mediaQueryOrder = ['(max-width: 1px)', '(max-width: 2px)', '(max-width: 3px)', '(max-width: 4px)'];
+    const compareMediaQueries: GriffelRenderer['compareMediaQueries'] = (a: string, b: string) =>
+      mediaQueryOrder.indexOf(a) - mediaQueryOrder.indexOf(b);
+
+    expect(sortCSSRules(css, compareMediaQueries)).toMatchInlineSnapshot(`
+      .foo {
+        color: green;
+      }
+      @media (max-width: 1px) {
+        .foo {
+          color: red;
+        }
+      }
+      @media (max-width: 2px) {
+        .foo {
+          color: blue;
+        }
+      }
+      @media (max-width: 3px) {
+        .foo {
+          color: red;
+        }
+      }
+    `);
+  });
+});

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -34,7 +34,7 @@ describe('getElementReference', () => {
   });
 });
 
-describe('getMetadata', () => {
+describe('getElementMetadata', () => {
   it.each`
     css                                                    | metadata
     ${'.foo { color: red; }'}                              | ${''}

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -1,0 +1,82 @@
+import { getStyleBucketName, GriffelRenderer, StyleBucketName, styleBucketOrdering } from '@griffel/core';
+import { compile, Element, KEYFRAMES, MEDIA, RULESET, serialize, stringify, SUPPORTS, tokenize } from 'stylis';
+
+export function getSelectorFromElement(element: Element) {
+  return tokenize(element.value).slice(1).join('');
+}
+
+export function getElementMetadata(element: Element): string {
+  if (element.type === MEDIA) {
+    return element.value.replace(/^@media/, '').trim();
+  }
+
+  return '';
+}
+
+export function getElementReference(element: Element, suffix = ''): string {
+  if (element.type === RULESET || element.type === KEYFRAMES) {
+    return element.value + suffix;
+  }
+
+  if (Array.isArray(element.children) && element.children.length === 1) {
+    return getElementReference(element.children[0], element.value + suffix);
+  }
+
+  function removeRootProperty(element: Element): unknown {
+    return {
+      ...element,
+      children: Array.isArray(element.children)
+        ? element.children.map(child => removeRootProperty(child))
+        : element.children,
+      root: undefined,
+      parent: undefined,
+    };
+  }
+
+  throw new Error(
+    [
+      'getElementReference(): An unhandled case, please report if it happens and provide debug information about an element:',
+      JSON.stringify(removeRootProperty(element), null, 2),
+    ].join('\n'),
+  );
+}
+
+export function getStyleBucketNameFromElement(element: Element): StyleBucketName {
+  if (element.type === KEYFRAMES) {
+    return 'k';
+  }
+
+  return getStyleBucketName(
+    getSelectorFromElement(element),
+    element.type === '@layer' ? element.value : '',
+    element.type === MEDIA ? element.value : '',
+    element.type === SUPPORTS ? element.value : '',
+  );
+}
+
+export function sortCSSRules(css: string, compareMediaQueries: GriffelRenderer['compareMediaQueries']): string {
+  return serialize(
+    compile(css)
+      .map(element => ({
+        ...element,
+        bucketName: getStyleBucketNameFromElement(element),
+        metadata: getElementMetadata(element),
+        reference: getElementReference(element),
+      }))
+      .filter(
+        (elementA, index, self) => self.findIndex(elementB => elementA.reference === elementB.reference) === index,
+      )
+      .sort((nodeA, nodeB) => {
+        if (nodeA.bucketName === 'm' && nodeB.bucketName === 'm') {
+          return compareMediaQueries(nodeA.metadata, nodeB.metadata);
+        }
+
+        if (nodeA.bucketName === nodeB.bucketName) {
+          return 0;
+        }
+
+        return styleBucketOrdering.indexOf(nodeA.bucketName) - styleBucketOrdering.indexOf(nodeB.bucketName);
+      }),
+    stringify,
+  );
+}


### PR DESCRIPTION
This PR is the last one to support CSS extraction.

The PR:
- add sorting of CSS rules and implements the same logic as #141 with Stylis
- adds new fixtures and tests
- cleanup `@internal` modifiers and adds necessary exports from `@griffel/core`