### PR TITLE
chore: export "EvalCache" & "Module" from @griffel/babel-preset

### DIFF
--- a/change/@griffel-babel-preset-9f9b43ef-1aa0-45c0-ba63-27be317357d3.json
+++ b/change/@griffel-babel-preset-9f9b43ef-1aa0-45c0-ba63-27be317357d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: re-export Module & EvalCache from Linaria",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-loader-6a8b470c-f154-43cc-aebb-08c5a47e124d.json
+++ b/change/@griffel-webpack-loader-6a8b470c-f154-43cc-aebb-08c5a47e124d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove dependency on @linaria/babel-preset",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -4,6 +4,7 @@ import type { ConfigAPI } from '@babel/core';
 import type { BabelPluginOptions } from './types';
 
 export { default as shakerEvaluator } from '@linaria/shaker';
+export { EvalCache, Module } from '@linaria/babel-preset';
 export { configSchema } from './schema';
 
 export type { Evaluator, EvalRule } from '@linaria/babel-preset';

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@babel/core": "^7.12.13",
     "@griffel/babel-preset": "^1.2.0",
-    "@linaria/babel-preset": "^3.0.0-beta.14",
     "enhanced-resolve": "^5.8.2",
     "loader-utils": "^2.0.0",
     "schema-utils": "^3.1.1",

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -1,5 +1,4 @@
-import { configSchema, BabelPluginOptions } from '@griffel/babel-preset';
-import { EvalCache, Module } from '@linaria/babel-preset';
+import { configSchema, BabelPluginOptions, EvalCache, Module } from '@griffel/babel-preset';
 import * as enhancedResolve from 'enhanced-resolve';
 import { getOptions } from 'loader-utils';
 import * as path from 'path';


### PR DESCRIPTION
## Problem

Both `@griffel/babel-preset` & `@griffel/webpack-loader` depend on `@linaria/babel-preset`. There should be nothing wrong with that, but Yarn v1 does not hoist dependencies to root `node_modules`.

#### Expected

```
/node_modules
  /@linaria/babel-preset
  /@griffel/babel-preset
  /@griffel/webpack-loader
```

#### Actual

```
/node_modules
  /@griffel/babel-preset
    /@linaria/babel-preset
  /@griffel/webpack-loader
    /@linaria/babel-preset
```

As module resolution is injected as a static property this causes hard to catch bugs.

https://github.com/microsoft/griffel/blob/01e52783012cb38d91b474858419d417b6c46410/packages/webpack-loader/src/webpackLoader.ts#L88-L92

Example of the issue: https://github.com/microsoft/fluentui/pull/21976#discussion_r843964679