### PR TITLE
docs: add limitations & shorthands, minor improvements

### DIFF
--- a/apps/website/docs/react/api/create-dom-renderer.md
+++ b/apps/website/docs/react/api/create-dom-renderer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # createDOMRenderer

--- a/apps/website/docs/react/api/make-static-styles.md
+++ b/apps/website/docs/react/api/make-static-styles.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 import OutputTitle from '@site/src/components/OutputTitle'

--- a/apps/website/docs/react/api/shorthands.md
+++ b/apps/website/docs/react/api/shorthands.md
@@ -4,6 +4,12 @@ sidebar_position: 3
 
 # shorthands
 
+:::note
+
+Check [limitations](/react/guides/limitations) to understand why these helpers are needed.
+
+:::
+
 `shorthands` provides a set of functions to mimic [CSS shorthands](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties) and improve developer experience as [CSS shorthands are not supported](/react/guides/limitations#css-shorthands-are-not-supported) by Griffel. For example:
 
 ```tsx

--- a/apps/website/docs/react/api/shorthands.md
+++ b/apps/website/docs/react/api/shorthands.md
@@ -1,0 +1,176 @@
+---
+sidebar_position: 3
+---
+
+# shorthands
+
+`shorthands` provides a set of functions to mimic [CSS shorthands](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties) and improve developer experience as [CSS shorthands are not supported](/react/guides/limitations#css-shorthands-are-not-supported) by Griffel. For example:
+
+```tsx
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    // ❌ This is not supported, TypeScript compiler will throw, styles will not be inserted to DOM
+    padding: '2px 4px 8px 16px',
+    // ✅ Use shorthand functions to avoid writting CSS longhands
+    ...shorthands.padding('2px', '4px', '8px', '16px'),
+  },
+});
+```
+
+:::caution
+
+The most of the functions follow syntax in matching CSS properties, but each value should a separate argument:
+
+```js
+// ❌ Will produce wrong results
+shorthands.padding('2px 4px');
+// ✅ Correct output
+shorthands.padding('2px', '4px');
+```
+
+:::
+
+Function in a `shorthand` set are pure, you can simply use `console.log` to better understand produced rules:
+
+```js
+console.log(padding('12px', '24px', '36px', '48px'));
+// ⬇️⬇️⬇️
+// {
+//  paddingBottom: '36px',
+//  paddingLeft: '48px',
+//  paddingRight: '24px',
+//  paddingTop: '12px',
+// }
+```
+
+### `shorthands.border`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.border('2px'),
+    ...shorthands.border('2px', 'solid'),
+    ...shorthands.border('2px', 'solid', 'red'),
+  },
+});
+```
+
+### `shorthands.borderBottom`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    // The same is true for "borderTop", "borderLeft" & "borderRight"
+    ...shorthands.borderBottom('2px'),
+    ...shorthands.borderBottom('2px', 'solid'),
+    ...shorthands.borderBottom('2px', 'solid', 'red'),
+  },
+});
+```
+
+### `shorthands.borderColor`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.borderColor('red'),
+    ...shorthands.borderColor('red', 'blue'),
+    ...shorthands.borderColor('red', 'blue', 'green'),
+    ...shorthands.borderColor('red', 'blue', 'green', 'yellow'),
+  },
+});
+```
+
+### `shorthands.borderStyle`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.borderStyle('solid'),
+    ...shorthands.borderStyle('solid', 'dashed'),
+    ...shorthands.borderStyle('solid', 'dashed', 'dotted'),
+    ...shorthands.borderStyle('solid', 'dashed', 'dotted', 'double'),
+  },
+});
+```
+
+### `shorthands.borderWidth`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.borderWidth('12px'),
+    ...shorthands.borderWidth('12px', '24px'),
+    ...shorthands.borderWidth('12px', '24px', '36px'),
+    ...shorthands.borderWidth('12px', '24px', '36px', '48px'),
+  },
+});
+```
+
+### `shorthands.gap`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.gap('12px'),
+    ...shorthands.gap('12px', '24px'),
+  },
+});
+```
+
+### `shorthands.margin`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.margin('12px'),
+    ...shorthands.margin('12px', '24px'),
+    ...shorthands.margin('12px', '24px', '36px'),
+    ...shorthands.margin('12px', '24px', '36px', '48px'),
+  },
+});
+```
+
+### `shorthands.overflow`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.overflow('visible'),
+    ...shorthands.overflow('visible', 'hidden'),
+  },
+});
+```
+
+### `shorthands.padding`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.padding('12px'),
+    ...shorthands.padding('12px', '24px'),
+    ...shorthands.padding('12px', '24px', '36px'),
+    ...shorthands.padding('12px', '24px', '36px', '48px'),
+  },
+});
+```

--- a/apps/website/docs/react/guides/atomic-css.md
+++ b/apps/website/docs/react/guides/atomic-css.md
@@ -3,3 +3,5 @@ sidebar_position: 1
 ---
 
 # Atomic CSS
+
+This page is not ready yet.

--- a/apps/website/docs/react/guides/build-time-transforms.md
+++ b/apps/website/docs/react/guides/build-time-transforms.md
@@ -3,3 +3,5 @@ sidebar_position: 3
 ---
 
 # Build time transforms
+
+This page is not ready yet.

--- a/apps/website/docs/react/guides/limitations.md
+++ b/apps/website/docs/react/guides/limitations.md
@@ -46,7 +46,7 @@ Griffel relies on [Atomic CSS](/react/guides/atomic-css) and produces atomic cla
 <div class="b c">Hello world!</div>
 ```
 
-- In "Case 1" both classes are applied to an element: it's wrong as result is **not deterministic** and depends on classes order in CSS definitions (i.e. [order of appearance](https://www.w3.org/TR/css-cascade-3/#cascade-order)), [demo on CodeSandbox](https://codesandbox.io/s/css-insertion-order-matters-mgt6y)
+- In "Case 1" both classes are applied to an element: it's wrong as result is **nondeterministic** and depends on classes order in CSS definitions (i.e. [order of appearance](https://www.w3.org/TR/css-cascade-3/#cascade-order)), [demo on CodeSandbox](https://codesandbox.io/s/css-insertion-order-matters-mgt6y)
 - In "Case 2" only single classname per CSS property is applied, result will be deterministic
 
 This problem is solved by [`mergeClasses()`](https://github.com/microsoft/griffel/blob/main/packages/core/src/mergeClasses.ts) function: it de-duplicates classes based on property name.
@@ -81,10 +81,10 @@ const useClasses2 = makeStyles({
 
 :::caution
 
-In this example the problem is the same: both classes will be applied, result depends on order of appearance.
+In this example the problem is the same: both classes will be applied, result depends on the order of appearance.
 
 :::
 
-There is an option to expand CSS shorthands to longhands, but it's not reliable and does not with static rules i.e. you can't expand rules with CSS variables without knowing their value. The single predictable solution is disallow usage of CSS shorthands.
+There is an option to expand CSS shorthands to longhands, but it's not reliable and does not work with static rules i.e. you can't expand rules with CSS variables without knowing their value. The single predictable solution is to disallow the usage of CSS shorthands.
 
 You can get more information on the original RFC, [microsoft/fluentui#20573](https://github.com/microsoft/fluentui/pull/20573).

--- a/apps/website/docs/react/guides/limitations.md
+++ b/apps/website/docs/react/guides/limitations.md
@@ -3,3 +3,88 @@ sidebar_position: 2
 ---
 
 # Limitations
+
+## CSS shorthands are not supported
+
+There are [shorthand and longhand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties) in CSS. Shorthand properties allow to define a set of longhand properties. For example:
+
+```css
+/* Define with multiple properties */
+.longhand-rule {
+  padding-top: 2px;
+  padding-right: 4px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+}
+
+/* Define with a single property */
+.shorthand-rule {
+  padding: 2px 4px 8px 16px;
+}
+```
+
+Griffel relies on [Atomic CSS](/react/guides/atomic-css) and produces atomic classes:
+
+```css
+/* 💡 makeStyles() generates hashed classes, but it's not important in this example */
+.a {
+  background-color: red;
+}
+.b {
+  background-color: green;
+}
+.c {
+  color: yellow;
+}
+```
+
+```html
+<!-- Case 1: ❌ Wrong usage -->
+<div class="a b c">Hello world!</div>
+<!-- Case 2: ✅ Correct usage -->
+<div class="a c">Hello world!</div>
+<div class="b c">Hello world!</div>
+```
+
+- In "Case 1" both classes are applied to an element: it's wrong as result is **not deterministic** and depends on classes order in CSS definitions (i.e. [order of appearance](https://www.w3.org/TR/css-cascade-3/#cascade-order)), [demo on CodeSandbox](https://codesandbox.io/s/css-insertion-order-matters-mgt6y)
+- In "Case 2" only single classname per CSS property is applied, result will be deterministic
+
+This problem is solved by [`mergeClasses()`](https://github.com/microsoft/griffel/blob/main/packages/core/src/mergeClasses.ts) function: it de-duplicates classes based on property name.
+
+```jsx
+// ⚠ Simplified example
+function App() {
+  //                     👇 skips "a", returns only "b c"
+  return <div className={mergeClasses('a', 'b', 'c')}>Hello world</div>;
+}
+```
+
+> Only non colliding properties should be applied to DOM elements with Atomic CSS.
+
+This works well for longhands, but there are cases when longhands and shorthands are combined:
+
+```js
+// ⚠ Not real code
+const useClasses1 = makeStyles({
+  root: {
+    backgroundColor: 'red',
+    background: 'green',
+  },
+});
+const useClasses2 = makeStyles({
+  root: {
+    background: 'green',
+    backgroundColor: 'red',
+  },
+});
+```
+
+:::caution
+
+In this example the problem is the same: both classes will be applied, result depends on order of appearance.
+
+:::
+
+There is an option to expand CSS shorthands to longhands, but it's not reliable and does not with static rules i.e. you can't expand rules with CSS variables without knowing their value. The single predictable solution is disallow usage of CSS shorthands.
+
+You can get more information on the original RFC, [microsoft/fluentui#20573](https://github.com/microsoft/fluentui/pull/20573).

--- a/apps/website/docs/react/guides/limitations.md
+++ b/apps/website/docs/react/guides/limitations.md
@@ -87,4 +87,4 @@ In this example the problem is the same: both classes will be applied, result de
 
 There is an option to expand CSS shorthands to longhands, but it's not reliable and does not work with static rules i.e. you can't expand rules with CSS variables without knowing their value. The single predictable solution is to disallow the usage of CSS shorthands.
 
-You can get more information on the original RFC, [microsoft/fluentui#20573](https://github.com/microsoft/fluentui/pull/20573).
+You can get more information on the original RFC, [microsoft/fluentui#20573](https://github.com/microsoft/fluentui/pull/20573). For this reason Griffel disallows CSS shorthand properties in the input style object. Instead of shorthand properties, use [shorthands helper functions](/react/api/shorthands) which do the shorthand to longhand expansion statically.

--- a/apps/website/docs/react/guides/ssr-usage.md
+++ b/apps/website/docs/react/guides/ssr-usage.md
@@ -21,12 +21,14 @@ A complete demo project is available on [CodeSandbox](https://codesandbox.io/s/n
 
 1. Create a `_document.js` file under your `pages` folder with the following content:
 
-```tsx
+```jsx
+// highlight-next-line
 import { createDOMRenderer, renderToStyleElements } from '@griffel/react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
+    // highlight-start
     // 👇 creates a renderer
     const renderer = createDOMRenderer();
     const originalRenderPage = ctx.renderPage;
@@ -35,8 +37,10 @@ class MyDocument extends Document {
       originalRenderPage({
         enhanceApp: App => props => <App {...props} renderer={renderer} />,
       });
+    // highlight-end
 
     const initialProps = await Document.getInitialProps(ctx);
+    // highlight-start
     const styles = renderToStyleElements(renderer);
 
     return {
@@ -44,6 +48,7 @@ class MyDocument extends Document {
       // 👇 adding our styles elements to output
       styles: [...initialProps.styles, ...styles],
     };
+    // highlight-end
   }
 
   render() {

--- a/change/@griffel-core-cbfaaa86-8f9f-4b6d-bbbc-97a91bc628f3.json
+++ b/change/@griffel-core-cbfaaa86-8f9f-4b6d-bbbc-97a91bc628f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "README update",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-react-bdfe2a55-bc15-43bf-8c29-e63d7ac1b1d5.json
+++ b/change/@griffel-react-bdfe2a55-bc15-43bf-8c29-e63d7ac1b1d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "README update",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,3 +1,3 @@
 # `@griffel/core`
 
-DOM implementation of Griffel.
+DOM implementation of Griffel. Do not use this package directly, please use [`@griffel/react`](../react) instead.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -70,6 +70,140 @@ function Component() {
 }
 ```
 
+## `shorthands`
+
+`shorthands` provides a set of functions to mimic [CSS shorthands](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties) and improve developer experience as [CSS shorthands are not supported](https://griffel.js.org/react/guides/limitations#css-shorthands-are-not-supported) by Griffel.
+
+### `shorthands.border`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.border('2px'),
+    ...shorthands.border('2px', 'solid'),
+    ...shorthands.border('2px', 'solid', 'red'),
+  },
+});
+```
+
+### `shorthands.borderBottom`, `shorthands.borderTop`, `shorthands.borderLeft`, `shorthands.borderRight`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    // The same is true for "borderTop", "borderLeft" & "borderRight"
+    ...shorthands.borderBottom('2px'),
+    ...shorthands.borderBottom('2px', 'solid'),
+    ...shorthands.borderBottom('2px', 'solid', 'red'),
+  },
+});
+```
+
+### `shorthands.borderColor`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.borderColor('red'),
+    ...shorthands.borderColor('red', 'blue'),
+    ...shorthands.borderColor('red', 'blue', 'green'),
+    ...shorthands.borderColor('red', 'blue', 'green', 'yellow'),
+  },
+});
+```
+
+### `shorthands.borderStyle`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.borderStyle('solid'),
+    ...shorthands.borderStyle('solid', 'dashed'),
+    ...shorthands.borderStyle('solid', 'dashed', 'dotted'),
+    ...shorthands.borderStyle('solid', 'dashed', 'dotted', 'double'),
+  },
+});
+```
+
+### `shorthands.borderWidth`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.borderWidth('12px'),
+    ...shorthands.borderWidth('12px', '24px'),
+    ...shorthands.borderWidth('12px', '24px', '36px'),
+    ...shorthands.borderWidth('12px', '24px', '36px', '48px'),
+  },
+});
+```
+
+### `shorthands.gap`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.gap('12px'),
+    ...shorthands.gap('12px', '24px'),
+  },
+});
+```
+
+### `shorthands.margin`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.margin('12px'),
+    ...shorthands.margin('12px', '24px'),
+    ...shorthands.margin('12px', '24px', '36px'),
+    ...shorthands.margin('12px', '24px', '36px', '48px'),
+  },
+});
+```
+
+### `shorthands.overflow`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.overflow('visible'),
+    ...shorthands.overflow('visible', 'hidden'),
+  },
+});
+```
+
+### `shorthands.padding`
+
+```js
+import { makeStyles, shorthands } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    ...shorthands.padding('12px'),
+    ...shorthands.padding('12px', '24px'),
+    ...shorthands.padding('12px', '24px', '36px'),
+    ...shorthands.padding('12px', '24px', '36px', '48px'),
+  },
+});
+```
+
 ## `makeStaticStyles()`
 
 Creates styles attached to a global selector. Styles can be defined via objects:


### PR DESCRIPTION
Fixes #30.

This PR:
- adds new page to website about `shorthands` & section to README
- adds limitations page that describes why CSS shorthands are forbidden
- minor improvements