### PR TITLE
fix: update isInsideComponent() check

### DIFF
--- a/change/@griffel-react-e94080df-e358-4de3-83bf-f02d976143ac.json
+++ b/change/@griffel-react-e94080df-e358-4de3-83bf-f02d976143ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update isInsideComponent() check",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/makeStyles.ts
+++ b/packages/react/src/makeStyles.ts
@@ -8,11 +8,19 @@ import { useTextDirection } from './TextDirectionContext';
 function isInsideComponent() {
   // React 18 always logs errors if a dispatcher is not present:
   // https://github.com/facebook/react/blob/42f15b324f50d0fd98322c21646ac3013e30344a/packages/react/src/ReactHooks.js#L26-L36
-  //
-  // A check with hooks call (i.e. call "React.useContext()" outside a component) will always produce errors
   try {
     // @ts-expect-error "SECRET_INTERNALS" are not typed
-    return !!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher.current;
+    const dispatcher = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher.current;
+
+    // Before any React component was rendered "dispatcher" will be "null"
+    if (dispatcher === null) {
+      return false;
+    }
+
+    // A check with hooks call (i.e. call "React.useContext()" outside a component) will always produce errors, but
+    // a call on the dispatcher don't
+    dispatcher.useContext({});
+    return true;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Follow up for #95.

---

There was misunderstanding from my side on how React works. PR was updated based on debugging: 

- `.ReactCurrentDispatcher.current` is `null` only before actual rendering of any React components
- before/after rendering it's [`ContextOnlyDispatcher`](https://github.com/facebook/react/blob/c7e494b55320768863b821be96896b28f0a280ef/packages/react-reconciler/src/ReactFiberHooks.new.js#L2427-L2448) (the same behavior as `React.useContext`)
- during render it's [`HooksDispatcherOnRerender`](https://github.com/facebook/react/blob/c7e494b55320768863b821be96896b28f0a280ef/packages/react-reconciler/src/ReactFiberHooks.new.js#L2510-L2531) or [`HooksDispatcherOnMount`](https://github.com/facebook/react/blob/c7e494b55320768863b821be96896b28f0a280ef/packages/react-reconciler/src/ReactFiberHooks.new.js#L2455-L2476)