### PR TITLE
Fix: Multiple selectors and RTL flipping

### DIFF
--- a/change/@griffel-core-94a0ec59-abfa-4d0f-a8a8-843026c57848.json
+++ b/change/@griffel-core-94a0ec59-abfa-4d0f-a8a8-843026c57848.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix issue with comma-separated selectors and RTL",
+  "packageName": "@griffel/core",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/compileCSS.ts
+++ b/packages/core/src/runtime/compileCSS.ts
@@ -102,7 +102,7 @@ export function compileCSS(options: CompileCSSOptions): [string /* ltr definitio
     cssRule = `${classNameSelector}{${normalizedPseudo} ${cssDeclaration}};`;
 
     if (rtlProperty) {
-      cssRule = `${cssRule}; ${rtlClassNameSelector}${normalizedPseudo} ${rtlCSSDeclaration};`;
+      cssRule = `${cssRule}; ${rtlClassNameSelector}{${normalizedPseudo} ${rtlCSSDeclaration}};`;
     }
   }
 

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -327,6 +327,25 @@ describe('resolveStyleRules', () => {
       `);
     });
 
+    it('handles comma-separated selectors', () => {
+      expect(
+        resolveStyleRules({
+          ':active,:focus-within': {
+            paddingLeft: '10px',
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        .f14f5aie:active,
+        .f14f5aie:focus-within {
+          padding-left: 10px;
+        }
+        .f1sheuf0:active,
+        .f1sheuf0:focus-within {
+          padding-right: 10px;
+        }
+      `);
+    });
+
     it('handles media queries', () => {
       expect(
         resolveStyleRules({


### PR DESCRIPTION
Fixes #105 

## Current Behavior

When writing styles with multiple selectors and rules that will be flipped for RTL only the first selector is properly scoped to the generated class name.

```js
import { makeStyles } from '@griffel/core';

export default makeStyles({
  root: {
    ':active,:focus-within': {
      paddingLeft: '10px'
    }
  },
});
```

Generates

```
.f14f5aie:active,
.f14f5aie:focus-within {
  padding-left: 10px;
}

.f1sheuf0:active,
// 💣💥`:focus-with` rule applies globally! 😱
:focus-within {
  padding-right: 10px;
}
```

## New Behavior

```js
import { makeStyles } from '@griffel/core';

export default makeStyles({
  root: {
    ':active,:focus-within': {
      paddingLeft: '10px'
    }
  },
});
```

Generates

```
.f14f5aie:active,
.f14f5aie:focus-within {
  padding-left: 10px;
}

.f1sheuf0:active,
// `:focus-within` is properly scoped 👍👍
.f1sheuf0:focus-within {
  padding-right: 10px;
}
```
