### PR TITLE
feat: export useRenderer_unstable

### DIFF
--- a/change/@griffel-react-1edea5c5-031f-429a-b073-dbb1396fdb96.json
+++ b/change/@griffel-react-1edea5c5-031f-429a-b073-dbb1396fdb96.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export useRenderer_unstable",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/RendererContext.tsx
+++ b/packages/react/src/RendererContext.tsx
@@ -45,7 +45,7 @@ export const RendererProvider: React.FC<RendererProviderProps> = ({ children, re
 /**
  * Returns an instance of current makeStyles() renderer.
  *
- * @private
+ * @private Exported as "useRenderer_unstable" use it on own risk. Can be changed or removed without a notice.
  */
 export function useRenderer(): GriffelRenderer {
   return React.useContext(RendererContext);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,7 +5,7 @@ export { makeStyles } from './makeStyles';
 export { makeStaticStyles } from './makeStaticStyles';
 export { renderToStyleElements } from './renderToStyleElements';
 
-export { RendererProvider } from './RendererContext';
+export { RendererProvider, useRenderer as useRenderer_unstable } from './RendererContext';
 export { TextDirectionProvider } from './TextDirectionContext';
 
 // Private exports, are used by build time transforms


### PR DESCRIPTION
This PR exports `useRenderer_unstable`, current instance of `GriffelRenderer` can be obtained from it.

⚠️ **It's unstable & undocumented API, use it on own risk.**