### PR TITLE
Fix transform plugin so it can handle more than one matched import sources

### DIFF
--- a/change/@griffel-babel-preset-41b92af0-6e5b-4e53-b341-0bd5b8407b76.json
+++ b/change/@griffel-babel-preset-41b92af0-6e5b-4e53-b341-0bd5b8407b76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix makeStyles transform plugin so it can handle duplicated import sources",
+  "packageName": "@griffel/babel-preset",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-babel-preset-41b92af0-6e5b-4e53-b341-0bd5b8407b76.json
+++ b/change/@griffel-babel-preset-41b92af0-6e5b-4e53-b341-0bd5b8407b76.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix makeStyles transform plugin so it can handle duplicated import sources",
+  "comment": "fix: handle duplicated import sources properly",
   "packageName": "@griffel/babel-preset",
   "email": "rezha@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
@@ -1,9 +1,11 @@
 import { dupImport1 } from 'custom-package';
 import { createStyles } from 'custom-package';
-import { dupImport2 } from 'custom-package';
+import { dupImport2 } from 'another-custom-package';
+import { otherImport } from 'another-package';
 
 dupImport1;
 dupImport2;
+otherImport;
 
 export const useStyles = createStyles({
   root: { color: 'red' },

--- a/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
@@ -1,24 +1,12 @@
 // @ts-expect-error This module does not exist, but will be resolved via aliases
 import { createStylesA } from 'custom-package';
 // @ts-expect-error This module does not exist, but will be resolved via aliases
-import { createStyles } from 'custom-package';
-// @ts-expect-error This module does not exist, but will be resolved via aliases
-import { createStylesB } from 'another-custom-package';
-// @ts-expect-error This module does not exist, but will be resolved via aliases
-import { createStylesC } from 'another-package';
+import { createStylesB } from 'custom-package';
 
-export const useStyles = createStyles({
+export const useClassesA = createStylesA({
   root: { color: 'red' },
 });
 
-export const useClassesA = createStylesA({
-  root: { color: 'yellow' },
-});
-
 export const useClassesB = createStylesB({
-  root: { color: 'blue' },
-});
-
-export const useClassesC = createStylesC({
-  root: { color: 'orange' },
+  root: { color: 'yellow' },
 });

--- a/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
@@ -1,0 +1,10 @@
+import { dupImport1 } from 'custom-package';
+import { createStyles } from 'custom-package';
+import { dupImport2 } from 'custom-package';
+
+dupImport1;
+dupImport2;
+
+export const useStyles = createStyles({
+  root: { color: 'red' },
+});

--- a/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
@@ -1,12 +1,20 @@
-import { dupImport1 } from 'custom-package';
+import { createStylesA } from 'custom-package';
 import { createStyles } from 'custom-package';
-import { dupImport2 } from 'another-custom-package';
-import { otherImport } from 'another-package';
-
-dupImport1;
-dupImport2;
-otherImport;
+import { createStylesB } from 'another-custom-package';
+import { createStylesC } from 'another-package';
 
 export const useStyles = createStyles({
   root: { color: 'red' },
+});
+
+export const useClassesA = createStylesA({
+  root: { color: 'yellow' },
+});
+
+export const useClassesB = createStylesB({
+  root: { color: 'blue' },
+});
+
+export const useClassesC = createStylesC({
+  root: { color: 'orange' },
 });

--- a/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/code.ts
@@ -1,6 +1,10 @@
+// @ts-expect-error This module does not exist, but will be resolved via aliases
 import { createStylesA } from 'custom-package';
+// @ts-expect-error This module does not exist, but will be resolved via aliases
 import { createStyles } from 'custom-package';
+// @ts-expect-error This module does not exist, but will be resolved via aliases
 import { createStylesB } from 'another-custom-package';
+// @ts-expect-error This module does not exist, but will be resolved via aliases
 import { createStylesC } from 'another-package';
 
 export const useStyles = createStyles({

--- a/packages/babel-preset/__fixtures__/duplicated-imports/options.json
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/options.json
@@ -1,0 +1,3 @@
+{
+  "modules": [{ "moduleSource": "custom-package", "importName": "createStyles" }]
+}

--- a/packages/babel-preset/__fixtures__/duplicated-imports/options.json
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/options.json
@@ -1,6 +1,3 @@
 {
-  "modules": [
-    { "moduleSource": "custom-package", "importName": "createStyles" },
-    { "moduleSource": "another-custom-package", "importName": "createMyStyles" }
-  ]
+  "modules": [{ "moduleSource": "custom-package", "importName": "createStylesA" }]
 }

--- a/packages/babel-preset/__fixtures__/duplicated-imports/options.json
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/options.json
@@ -1,3 +1,6 @@
 {
-  "modules": [{ "moduleSource": "custom-package", "importName": "createStyles" }]
+  "modules": [
+    { "moduleSource": "custom-package", "importName": "createStyles" },
+    { "moduleSource": "another-custom-package", "importName": "createMyStyles" }
+  ]
 }

--- a/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
@@ -1,8 +1,10 @@
 import { dupImport1 } from 'custom-package';
 import { __styles } from 'custom-package';
-import { dupImport2 } from 'custom-package';
+import { dupImport2 } from 'another-custom-package';
+import { otherImport } from 'another-package';
 dupImport1;
 dupImport2;
+otherImport;
 export const useStyles = __styles(
   {
     root: {

--- a/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
@@ -1,10 +1,7 @@
-import { dupImport1 } from 'custom-package';
+import { createStylesA } from 'custom-package';
 import { __styles } from 'custom-package';
-import { dupImport2 } from 'another-custom-package';
-import { otherImport } from 'another-package';
-dupImport1;
-dupImport2;
-otherImport;
+import { createStylesB } from 'another-custom-package';
+import { createStylesC } from 'another-package';
 export const useStyles = __styles(
   {
     root: {
@@ -15,3 +12,18 @@ export const useStyles = __styles(
     d: ['.fe3e8s9{color:red;}'],
   },
 );
+export const useClassesA = createStylesA({
+  root: {
+    color: 'yellow',
+  },
+});
+export const useClassesB = createStylesB({
+  root: {
+    color: 'blue',
+  },
+});
+export const useClassesC = createStylesC({
+  root: {
+    color: 'orange',
+  },
+});

--- a/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
@@ -1,12 +1,8 @@
 // @ts-expect-error This module does not exist, but will be resolved via aliases
-import { createStylesA } from 'custom-package'; // @ts-expect-error This module does not exist, but will be resolved via aliases
-
 import { __styles } from 'custom-package'; // @ts-expect-error This module does not exist, but will be resolved via aliases
 
-import { createStylesB } from 'another-custom-package'; // @ts-expect-error This module does not exist, but will be resolved via aliases
-
-import { createStylesC } from 'another-package';
-export const useStyles = __styles(
+import { createStylesB } from 'custom-package';
+export const useClassesA = __styles(
   {
     root: {
       sj55zd: 'fe3e8s9',
@@ -16,18 +12,8 @@ export const useStyles = __styles(
     d: ['.fe3e8s9{color:red;}'],
   },
 );
-export const useClassesA = createStylesA({
-  root: {
-    color: 'yellow',
-  },
-});
 export const useClassesB = createStylesB({
   root: {
-    color: 'blue',
-  },
-});
-export const useClassesC = createStylesC({
-  root: {
-    color: 'orange',
+    color: 'yellow',
   },
 });

--- a/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
@@ -1,0 +1,15 @@
+import { dupImport1 } from 'custom-package';
+import { __styles } from 'custom-package';
+import { dupImport2 } from 'custom-package';
+dupImport1;
+dupImport2;
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
+++ b/packages/babel-preset/__fixtures__/duplicated-imports/output.ts
@@ -1,6 +1,10 @@
-import { createStylesA } from 'custom-package';
-import { __styles } from 'custom-package';
-import { createStylesB } from 'another-custom-package';
+// @ts-expect-error This module does not exist, but will be resolved via aliases
+import { createStylesA } from 'custom-package'; // @ts-expect-error This module does not exist, but will be resolved via aliases
+
+import { __styles } from 'custom-package'; // @ts-expect-error This module does not exist, but will be resolved via aliases
+
+import { createStylesB } from 'another-custom-package'; // @ts-expect-error This module does not exist, but will be resolved via aliases
+
 import { createStylesC } from 'another-package';
 export const useStyles = __styles(
   {


### PR DESCRIPTION
Currently, the transform plugin only keeps tab of the last import statement where the package name (`moduleSource`) is a match. For example, in:

```javascript
import { dupImport1 } from 'custom-package';
import { createStyles } from 'custom-package';
import { dupImport2 } from 'another-custom-package';
import { otherImport } from 'another-package';
```

with config:
```javascript
{
  "modules": [
    { "moduleSource": "custom-package", "importName": "createStyles" },
    { "moduleSource": "another-custom-package", "importName": "createMyStyles" }
  ]
}
```

The plugin will only focus on the 3rd import line (`import { dupImport2 } from 'another-custom-package';`) and then decide that there's no placement needed, thus missing the 2nd import where `createStyles` actually exists.

This PR fixes this issue by changing the `importDeclarationPath` into an `importDeclarationPaths` array, so we don't miss any imports to replace.