### PR TITLE
chore: use proper NPM token

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
         displayName: Authenticate git for pushes
 
       - script: |
-          yarn beachball publish -b origin/main --access public -y -n $(npmTokenTmp)
+          yarn beachball publish -b origin/main --access public -y -n $(npmToken)
           git reset --hard origin/main
         env:
           GITHUB_PAT: $(githubPAT)


### PR DESCRIPTION
Before I used personal temporary NPM token for releasing. This is not good 😈

We have solved difficulties and can use proper tokens now.