### PR TITLE
feat(devtools): Add triangle right indicator for collapsed slot

### DIFF
--- a/packages/devtools/src/SlotCSSRules.tsx
+++ b/packages/devtools/src/SlotCSSRules.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 
 import { getMonolithicCSSRules } from './getMonolithicCSSRules';
 import { MonolithicRulesView } from './MonolithicRulesView';
@@ -16,6 +16,19 @@ const useStyles = makeStyles({
     ...shorthands.borderBottom('1px', 'solid', tokens.slotNameBorder),
     backgroundColor: tokens.slotNameBackground,
   },
+  slotNameCollapsed: {
+    ':before': {
+      content: "''",
+      width: 0,
+      height: 0,
+      fontSize: 0,
+      verticalAlign: 'text-top',
+      ...shorthands.borderTop('3px', 'solid', 'transparent'),
+      ...shorthands.borderRight('3px', 'solid', 'transparent'),
+      ...shorthands.borderBottom('3px', 'solid', 'transparent'),
+      ...shorthands.borderLeft('3px', 'solid', tokens.foreground),
+    },
+  },
   rules: {
     ...shorthands.padding(0, '5px'),
   },
@@ -23,17 +36,19 @@ const useStyles = makeStyles({
 
 export const SlotCSSRules: React.FC<{ slot: string; atomicRules: AtomicRules[] }> = ({ slot, atomicRules }) => {
   const rules = React.useMemo(() => getMonolithicCSSRules(atomicRules), [atomicRules]);
-  const classes = useStyles();
 
   const [expanded, setExpanded] = React.useState(true);
   const toggleExpanded = () => setExpanded(v => !v);
+
+  const classes = useStyles();
+  const slotClassName = mergeClasses(classes.slotName, !expanded && classes.slotNameCollapsed);
 
   const { setHighlightedClass } = useViewContext();
   const undoHighlight = () => setHighlightedClass('');
 
   return (
     <div>
-      <pre className={classes.slotName} onClick={toggleExpanded}>
+      <pre className={slotClassName} onClick={toggleExpanded}>
         {slot}
       </pre>
       {expanded && (

--- a/packages/devtools/src/SlotCSSRules.tsx
+++ b/packages/devtools/src/SlotCSSRules.tsx
@@ -10,23 +10,33 @@ import type { AtomicRules } from './types';
 
 const useStyles = makeStyles({
   slotName: {
+    display: 'flex',
+    alignItems: 'center',
+    position: 'relative',
+
     cursor: 'pointer',
     ...shorthands.padding('2px', '5px'),
     ...shorthands.borderTop('1px', 'solid', tokens.slotNameBorder),
     ...shorthands.borderBottom('1px', 'solid', tokens.slotNameBorder),
     backgroundColor: tokens.slotNameBackground,
-  },
-  slotNameCollapsed: {
+
     ':before': {
       content: "''",
+      position: 'absolute',
+      right: '5px',
       width: 0,
       height: 0,
       fontSize: 0,
-      verticalAlign: 'text-top',
-      ...shorthands.borderTop('3px', 'solid', 'transparent'),
+      ...shorthands.borderTop('3px', 'solid', tokens.foreground),
       ...shorthands.borderRight('3px', 'solid', 'transparent'),
+      ...shorthands.borderLeft('3px', 'solid', 'transparent'),
       ...shorthands.borderBottom('3px', 'solid', 'transparent'),
-      ...shorthands.borderLeft('3px', 'solid', tokens.foreground),
+    },
+  },
+  slotNameCollapsed: {
+    ':before': {
+      ...shorthands.borderTop('3px', 'solid', 'transparent'),
+      ...shorthands.borderRight('3px', 'solid', tokens.foreground),
     },
   },
   rules: {


### PR DESCRIPTION
When click on slotName to expand/collapse styles within, show triangle indicator:

<img width="413" alt="Screenshot 2022-05-04 at 14 58 39" src="https://user-images.githubusercontent.com/28751745/166686116-c4a0e82d-df06-4ceb-a6a1-8ae932dec660.png">

<img width="421" alt="Screenshot 2022-05-04 at 14 58 27" src="https://user-images.githubusercontent.com/28751745/166686153-8d887f17-1672-49ba-9e13-967a8c7aa61c.png">
