### PR TITLE
fix: update isDevToolsEnabled check

### DIFF
--- a/change/@griffel-core-fc0dd800-dab6-437c-8222-72f89351fdf8.json
+++ b/change/@griffel-core-fc0dd800-dab6-437c-8222-72f89351fdf8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update isDevToolsEnabled check",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/devtools/isDevToolsEnabled.ts
+++ b/packages/core/src/devtools/isDevToolsEnabled.ts
@@ -1,8 +1,8 @@
-export const isDevToolsEnabled: Boolean = (() => {
+export const isDevToolsEnabled: boolean = (() => {
   // Accessing "window.sessionStorage" causes an exception when third party cookies are blocked
   // https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni
   try {
-    return Boolean(typeof window !== 'undefined' && window?.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__'));
+    return Boolean(typeof window !== 'undefined' && window.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__'));
   } catch (e) {
     return false;
   }

--- a/packages/core/src/devtools/isDevToolsEnabled.ts
+++ b/packages/core/src/devtools/isDevToolsEnabled.ts
@@ -1,3 +1,9 @@
-export const isDevToolsEnabled = Boolean(
-  typeof window !== 'undefined' && window?.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__'),
-);
+export const isDevToolsEnabled: Boolean = (() => {
+  // Accessing "window.sessionStorage" causes an exception when third party cookies are blocked
+  // https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni
+  try {
+    return Boolean(typeof window !== 'undefined' && window?.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__'));
+  } catch (e) {
+    return false;
+  }
+})();


### PR DESCRIPTION
There are two issues with the existing check:
- it's not properly tree shaken with `webpack@4` & `terser-webpack-plugin@4`
  ![image](https://user-images.githubusercontent.com/14183168/168762144-11663716-3d5f-4345-83a6-607030497c6f.png)
- it throws in incognito mode & with blocked third party cookies
  ```
  Uncaught DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.
      at http://192.168.0.150:3000/iframe:18:28
      at http://192.168.0.150:3000/iframe:25:9
  ```
