### PR TITLE
feat(Devtools): UI to display monolithic css rules per makeStyle slot 

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -11,7 +11,9 @@
   "sideEffects": false,
   "dependencies": {
     "@griffel/react": "^1.0.3",
+    "js-beautify": "^1.14.0",
     "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react-dom": ">=16.8.0 <18.0.0",
+    "stylis": "^4.0.13"
   }
 }

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { makeStaticStyles, makeStyles, shorthands } from '@griffel/react';
+
+import { SlotCSSRules } from './SlotCSSRules';
+import { getRulesBySlots } from './utils';
+import { ViewContext } from './ViewContext';
+
+import type { DebugResult } from '@griffel/core';
+import type { SlotInfo } from './types';
+
+const View: React.FC<{ slots: SlotInfo[] }> = ({ slots }) => {
+  const [highlightedClass, setHighlightedClass] = React.useState('');
+  const contextDefault = React.useMemo(() => ({ highlightedClass, setHighlightedClass }), [highlightedClass]);
+
+  return (
+    <ViewContext.Provider value={contextDefault}>
+      {slots.map(({ slot, rules }) => (
+        <SlotCSSRules key={slot} slot={slot} atomicRules={rules} />
+      ))}
+    </ViewContext.Provider>
+  );
+};
+
+const useStyles = makeStyles({
+  root: {
+    paddingBottom: '10px',
+  },
+  info: {
+    ...shorthands.margin(0, '5px'),
+  },
+});
+
+const useStaticStyles = makeStaticStyles({
+  pre: {
+    fontFamily: 'Menlo, Consolas, "dejavu sans mono", monospace',
+    margin: 'initial',
+    whiteSpace: 'normal',
+    fontSize: '11px',
+    lineHeight: '14px',
+  },
+});
+
+export const FlattenView = ({ debugResultRoot }: { debugResultRoot: DebugResult }) => {
+  const slots = React.useMemo(() => getRulesBySlots(debugResultRoot), [debugResultRoot]);
+
+  useStaticStyles();
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.info}>direction: {debugResultRoot.direction}</div>
+      <View slots={slots} />
+    </div>
+  );
+};

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -40,7 +40,10 @@ const useStaticStyles = makeStaticStyles({
   },
 });
 
-export const FlattenView = ({ debugResultRoot }: { debugResultRoot: DebugResult }) => {
+type FlattenViewProps = { debugResultRoot: DebugResult };
+
+export const FlattenView: React.FC<FlattenViewProps> = props => {
+  const { debugResultRoot } = props;
   const slots = React.useMemo(() => getRulesBySlots(debugResultRoot), [debugResultRoot]);
 
   useStaticStyles();

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -10,10 +10,10 @@ import type { SlotInfo } from './types';
 
 const View: React.FC<{ slots: SlotInfo[] }> = ({ slots }) => {
   const [highlightedClass, setHighlightedClass] = React.useState('');
-  const contextDefault = React.useMemo(() => ({ highlightedClass, setHighlightedClass }), [highlightedClass]);
+  const contextValue = React.useMemo(() => ({ highlightedClass, setHighlightedClass }), [highlightedClass]);
 
   return (
-    <ViewContext.Provider value={contextDefault}>
+    <ViewContext.Provider value={contextValue}>
       {slots.map(({ slot, rules }) => (
         <SlotCSSRules key={slot} slot={slot} atomicRules={rules} />
       ))}

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -6,20 +6,6 @@ import { getRulesBySlots } from './utils';
 import { ViewContext } from './ViewContext';
 
 import type { DebugResult } from '@griffel/core';
-import type { SlotInfo } from './types';
-
-const View: React.FC<{ slots: SlotInfo[] }> = ({ slots }) => {
-  const [highlightedClass, setHighlightedClass] = React.useState('');
-  const contextValue = React.useMemo(() => ({ highlightedClass, setHighlightedClass }), [highlightedClass]);
-
-  return (
-    <ViewContext.Provider value={contextValue}>
-      {slots.map(({ slot, rules }) => (
-        <SlotCSSRules key={slot} slot={slot} atomicRules={rules} />
-      ))}
-    </ViewContext.Provider>
-  );
-};
 
 const useStyles = makeStyles({
   root: {
@@ -49,10 +35,17 @@ export const FlattenView: React.FC<FlattenViewProps> = props => {
   useStaticStyles();
   const classes = useStyles();
 
+  const [highlightedClass, setHighlightedClass] = React.useState('');
+  const contextValue = React.useMemo(() => ({ highlightedClass, setHighlightedClass }), [highlightedClass]);
+
   return (
     <div className={classes.root}>
       <div className={classes.info}>direction: {debugResultRoot.direction}</div>
-      <View slots={slots} />
+      <ViewContext.Provider value={contextValue}>
+        {slots.map(({ slot, rules }) => (
+          <SlotCSSRules key={slot} slot={slot} atomicRules={rules} />
+        ))}
+      </ViewContext.Provider>
     </div>
   );
 };

--- a/packages/devtools/src/MonolithicRulesView.tsx
+++ b/packages/devtools/src/MonolithicRulesView.tsx
@@ -70,8 +70,8 @@ type MonolithicRulesViewProps = {
   noLineSpacing?: boolean;
 };
 
-export const MonolithicRulesView: React.FC<MonolithicRulesViewProps> = (props) => {
-  const { rules, noLineSpacing } = props
+export const MonolithicRulesView: React.FC<MonolithicRulesViewProps> = props => {
+  const { rules, noLineSpacing } = props;
   const classes = useMonolithicRulesStyles();
 
   return (

--- a/packages/devtools/src/RulesView.tsx
+++ b/packages/devtools/src/RulesView.tsx
@@ -1,0 +1,95 @@
+import beautify from 'js-beautify';
+import * as React from 'react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+
+import { useViewContext } from './ViewContext';
+import type { MonolithicRules, RuleDetail } from './types';
+
+const formatCSS = (css: string) => {
+  const formatted = beautify.css_beautify(`{${css}}`); // add {} for formatting
+  return formatted.slice(1, -1).trim(); // remove {}
+};
+
+const INDENT = '10px';
+
+const useSingleRuleStyles = makeStyles({
+  overriden: {
+    textDecorationLine: 'line-through',
+  },
+  indent: {
+    marginLeft: INDENT,
+  },
+  highlighted: {
+    outlineColor: 'orangered',
+    outlineStyle: 'dashed',
+    outlineWidth: '1px',
+  },
+});
+
+const SingleRuleView: React.FC<{ rule: RuleDetail; indent?: boolean }> = ({ rule, indent }) => {
+  const { highlightedClass, setHighlightedClass } = useViewContext();
+
+  const handleClick = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+    if (rule.overriddenBy) {
+      setHighlightedClass(highlighted => (highlighted === rule.overriddenBy ? '' : rule.overriddenBy!));
+    } else {
+      setHighlightedClass('');
+    }
+  };
+
+  const classes = useSingleRuleStyles();
+  const className = mergeClasses(
+    rule.overriddenBy && classes.overriden,
+    indent && classes.indent,
+    highlightedClass === rule.className && classes.highlighted,
+  );
+
+  return (
+    <div onClick={handleClick} className={className}>
+      <pre>{formatCSS(rule.css)}</pre>
+    </div>
+  );
+};
+
+const useMonolithicRulesStyles = makeStyles({
+  atRulesIndent: {
+    marginLeft: INDENT,
+  },
+  lineSpacing: {
+    ...shorthands.margin('5px', 0),
+  },
+  noLineSpacing: {
+    ...shorthands.margin(0),
+  },
+});
+
+type MonolithicRulesViewProps = {
+  rules: MonolithicRules;
+  // specify if there should be spacing between rules with different selectors
+  noLineSpacing?: boolean;
+};
+
+export const MonolithicRulesView: React.FC<MonolithicRulesViewProps> = ({ rules, noLineSpacing }) => {
+  const classes = useMonolithicRulesStyles();
+
+  return (
+    <>
+      {Object.entries(rules).map(([selector, rules]) => {
+        return (
+          <div key={selector} className={noLineSpacing ? classes.noLineSpacing : classes.lineSpacing}>
+            {selector && <pre>{`${selector} {`} </pre>}
+            {Array.isArray(rules) ? (
+              rules.map(rule => <SingleRuleView key={rule.css} rule={rule} indent={!!selector} />)
+            ) : (
+              <div className={classes.atRulesIndent}>
+                <MonolithicRulesView rules={rules} noLineSpacing />
+              </div>
+            )}
+            {selector && <pre>{`}`} </pre>}
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/packages/devtools/src/RulesView.tsx
+++ b/packages/devtools/src/RulesView.tsx
@@ -70,7 +70,8 @@ type MonolithicRulesViewProps = {
   noLineSpacing?: boolean;
 };
 
-export const MonolithicRulesView: React.FC<MonolithicRulesViewProps> = ({ rules, noLineSpacing }) => {
+export const MonolithicRulesView: React.FC<MonolithicRulesViewProps> = (props) => {
+  const { rules, noLineSpacing } = props
   const classes = useMonolithicRulesStyles();
 
   return (

--- a/packages/devtools/src/SlotCSSRules.tsx
+++ b/packages/devtools/src/SlotCSSRules.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
+
+import { getMonolithicCSSRules } from './getMonolithicCSSRules';
+import { MonolithicRulesView } from './RulesView';
+import { useViewContext } from './ViewContext';
+
+import type { AtomicRules } from './types';
+
+const useStyles = makeStyles({
+  slotName: {
+    ...shorthands.padding('2px', '5px'),
+    ...shorthands.margin('5px', 0),
+    ...shorthands.borderTop('1px', 'solid', 'grey'),
+    ...shorthands.borderBottom('1px', 'solid', 'grey'),
+  },
+  rules: {
+    ...shorthands.padding(0, '5px'),
+  },
+});
+
+export const SlotCSSRules: React.FC<{ slot: string; atomicRules: AtomicRules[] }> = ({ slot, atomicRules }) => {
+  const rules = React.useMemo(() => getMonolithicCSSRules(atomicRules), [atomicRules]);
+
+  const classes = useStyles();
+
+  const { setHighlightedClass } = useViewContext();
+  const undoHighlight = () => setHighlightedClass('');
+
+  return (
+    <>
+      <pre className={classes.slotName}>{slot}</pre>
+      <div className={classes.rules} onClick={undoHighlight}>
+        <MonolithicRulesView rules={rules} />
+      </div>
+    </>
+  );
+};

--- a/packages/devtools/src/SlotCSSRules.tsx
+++ b/packages/devtools/src/SlotCSSRules.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
 
 import { getMonolithicCSSRules } from './getMonolithicCSSRules';
-import { MonolithicRulesView } from './RulesView';
+import { MonolithicRulesView } from './MonolithicRulesView';
 import { useViewContext } from './ViewContext';
 
 import type { AtomicRules } from './types';

--- a/packages/devtools/src/ViewContext.ts
+++ b/packages/devtools/src/ViewContext.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export type ViewContextType = {
+  highlightedClass: string;
+  setHighlightedClass: React.Dispatch<React.SetStateAction<string>>;
+};
+
+export const ViewContext = React.createContext<ViewContextType>({
+  highlightedClass: '',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setHighlightedClass: () => {},
+});
+
+export function useViewContext() {
+  return React.useContext(ViewContext);
+}

--- a/packages/devtools/src/getMonolithicCSSRules.test.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.test.ts
@@ -1,0 +1,148 @@
+import { getMonolithicCSSRules } from './getMonolithicCSSRules';
+
+describe('getMonolithicCSSRules', () => {
+  it('group atomic css with class names selector', () => {
+    const rules = ['.abcdef0{background-color:red;}', '.abcdef1{color:red;}'].map(cssRule => ({ cssRule }));
+    expect(getMonolithicCSSRules(rules)).toEqual({
+      '': [
+        {
+          className: 'abcdef0',
+          css: 'background-color:red;',
+        },
+        {
+          className: 'abcdef1',
+          css: 'color:red;',
+        },
+      ],
+    });
+  });
+
+  it('separate atomic css with class names selector and pseudo selector', () => {
+    const rules = [
+      '.abcdef0{background-color:red;}',
+      '.abcdef1{display:block;}',
+      '.abcdef2:hover{display:none;}',
+      '.abcdef3:hover{color:red;}',
+    ].map(cssRule => ({ cssRule }));
+    expect(getMonolithicCSSRules(rules)).toEqual({
+      '': [
+        {
+          className: 'abcdef0',
+          css: 'background-color:red;',
+        },
+        {
+          className: 'abcdef1',
+          css: 'display:block;',
+        },
+      ],
+      ':hover': [
+        {
+          className: 'abcdef2',
+          css: 'display:none;',
+        },
+        {
+          className: 'abcdef3',
+          css: 'color:red;',
+        },
+      ],
+    });
+  });
+
+  it('group atomic css with media selector', () => {
+    const rules = [
+      '.abcdef0{background-color:red;}',
+      '.abcdef1{display:block;}',
+      '.abcdef2:hover{display:none;}',
+      '.abcdef3:hover{color:red;}',
+    ].map(cssRule => ({ cssRule: `@media screen and (max-width: 992px){${cssRule}}` }));
+    expect(getMonolithicCSSRules(rules)).toEqual({
+      '@media screen and (max-width: 992px)': {
+        '': [
+          {
+            className: 'abcdef0',
+            css: 'background-color:red;',
+          },
+          {
+            className: 'abcdef1',
+            css: 'display:block;',
+          },
+        ],
+        ':hover': [
+          {
+            className: 'abcdef2',
+            css: 'display:none;',
+          },
+          {
+            className: 'abcdef3',
+            css: 'color:red;',
+          },
+        ],
+      },
+    });
+  });
+
+  it('separate atomic css with different media selector', () => {
+    const rules = [
+      '.abcdef0{background-color:red;}',
+      '@media screen and (max-width: 992px){.abcdef0{background-color:blue;}}',
+      '@media screen and (max-width: 1024px){.abcdef0{background-color:green;}}',
+    ].map(cssRule => ({ cssRule }));
+    expect(getMonolithicCSSRules(rules)).toEqual({
+      '': [
+        {
+          className: 'abcdef0',
+          css: 'background-color:red;',
+        },
+      ],
+      '@media screen and (max-width: 1024px)': {
+        '': [
+          {
+            className: 'abcdef0',
+            css: 'background-color:green;',
+          },
+        ],
+      },
+      '@media screen and (max-width: 992px)': {
+        '': [
+          {
+            className: 'abcdef0',
+            css: 'background-color:blue;',
+          },
+        ],
+      },
+    });
+  });
+
+  it('pass on overriddenBy information from atomic css to monolithic css', () => {
+    const rules = [
+      { cssRule: '.abcdef0{background-color:red;}', overriddenBy: 'bcdefg0' },
+      { cssRule: '.abcdef0>div{color:green;}', overriddenBy: 'bcdefg1' },
+      { cssRule: '@media screen and (max-width: 992px){.abcdef0{background-color:blue;}}', overriddenBy: 'bcdefg2' },
+    ];
+    expect(getMonolithicCSSRules(rules)).toEqual({
+      '': [
+        {
+          className: 'abcdef0',
+          css: 'background-color:red;',
+          overriddenBy: 'bcdefg0',
+        },
+      ],
+      '>div': [
+        {
+          className: 'abcdef0',
+          css: 'color:green;',
+          overriddenBy: 'bcdefg1',
+        },
+      ],
+      '@media screen and (max-width: 992px)': {
+        '': [
+          {
+            className: 'abcdef0',
+            css: 'background-color:blue;',
+            overriddenBy: 'bcdefg2',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -9,13 +9,17 @@ function parseRuleElement(monolithicRules: MonolithicRules, element: stylis.Elem
   const nestedSelector = stylis.tokenize(classNameSelector).slice(1).join('');
   monolithicRules[nestedSelector] = monolithicRules[nestedSelector] ?? [];
 
-  (children as stylis.Element[]).forEach(child => {
-    (monolithicRules[nestedSelector] as RuleDetail[]).push({
-      css: child.value,
-      className: stylis.tokenize(classNameSelector)[0].slice(1),
-      overriddenBy,
+  if (Array.isArray(children)) {
+    children.forEach(child => {
+      (monolithicRules[nestedSelector] as RuleDetail[]).push({
+        css: child.value,
+        className: stylis.tokenize(classNameSelector)[0].slice(1),
+        overriddenBy,
+      });
     });
-  });
+  } else {
+    throw new Error('Unsupported input from "element.children"');
+  }
 }
 
 function parseAtElement(monolithicRules: MonolithicRules, element: stylis.Element, overriddenBy?: string) {

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -44,6 +44,8 @@ function parseStylisElement(monolithicRules: MonolithicRules, element: stylis.El
     parseAtElement(monolithicRules, element, overriddenBy);
   } else if (type === 'rule') {
     parseRuleElement(monolithicRules, element, overriddenBy);
+  } else {
+    throw new Error('Unsupported type of entries');
   }
 }
 

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -1,0 +1,51 @@
+import * as stylis from 'stylis';
+import type { AtomicRules, MonolithicAtRules, MonolithicRules, RuleDetail } from './types';
+
+function parseRuleElement(monolithicRules: MonolithicRules, element: stylis.Element, overriddenBy?: string) {
+  const { value, children } = element;
+  const selector = stylis.tokenize(value).slice(1).join('');
+  monolithicRules[selector] = monolithicRules[selector] ?? [];
+
+  (children as stylis.Element[]).forEach(child => {
+    (monolithicRules[selector] as RuleDetail[]).push({
+      css: child.value,
+      className: stylis.tokenize(value)[0].slice(1),
+      overriddenBy,
+    });
+  });
+}
+
+function parseAtElement(monolithicRules: MonolithicRules, element: stylis.Element, overriddenBy?: string) {
+  const { value: atSelector, children } = element;
+  monolithicRules[atSelector] = monolithicRules[atSelector] ?? {};
+
+  (children as stylis.Element[]).forEach(child => {
+    const childResult = {};
+    parseStylisElement(childResult, child, overriddenBy);
+
+    Object.entries<RuleDetail[]>(childResult).forEach(([selector, ruleDetails]) => {
+      const atResult = monolithicRules[atSelector] as MonolithicAtRules;
+      atResult[selector] = [...(atResult[selector] ?? []), ...ruleDetails];
+    });
+  });
+}
+
+function parseStylisElement(monolithicRules: MonolithicRules, element: stylis.Element, overriddenBy?: string) {
+  const { type } = element;
+  if (type.startsWith('@')) {
+    parseAtElement(monolithicRules, element, overriddenBy);
+  } else if (type === 'rule') {
+    parseRuleElement(monolithicRules, element, overriddenBy);
+  }
+}
+
+export function getMonolithicCSSRules(rules: AtomicRules[]): MonolithicRules {
+  const monolithicRules = {};
+  rules.forEach(entry => {
+    const compiled = stylis.compile(entry.cssRule);
+    compiled.forEach(element => {
+      parseStylisElement(monolithicRules, element, entry.overriddenBy);
+    });
+  });
+  return monolithicRules;
+}

--- a/packages/devtools/src/index.tsx
+++ b/packages/devtools/src/index.tsx
@@ -8,7 +8,7 @@ import { useMakeStylesState } from './useMakeStylesState';
 const DevTools: React.FC = () => {
   const state = useMakeStylesState();
 
-  if (state) {
+  if (state && Object.keys(state).length > 0) {
     return <FlattenView debugResultRoot={state} />;
   }
 

--- a/packages/devtools/src/index.tsx
+++ b/packages/devtools/src/index.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { DefaultMessage } from './DefaultMessage';
+import { FlattenView } from './FlattenView';
 import { useMakeStylesState } from './useMakeStylesState';
 
 const DevTools: React.FC = () => {
   const state = useMakeStylesState();
 
   if (state) {
-    console.log(state);
+    return <FlattenView debugResultRoot={state} />;
   }
 
   return <DefaultMessage />;

--- a/packages/devtools/src/stories/FlattenView.stories.tsx
+++ b/packages/devtools/src/stories/FlattenView.stories.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { FlattenView } from '../FlattenView';
+import type { DebugResult } from '@griffel/core';
+
+const debugResultRoot: DebugResult = {
+  sequenceHash: '___29aowz0_1rg0tlg',
+  direction: 'ltr',
+  children: [
+    {
+      sequenceHash: '___12k6f67_1qq0ij4',
+      direction: 'ltr',
+      children: [
+        {
+          sequenceHash: '___1cxgqvx_0000000',
+          direction: 'ltr',
+          children: [],
+          debugClassNames: [
+            { className: 'f3rmtva', overriddenBy: 'fdmssx0' },
+            { className: 'f1s6fcnf' },
+            { className: 'f8491dx' },
+            { className: 'f139dqjh', overriddenBy: 'f19s2fr6' },
+          ],
+          rules: {
+            f3rmtva: '.f3rmtva{background-color:transparent;}',
+            f1s6fcnf: '.f1s6fcnf{outline-style:none;}',
+            f8491dx: '.f8491dx:hover{cursor:pointer;}',
+            f139dqjh: '.f139dqjh:hover{background-color:#ddd;}',
+          },
+          slot: 'root',
+        },
+        {
+          sequenceHash: '___1wgw9g0_0000000',
+          direction: 'ltr',
+          children: [],
+          debugClassNames: [
+            { className: 'fdmssx0', overriddenBy: 'f3xbvq9' },
+            { className: 'f183xr6j' },
+            { className: 'f19s2fr6' },
+            { className: 'f15639b', overriddenBy: 'fy4xd57' },
+          ],
+          rules: {
+            fdmssx0: '.fdmssx0{background-color:#106ebe;}',
+            f183xr6j: '.f183xr6j{color:#eff6fc;}',
+            f19s2fr6: '.f19s2fr6:hover{background-color:#2899f5;}',
+            f15639b: '@media screen and (max-width: 992px){.f15639b:hover{background-color:green;}}',
+          },
+          slot: 'primary',
+        },
+      ],
+      debugClassNames: [
+        { className: 'fdmssx0', overriddenBy: 'f3xbvq9' },
+        { className: 'f1s6fcnf' },
+        { className: 'f8491dx' },
+        { className: 'f19s2fr6' },
+        { className: 'f183xr6j' },
+        { className: 'f15639b', overriddenBy: 'fy4xd57' },
+      ],
+    },
+    {
+      sequenceHash: '___b844lz0_0000000',
+      direction: 'ltr',
+      children: [],
+      debugClassNames: [
+        { className: 'f3xbvq9' },
+        { className: 'f7sr9i2' },
+        { className: 'fg103nd' },
+        { className: 'fsz8qd4' },
+        { className: 'f7wpa5l' },
+        { className: 'fy4xd57' },
+      ],
+      rules: {
+        f3xbvq9: '.f3xbvq9{background-color:red;}',
+        f7sr9i2: '.f7sr9i2>div{color:pink;}',
+        fg103nd: '.fg103nd>div:hover{border-top-color:#2899f5;}',
+        fsz8qd4: '@media (forced-colors: active):{.fsz8qd4{color:purple;}}',
+        f7wpa5l: '@media screen and (max-width: 992px){.f7wpa5l:hover{color:red;}}',
+        fy4xd57: '@media screen and (max-width: 992px){.fy4xd57:hover{background-color:blue;}}',
+      },
+      slot: 'primaryRed',
+    },
+  ],
+  debugClassNames: [
+    { className: 'f3xbvq9' },
+    { className: 'f1s6fcnf' },
+    { className: 'f8491dx' },
+    { className: 'f19s2fr6' },
+    { className: 'f183xr6j' },
+    { className: 'fy4xd57' },
+    { className: 'f7sr9i2' },
+    { className: 'fg103nd' },
+    { className: 'fsz8qd4' },
+    { className: 'f7wpa5l' },
+  ],
+};
+
+export const Default = () => (
+  <div style={{ border: '3px solid gray', width: 400 }}>
+    <FlattenView debugResultRoot={debugResultRoot} />
+  </div>
+);
+
+export default {
+  title: 'FlattenView',
+};

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -1,0 +1,11 @@
+export type SlotInfo = { slot: string; rules: AtomicRules[] };
+
+export type AtomicRules = { cssRule: string; overriddenBy?: string };
+
+export type RuleDetail = {
+  className: string;
+  css: string;
+  overriddenBy?: string;
+};
+export type MonolithicAtRules = Record<string /** selector */, RuleDetail[]>;
+export type MonolithicRules = Record<string /** selector */, RuleDetail[] | MonolithicAtRules>;

--- a/packages/devtools/src/utils.test.ts
+++ b/packages/devtools/src/utils.test.ts
@@ -1,0 +1,74 @@
+import { getRulesBySlots } from './utils';
+import type { DebugResult } from '@griffel/core';
+
+describe('getRulesBySlots', () => {
+  it('traverse debug result, gather and return all makeStyles slot name and rules', () => {
+    const makeStylesNodes: DebugResult[] = [
+      {
+        sequenceHash: '___abcdef0_0000000',
+        direction: 'ltr',
+        children: [],
+        debugClassNames: [{ className: 'fabcde0' }],
+        rules: {
+          fabcde0: '.fabcde0{background-color:transparent;}',
+        },
+        slot: 'root',
+      },
+      {
+        sequenceHash: '___abcdef1_0000000',
+        direction: 'ltr',
+        children: [],
+        debugClassNames: [{ className: 'fabcde1', overriddenBy: 'fabcde2' }],
+        rules: {
+          fabcde1: '.fabcde1{display:block;}',
+        },
+        slot: 'slot1',
+      },
+      {
+        sequenceHash: '___abcdef2_0000000',
+        direction: 'ltr',
+        children: [],
+        debugClassNames: [{ className: 'fabcde2' }],
+        rules: {
+          fabcde2: '.fabcde2{display:none;}',
+        },
+        slot: 'slot2',
+      },
+    ];
+    const debugResultRoot = {
+      children: [
+        makeStylesNodes[0],
+        {
+          children: [makeStylesNodes[1], makeStylesNodes[2]],
+        },
+      ],
+    };
+    expect(getRulesBySlots(debugResultRoot as DebugResult)).toEqual([
+      {
+        slot: 'slot2',
+        rules: [
+          {
+            cssRule: '.fabcde2{display:none;}',
+          },
+        ],
+      },
+      {
+        slot: 'slot1',
+        rules: [
+          {
+            cssRule: '.fabcde1{display:block;}',
+            overriddenBy: 'fabcde2',
+          },
+        ],
+      },
+      {
+        slot: 'root',
+        rules: [
+          {
+            cssRule: '.fabcde0{background-color:transparent;}',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/devtools/src/utils.ts
+++ b/packages/devtools/src/utils.ts
@@ -1,12 +1,13 @@
 import type { DebugResult } from '@griffel/core';
 import { SlotInfo } from './types';
 
-export function getRulesBySlots(root: DebugResult) {
-  const result: SlotInfo[] = [];
-  const traverse = (node: DebugResult) => {
-    if (!node.children.length && node.slot) {
-      const { debugClassNames, rules, slot } = node;
-      result.push({
+export function getRulesBySlots(node: DebugResult, result: SlotInfo[] = []): SlotInfo[] {
+  if (node.children.length === 0 && node.slot) {
+    const { debugClassNames, rules, slot } = node;
+
+    return [
+      ...result,
+      {
         slot,
         rules: debugClassNames.map(({ className, overriddenBy }) => {
           return {
@@ -14,14 +15,11 @@ export function getRulesBySlots(root: DebugResult) {
             overriddenBy,
           };
         }),
-      });
-      return;
-    }
+      },
+    ];
+  }
 
-    node.children.reverse().forEach(child => {
-      traverse(child);
-    });
-  };
-  traverse(root);
-  return result;
+  return node.children.reverse().reduce((acc, child) => {
+    return [...acc, ...getRulesBySlots(child)];
+  }, result);
 }

--- a/packages/devtools/src/utils.ts
+++ b/packages/devtools/src/utils.ts
@@ -1,0 +1,27 @@
+import type { DebugResult } from '@griffel/core';
+import { SlotInfo } from './types';
+
+export function getRulesBySlots(root: DebugResult) {
+  const result: SlotInfo[] = [];
+  const traverse = (node: DebugResult) => {
+    if (!node.children.length && node.slot) {
+      const { debugClassNames, rules, slot } = node;
+      result.push({
+        slot,
+        rules: debugClassNames.map(({ className, overriddenBy }) => {
+          return {
+            cssRule: rules![className],
+            overriddenBy,
+          };
+        }),
+      });
+      return;
+    }
+
+    node.children.reverse().forEach(child => {
+      traverse(child);
+    });
+  };
+  traverse(root);
+  return result;
+}


### PR DESCRIPTION
Add real UI for griffel devtools.
<img width="422" alt="Screenshot 2022-04-21 at 11 35 28" src="https://user-images.githubusercontent.com/28751745/164433695-fca36090-3f65-4a39-ba29-d77cde16a9f7.png">

- show all makeStyles calls with slot name and monolithic css rules
    - atomic css rules from devtools result are processed into monolithic css objects using `stylis`
- displayed overridden css rules; clicking on them highlights the overriding rules


TODOs on devtools UI
- Show code highlights for css rules
- Add search function
- Click slot name expand/collapse rules within
- Show className for each rule
- Collapse shorthands in devtools UI

TODOs on devtools data:
- currently devtools is always disabled from @griffel/core, find out a way to enable it that is compatible with SSR
- Add sourcemap to devtools data; jump to source code from devtools UI