### PR TITLE
feat: adds devcontainer for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG VARIANT="18-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Griffel Container",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "18-bullseye"
+    }
+  },
+  "settings": {},
+  "extensions": [
+    "nrwl.angular-console",
+    "esbenp.prettier-vscode",
+    "firsttris.vscode-jest-runner",
+    "dbaeumer.vscode-eslint"
+  ],
+  "remoteUser": "node"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ node_modules
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+*.code-workspace
 
 # misc
 .docusaurus


### PR DESCRIPTION
## What's new

Adds `devcontainer` base configuration file to allow [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers) with Docker at vscode.

## Todo

Might need to add extra configuration on Dockerfile to ensure e2e tests with cypress