### PR TITLE
feat(Devtools): enable it via content_scripts

### DIFF
--- a/change/@griffel-core-8e16f578-f749-4f26-9899-b90b14811104.json
+++ b/change/@griffel-core-8e16f578-f749-4f26-9899-b90b14811104.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Inject devtools when session storage contains __GRIFFEL_DEVTOOLS__",
+  "packageName": "@griffel/core",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,5 +6,4 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/packages/core',
-  globals: { window: {} },
 };

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/packages/core',
+  globals: { window: {} },
 };

--- a/packages/core/src/devtools/isDevToolsEnabled.ts
+++ b/packages/core/src/devtools/isDevToolsEnabled.ts
@@ -1,1 +1,3 @@
-export const isDevToolsEnabled = window?.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__');
+export const isDevToolsEnabled = Boolean(
+  typeof window !== 'undefined' && window?.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__'),
+);

--- a/packages/core/src/devtools/isDevToolsEnabled.ts
+++ b/packages/core/src/devtools/isDevToolsEnabled.ts
@@ -1,1 +1,1 @@
-export const isDevToolsEnabled = window.sessionStorage.getItem('__GRIFFEL_DEVTOOLS__');
+export const isDevToolsEnabled = window?.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__');

--- a/packages/core/src/devtools/isDevToolsEnabled.ts
+++ b/packages/core/src/devtools/isDevToolsEnabled.ts
@@ -1,1 +1,1 @@
-export const isDevToolsEnabled = false;
+export const isDevToolsEnabled = window.sessionStorage.getItem('__GRIFFEL_DEVTOOLS__');

--- a/packages/devtools/public/content-script.js
+++ b/packages/devtools/public/content-script.js
@@ -1,0 +1,1 @@
+window.sessionStorage.setItem('__GRIFFEL_DEVTOOLS__', 'enabled');

--- a/packages/devtools/public/manifest.json
+++ b/packages/devtools/public/manifest.json
@@ -3,5 +3,13 @@
   "manifest_version": 3,
   "name": "griffel-devtools",
   "version": "1.0",
-  "devtools_page": "devtools-page.html"
+  "devtools_page": "devtools-page.html",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "all_frames": true,
+      "run_at": "document_start"
+    }
+  ]
 }


### PR DESCRIPTION
When griffel devtools start, content-script.js will run and add `__GRIFFEL_DEVTOOLS__` as `enabled` in sessionStorage.
Griffel core can use it to determine if devtools should be injected.

Reason for `sessionStorage`: content script runs in an isolated world. Changes like `document.XXX = yyy` in content script will not be reflected on the page (page will still have `document.XXX = undefined`)