### PR TITLE
fix: avoid errors with React 18

### DIFF
--- a/change/@griffel-react-82e46cbc-d83a-4acd-89ff-4278e1eb9b1e.json
+++ b/change/@griffel-react-82e46cbc-d83a-4acd-89ff-4278e1eb9b1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid errors with React 18",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/makeStyles.ts
+++ b/packages/react/src/makeStyles.ts
@@ -6,10 +6,13 @@ import { useRenderer } from './RendererContext';
 import { useTextDirection } from './TextDirectionContext';
 
 function isInsideComponent() {
+  // React 18 always logs errors if a dispatcher is not present:
+  // https://github.com/facebook/react/blob/42f15b324f50d0fd98322c21646ac3013e30344a/packages/react/src/ReactHooks.js#L26-L36
+  //
+  // A check with hooks call (i.e. call "React.useContext()" outside a component) will always produce errors
   try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useContext({} as unknown as React.Context<unknown>);
-    return true;
+    // @ts-expect-error "SECRET_INTERNALS" are not typed
+    return !!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher.current;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Fixes #89.

This PR fixes a warning (see the issue for details) by checking if React's dispatcher is present. While this approach uses `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` it works consistently with all versions of React.

See, https://github.com/microsoft/griffel/issues/89#issuecomment-1086589073.

- React 16.8 https://codesandbox.io/s/focused-fast-01v7xq?file=/src/App.js
- React 17 https://codesandbox.io/s/musing-sunset-d3k6rl?file=/src/App.js
- React 18 https://codesandbox.io/s/twilight-hill-8biwip?file=/src/App.js
