### PR TITLE
feat: create ESLint plugin for Griffel

### DIFF
--- a/change/@griffel-core-8a3b4de2-ff52-4c79-aa40-84cdf0bb669e.json
+++ b/change/@griffel-core-8a3b4de2-ff52-4c79-aa40-84cdf0bb669e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add a comment to exports",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-eslint-plugin-0f2d3131-9acc-46f2-b1a1-b7c23c1e852a.json
+++ b/change/@griffel-eslint-plugin-0f2d3131-9acc-46f2-b1a1-b7c23c1e852a.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "initial release",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@emotion/hash": "^0.8.0",
     "@linaria/babel-preset": "^3.0.0-beta.14",
     "@linaria/shaker": "^3.0.0-beta.14",
+    "@typescript-eslint/utils": "^5.20.0",
     "ajv": "^8.4.0",
     "csstype": "^3.0.10",
     "enhanced-resolve": "^5.8.2",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,4 +65,5 @@ export type {
   GriffelRenderer,
 } from './types';
 
+// Private exports, are used by devtools
 export type { DebugCSSRules, DebugSequence, DebugResult } from './devtools';

--- a/packages/eslint-plugin/.babelrc
+++ b/packages/eslint-plugin/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/eslint-plugin/.eslintrc.json
+++ b/packages/eslint-plugin/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,44 @@
+# ESLint plugin for Griffel
+
+ESLint plugin to follow best practices and anticipate common mistakes when writing styles with Griffel
+
+## Install
+
+```bash
+yarn add --dev @griffel/eslint-plugin
+# or
+npm install --dev @griffel/eslint-plugin
+```
+
+## Usage
+
+Add `@griffel/eslint-plugin` to the extends section of your `.eslintrc` configuration file:
+
+```json
+{
+  "extends": ["@griffel"]
+}
+```
+
+## Shareable configurations
+
+This plugin exports recommended configuration that enforce good practices, but you can use only uses that are required for your use case:
+
+```json
+{
+  "plugins": ["@griffel"],
+  "rules": {
+    "@griffel/no-shorthands": "warn"
+  }
+}
+```
+
+You can find more info about enabled rules in the [Supported Rules section](#supported-rules) below.
+
+## Supported Rules
+
+**Key**: 🔧 = fixable
+
+| Name                                                     | Description                    | 🔧  |
+| -------------------------------------------------------- | ------------------------------ | --- |
+| [`@griffel/no-shorthands`](./src/rules/no-shorthands.md) | Enforce usage of CSS longhands |     |

--- a/packages/eslint-plugin/jest.config.js
+++ b/packages/eslint-plugin/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'eslint-plugin',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/packages/eslint-plugin',
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,5 +10,8 @@
   "dependencies": {
     "csstype": "^3.0.10",
     "@typescript-eslint/utils": "^5.20.0"
+  },
+  "peerDependencies": {
+    "eslint": "^7.5.0 || ^8.0.0"
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@griffel/eslint-plugin",
+  "version": "0.0.1",
+  "description": "ESLint plugin with lint rules for Griffel",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/griffel"
+  },
+  "dependencies": {
+    "csstype": "^3.0.10",
+    "@typescript-eslint/utils": "^5.20.0"
+  }
+}

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -1,0 +1,49 @@
+{
+  "root": "packages/eslint-plugin",
+  "sourceRoot": "packages/eslint-plugin/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/eslint-plugin/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/eslint-plugin"],
+      "options": {
+        "jestConfig": "packages/eslint-plugin/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "build": {
+      "executor": "@nrwl/node:package",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/eslint-plugin",
+        "tsConfig": "packages/eslint-plugin/tsconfig.lib.json",
+        "packageJson": "packages/eslint-plugin/package.json",
+        "main": "packages/eslint-plugin/src/index.ts",
+        "assets": [
+          "packages/eslint-plugin/README.md",
+          {
+            "glob": "LICENSE.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "type-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "packages/babel-preset",
+        "commands": [{ "command": "tsc -b --pretty" }],
+        "outputPath": []
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,0 +1,6 @@
+export const recommendedConfig = {
+  plugins: ['@griffel'],
+  rules: {
+    '@griffel/no-shorthands': 'error',
+  },
+};

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,11 @@
+import { recommendedConfig } from './configs/recommended';
+import { noShorthandsRule } from './rules/no-shorthands';
+
+export = {
+  configs: {
+    recommended: recommendedConfig,
+  },
+  rules: {
+    'no-shorthands': noShorthandsRule,
+  },
+};

--- a/packages/eslint-plugin/src/rules/no-shorthands.md
+++ b/packages/eslint-plugin/src/rules/no-shorthands.md
@@ -1,0 +1,34 @@
+# Enforce usage of CSS longhands (`@griffel/no-shorthands`)
+
+Ensure that rules passed to `makeStyles()` function do not contain [CSS shorthands](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties).
+
+## Rule Details
+
+Griffel does not support usage of CSS shorthands, [microsoft/griffel#30](https://github.com/microsoft/griffel/issues/30#issuecomment-1045959297).
+This is enforced by typings, but there are cases when they don't work as expected [microsoft/griffel#78](https://github.com/microsoft/griffel/issues/78).
+
+Examples of **incorrect** code for this rule:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    background: 'red',
+    padding: '10px 20px',
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    backgroundColor: 'red',
+    ...shorthands.padding('10px', '20px'),
+  },
+});
+```

--- a/packages/eslint-plugin/src/rules/no-shorthands.test.ts
+++ b/packages/eslint-plugin/src/rules/no-shorthands.test.ts
@@ -1,0 +1,64 @@
+import { TSESLint } from '@typescript-eslint/utils';
+import * as path from 'path';
+
+import { noShorthandsRule, RULE_NAME } from './no-shorthands';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: path.resolve('./node_modules/@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run(RULE_NAME, noShorthandsRule, {
+  valid: [
+    {
+      name: 'without CSS shorthands',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { backgroundColor: 'red' },
+});
+`,
+    },
+    {
+      name: 'CSS shorthands can be used as slot names',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  background: { backgroundColor: 'red' },
+});
+`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'CSS shorthand or root level',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { background: 'red' },
+});
+`,
+      errors: [{ messageId: 'shorthandFound' }],
+    },
+    {
+      name: 'CSS shorthand in a selector',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    ':hover': { background: 'red' }
+  },
+});
+`,
+      errors: [{ messageId: 'shorthandFound' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-shorthands.ts
+++ b/packages/eslint-plugin/src/rules/no-shorthands.ts
@@ -1,0 +1,122 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import * as CSS from 'csstype';
+
+import { createRule } from '../utils/createRule';
+import { isIdentifier, isObjectExpression, isProperty } from '../utils/helpers';
+
+export const RULE_NAME = 'no-shorthands';
+
+// This collection is a map simply for faster access when checking if a CSS property is unsupported
+// @griffel/core has the same definition, but ESLint plugin should not depend on it
+const UNSUPPORTED_CSS_PROPERTIES: Record<keyof CSS.StandardShorthandProperties, true> = {
+  all: true,
+  animation: true,
+  background: true,
+  backgroundPosition: true,
+  border: true,
+  borderBlock: true,
+  borderBlockEnd: true,
+  borderBlockStart: true,
+  borderBottom: true,
+  borderColor: true,
+  borderImage: true,
+  borderInline: true,
+  borderInlineEnd: true,
+  borderInlineStart: true,
+  borderLeft: true,
+  borderRadius: true,
+  borderRight: true,
+  borderStyle: true,
+  borderTop: true,
+  borderWidth: true,
+  columns: true,
+  columnRule: true,
+  flex: true,
+  flexFlow: true,
+  font: true,
+  gap: true,
+  grid: true,
+  gridArea: true,
+  gridColumn: true,
+  gridRow: true,
+  gridTemplate: true,
+  lineClamp: true,
+  listStyle: true,
+  margin: true,
+  mask: true,
+  maskBorder: true,
+  motion: true,
+  offset: true,
+  outline: true,
+  overflow: true,
+  overscrollBehavior: true,
+  padding: true,
+  placeItems: true,
+  placeSelf: true,
+  textDecoration: true,
+  textEmphasis: true,
+  transition: true,
+};
+
+function findShorthandProperties(
+  node: TSESTree.ObjectExpression,
+  isRoot = false,
+  result: TSESTree.Identifier[] = [],
+): TSESTree.Identifier[] {
+  for (const propertyNode of node.properties) {
+    if (isProperty(propertyNode)) {
+      if (isIdentifier(propertyNode.key) && !isRoot) {
+        if (Object.prototype.hasOwnProperty.call(UNSUPPORTED_CSS_PROPERTIES, propertyNode.key.name)) {
+          result.push(propertyNode.key);
+        }
+      }
+
+      if (isObjectExpression(propertyNode.value)) {
+        findShorthandProperties(propertyNode.value, false, result);
+      }
+    }
+  }
+
+  return result;
+}
+
+export const noShorthandsRule: ReturnType<ReturnType<typeof ESLintUtils.RuleCreator>> = createRule({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow using CSS shorthands in makeStyles() calls',
+      recommended: 'error',
+    },
+    messages: {
+      shorthandFound: 'Usage of shorthands is prohibited',
+    },
+    schema: [
+      {
+        type: 'string',
+      },
+    ],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isIdentifier(node.callee) && node.callee.name === 'makeStyles') {
+          const argument = node.arguments[0];
+
+          if (isObjectExpression(argument)) {
+            const shorthandProperties = findShorthandProperties(argument, true);
+
+            shorthandProperties.forEach(shorthandProperty => {
+              context.report({
+                node: shorthandProperty,
+                messageId: 'shorthandFound',
+              });
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/utils/createRule.ts
+++ b/packages/eslint-plugin/src/utils/createRule.ts
@@ -1,0 +1,7 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const getDocsUrl = (ruleName: string): string =>
+  `https://github.com/microsoft/griffel/tree/main/packages/eslint-plugin/src/rules/${ruleName}.md`;
+
+export const createRule: ReturnType<typeof ESLintUtils.RuleCreator> = (...args) =>
+  ESLintUtils.RuleCreator(getDocsUrl)(...args);

--- a/packages/eslint-plugin/src/utils/helpers.ts
+++ b/packages/eslint-plugin/src/utils/helpers.ts
@@ -1,0 +1,11 @@
+import { AST_NODE_TYPES, ASTUtils, TSESTree } from '@typescript-eslint/utils';
+
+type IsHelper<NodeType extends AST_NODE_TYPES> = (node: TSESTree.Node | null | undefined) => node is TSESTree.Node & {
+  type: NodeType;
+};
+
+export const isIdentifier: IsHelper<AST_NODE_TYPES.Identifier> = ASTUtils.isIdentifier;
+export const isObjectExpression: IsHelper<AST_NODE_TYPES.ObjectExpression> = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.ObjectExpression,
+);
+export const isProperty: IsHelper<AST_NODE_TYPES.Property> = ASTUtils.isNodeOfType(AST_NODE_TYPES.Property);

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/eslint-plugin/tsconfig.lib.json
+++ b/packages/eslint-plugin/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "environment"]
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/packages/eslint-plugin/tsconfig.spec.json
+++ b/packages/eslint-plugin/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node", "environment"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,10 +15,11 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@griffel/e2e-typescript": ["e2e/typescript/src/index.ts"],
       "@griffel/babel-preset": ["packages/babel-preset/src/index.ts"],
       "@griffel/core": ["packages/core/src/index.ts"],
       "@griffel/devtools": ["packages/devtools/src/index.ts"],
+      "@griffel/e2e-typescript": ["e2e/typescript/src/index.ts"],
+      "@griffel/eslint-plugin": ["packages/eslint-plugin/src/index.ts"],
       "@griffel/jest-serializer": ["packages/jest-serializer/src/index.ts"],
       "@griffel/react": ["packages/react/src/index.ts"],
       "@griffel/webpack-loader": ["packages/webpack-loader/src/index.ts"]

--- a/workspace.json
+++ b/workspace.json
@@ -1,13 +1,14 @@
 {
   "version": 2,
   "projects": {
-    "@griffel/e2e-typescript": "e2e/typescript",
     "@griffel/babel-preset": "packages/babel-preset",
     "@griffel/core": "packages/core",
+    "@griffel/devtools": "packages/devtools",
+    "@griffel/e2e-typescript": "e2e/typescript",
+    "@griffel/eslint-plugin": "packages/eslint-plugin",
     "@griffel/jest-serializer": "packages/jest-serializer",
     "@griffel/react": "packages/react",
     "@griffel/webpack-loader": "packages/webpack-loader",
-    "@griffel/website": "apps/website",
-    "@griffel/devtools": "packages/devtools"
+    "@griffel/website": "apps/website"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6623,6 +6623,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.20.0"
+  dependencies:
+    "@typescript-eslint/types": 5.20.0
+    "@typescript-eslint/visitor-keys": 5.20.0
+  checksum: 904fd43f559dc2579958496ffad837eca124940b4a172666f0ea54ed606074d9ec7d2bec0f2141c3f9a8b894dd2644817cb86809e79a7a73ecba2b7babcdb5c9
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:5.3.1":
   version: 5.3.1
   resolution: "@typescript-eslint/scope-manager@npm:5.3.1"
@@ -6633,10 +6643,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@typescript-eslint/types@npm:5.20.0"
+  checksum: d7f6e51e23f59feee8857340828c47a98a0dd5eaa1b045e936dc11199b55754cf78ae5cd8d56c1fafb1b5a40a6f472c1ac921072951217caffe3f06a717fa61c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:5.3.1":
   version: 5.3.1
   resolution: "@typescript-eslint/types@npm:5.3.1"
   checksum: ccba0a505b96860b9a29f8cd1cd3c9dc7903fd21274c538ee988a4cf69c24274822e12ade61d05088626e43e3159ef5a9f5c0f4344d2c2223c6b3649cc70efb7
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.20.0"
+  dependencies:
+    "@typescript-eslint/types": 5.20.0
+    "@typescript-eslint/visitor-keys": 5.20.0
+    debug: ^4.3.2
+    globby: ^11.0.4
+    is-glob: ^4.0.3
+    semver: ^7.3.5
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 2b709292b7df3675d1f8eaf2f4e1ecf491f70fc525012c6a0fb5164aa893c165317b0a419022b8b00aaed502864d5b5b84092b58a9950d2633248e8d7627abd8
   languageName: node
   linkType: hard
 
@@ -6655,6 +6690,32 @@ __metadata:
     typescript:
       optional: true
   checksum: cc29aabda0e2f86783d82455a790deaa0b66b74373ae76709846d29eccce4fe7e942596e9329df39ad1ad44e7360100e9d0372e21ac66a0ab018ca8c10094c43
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^5.20.0":
+  version: 5.20.0
+  resolution: "@typescript-eslint/utils@npm:5.20.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    "@typescript-eslint/scope-manager": 5.20.0
+    "@typescript-eslint/types": 5.20.0
+    "@typescript-eslint/typescript-estree": 5.20.0
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: e387cf96124e34d079804220c5cb9134148fb3efc68d852a344453e285e3016e0b7e37b11308ef58c0e7afc638f145002cebc27c5da0fd03e0c074ff97d8210e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.20.0"
+  dependencies:
+    "@typescript-eslint/types": 5.20.0
+    eslint-visitor-keys: ^3.0.0
+  checksum: 1e1aa5f14fd60f1846ee26947d571953898dc82eb635a7eab3984c6b7db9bb8897743416713a129cc95c8cd63325cc0c64b3935d264f73100911fc5da76fc65f
   languageName: node
   linkType: hard
 
@@ -13239,6 +13300,7 @@ __metadata:
     "@types/tmp": 0.2.3
     "@typescript-eslint/eslint-plugin": ~5.3.0
     "@typescript-eslint/parser": ~5.3.0
+    "@typescript-eslint/utils": ^5.20.0
     ajv: ^8.4.0
     babel-jest: 27.2.3
     babel-loader: 8.1.0


### PR DESCRIPTION
This PR adds `@griffel/eslint-plugin` with a single ESLint rule to enforce usage of CSS longhands.

Fixes #76.

## Rule Details

Griffel does not support usage of CSS shorthands, [microsoft/griffel#30](https://github.com/microsoft/griffel/issues/30#issuecomment-1045959297).
This is enforced by typings, but there are cases when they don't work as expected [microsoft/griffel#78](https://github.com/microsoft/griffel/issues/78).

Examples of **incorrect** code for this rule:

```js
import { makeStyles } from '@griffel/react';

export const useStyles = makeStyles({
  root: {
    background: 'red',
    padding: '10px 20px',
  },
});
```

![image](https://user-images.githubusercontent.com/14183168/164482794-cb0782ac-0635-47ee-a3cc-13e3ff4401eb.png)

Examples of **correct** code for this rule:

```js
import { makeStyles } from '@griffel/react';

export const useStyles = makeStyles({
  root: {
    backgroundColor: 'red',
    ...shorthands.padding('10px', '20px'),
  },
});
```
