### PR TITLE
feat: export shaker evaluator

### DIFF
--- a/change/@griffel-babel-preset-893a7a76-6351-4d7d-95f0-4f85fc59cb2b.json
+++ b/change/@griffel-babel-preset-893a7a76-6351-4d7d-95f0-4f85fc59cb2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export shaker evaluator",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -101,7 +101,7 @@ module.exports = {
       {
         evaluationRules: [
           {
-            action: require('@linaria/shaker').default,
+            action: require('@griffel/babel-preset').shakerEvaluator,
           },
           {
             test: /[/\\]node_modules[/\\]/,
@@ -145,37 +145,25 @@ const useStyles = __styles(/* resolved styles */);
 This section focuses mainly on troubleshooting this babel preset in the [microsoft/fluentui](https://github.com/microsoft/fluentui) repo.
 However, the concepts are not coupled to the repo setup.
 
-### Linaria
+### Module evaluation
 
 The preset uses tools from [linaria](https://github.com/callstack/linaria) to evaluate runtime calls of `makeStyles`.
-[Linaria's debugging documentation can help here](https://github.com/callstack/linaria/blob/master/CONTRIBUTING.md#debugging-and-deep-dive-into-babel-plugin). Here are a few examples with building packages with linaria debug output.
+[Linaria's debugging documentation can help here](https://github.com/callstack/linaria/blob/master/CONTRIBUTING.md#debugging-and-deep-dive-into-babel-plugin).
 
-Directly from the package
+Debugging output can be activated with following environment variables:
 
 ```sh
 $ DEBUG=linaria\* LINARIA_LOG=debug yarn build
 ```
 
-Using Lage from the root of the repo
-
-```sh
-$ DEBUG=linaria\* LINARIA_LOG=debug yarn lage build --to <package-name>
-```
-
-Using `yarn workspace` from the root of the repo
-
-```sh
-$ DEBUG=linaria\* LINARIA_LOG=debug yarn workspace <package-name> build
-```
-
 On Windows it's required to set environment variables via [`set`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1) or you can use `cross-env`, for example:
 
 ```sh
-$ yarn cross-env DEBUG=linaria\* LINARIA_LOG=debug yarn workspace <package-name> build
+$ cross-env DEBUG=linaria\* LINARIA_LOG=debug yarn build
 ```
 
 The debug output will include:
 
-- Transformed code
+- Prepared code
 - Evaluated code
 - AST that indicates what code has been shaken with `@linaria/shaker`

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -3,6 +3,7 @@ import { transformPlugin } from './transformPlugin';
 import type { ConfigAPI } from '@babel/core';
 import type { BabelPluginOptions } from './types';
 
+export { default as shakerEvaluator } from '@linaria/shaker';
 export { configSchema } from './schema';
 
 export type { Evaluator, EvalRule } from '@linaria/babel-preset';


### PR DESCRIPTION
This PR re-exports the evaluator from `@linaria/shaker` and updates README file for `@griffel/babel-preset`.

We had the same experience with both existing internal customers of Webpack loader - it's required to tweak evaluation settings. For that we need to configure the evaluator, but it's not re-exported we need to add a dependency to third party module and update it separately 😯