### PR TITLE
feat: add "styleElementAttributes" to createDOMRenderer

### DIFF
--- a/apps/website/docs/react/api/create-dom-renderer.md
+++ b/apps/website/docs/react/api/create-dom-renderer.md
@@ -21,3 +21,17 @@ function App(props) {
   );
 }
 ```
+
+### styleElementAttributes
+
+A map of attributes that's passed to the generated style elements. For example, is useful to set ["nonce" attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce).
+
+```js
+import { createDOMRenderer } from '@griffel/react';
+
+const renderer = createDOMRenderer(targetDocument, {
+  styleElementAttributes: {
+    nonce: 'random',
+  },
+});
+```

--- a/change/@griffel-core-f0caf7c5-b487-47b5-8dbb-7f23f433c325.json
+++ b/change/@griffel-core-f0caf7c5-b487-47b5-8dbb-7f23f433c325.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add \"styleElementAttributes\" to createDOMRenderer",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-react-91a6f79f-816d-4ac0-8d0a-58fa0719a7d3.json
+++ b/change/@griffel-react-91a6f79f-816d-4ac0-8d0a-58fa0719a7d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: add docs for createDOMRenderer",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/core/src/renderer/createDOMRenderer.test.ts
+++ b/packages/core/src/renderer/createDOMRenderer.test.ts
@@ -49,4 +49,36 @@ describe('createDOMRenderer', () => {
       }
     `);
   });
+
+  it('applies custom attributes to elements', () => {
+    const renderer = createDOMRenderer(document, {
+      styleElementAttributes: {
+        'foo-bar': 'baz',
+        nonce: 'random',
+      },
+    });
+
+    // CSS rules are redundant for this test, but they are necessary as they trigger style nodes creation
+    const cssRules: CSSRulesByBucket = {
+      d: ['.foo { color: red; }'],
+      h: ['.foo:hover { color: blue; }'],
+    };
+
+    renderer.insertCSSRules(cssRules);
+
+    expect(document.head.children).toMatchInlineSnapshot(`
+      HTMLCollection [
+        <style
+          data-make-styles-bucket="d"
+          foo-bar="baz"
+          nonce="random"
+        />,
+        <style
+          data-make-styles-bucket="h"
+          foo-bar="baz"
+          nonce="random"
+        />,
+      ]
+    `);
+  });
 });

--- a/packages/core/src/renderer/createDOMRenderer.ts
+++ b/packages/core/src/renderer/createDOMRenderer.ts
@@ -5,7 +5,14 @@ let lastIndex = 0;
 
 export interface CreateDOMRendererOptions {
   /**
-   * A filter run before css rule insertion to systematically remove css rules at render time.
+   * A map of attributes that's passed to the generated style elements. Is useful to set "nonce" attribute.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
+   */
+  styleElementAttributes?: Record<string, string>;
+
+  /**
+   * A filter run before CSS rule insertion to systematically remove CSS rules at render time.
    * This can be used to forbid specific rules from being written to the style sheet at run time without
    * affecting build time styles.
    *
@@ -35,7 +42,9 @@ export function createDOMRenderer(
       // eslint-disable-next-line guard-for-in
       for (const styleBucketName in cssRules) {
         const cssRulesForBucket = cssRules[styleBucketName as StyleBucketName]!;
-        const sheet = target && getStyleSheetForBucket(styleBucketName as StyleBucketName, target, renderer);
+        const sheet =
+          target &&
+          getStyleSheetForBucket(styleBucketName as StyleBucketName, target, renderer, options.styleElementAttributes);
 
         // This is a hot path in rendering styles: ".length" is cached in "l" var to avoid accesses the property
         for (let i = 0, l = cssRulesForBucket.length; i < l; i++) {

--- a/packages/core/src/renderer/getStyleSheetForBucket.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.ts
@@ -35,6 +35,7 @@ export function getStyleSheetForBucket(
   bucketName: StyleBucketName,
   target: Document,
   renderer: GriffelRenderer,
+  elementAttributes: Record<string, string> = {},
 ): CSSStyleSheet {
   if (!renderer.styleElements[bucketName]) {
     let currentBucketIndex = styleBucketOrdering.indexOf(bucketName) + 1;
@@ -52,8 +53,12 @@ export function getStyleSheetForBucket(
     const tag = target.createElement('style');
 
     tag.dataset['makeStylesBucket'] = bucketName;
-    renderer.styleElements[bucketName] = tag;
 
+    for (const attribute in elementAttributes) {
+      tag.setAttribute(attribute, elementAttributes[attribute]);
+    }
+
+    renderer.styleElements[bucketName] = tag;
     target.head.insertBefore(tag, nextBucketFromCache);
   }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -133,6 +133,40 @@ function App() {
 }
 ```
 
+## `createDOMRenderer()`, `RendererProvider`
+
+`createDOMRenderer` is paired with `RendererProvider` component and is useful for child window rendering and SSR scenarios. This is the default renderer for web, and will make sure that styles are injected to a document.
+
+```jsx
+import { createDOMRenderer, RendererProvider } from '@griffel/react';
+
+function App(props) {
+  const { targetDocument } = props;
+  const renderer = React.useMemo(() => createDOMRenderer(targetDocument), [targetDocument]);
+
+  return (
+    <RendererProvider renderer={renderer} targetDocument={targetDocument}>
+      {/* Children components */}
+      {/* ... */}
+    </RendererProvider>
+  );
+}
+```
+
+### styleElementAttributes
+
+A map of attributes that's passed to the generated style elements. For example, is useful to set ["nonce" attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce).
+
+```js
+import { createDOMRenderer } from '@griffel/react';
+
+const renderer = createDOMRenderer(targetDocument, {
+  styleElementAttributes: {
+    nonce: 'random',
+  },
+});
+```
+
 ## Features support
 
 ### 📃 pseudo & class selectors, at-rules, global styles


### PR DESCRIPTION
Fixes #75.

This PR adds `styleElementAttributes` to `createDOMRenderer()`. `styleElementAttributes` is a map of attributes that's passed to the generated style elements. For example, is useful to set ["nonce" attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce).

```js
import { createDOMRenderer } from '@griffel/react';

const renderer = createDOMRenderer(targetDocument, {
  styleElementAttributes: {
    nonce: 'random',
  },
});
```
