### PR TITLE
fix(devtools): collect devtools data in __styles.ts

### DIFF
--- a/packages/core/src/__styles.ts
+++ b/packages/core/src/__styles.ts
@@ -1,3 +1,4 @@
+import { debugData, isDevToolsEnabled } from './devtools';
 import { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
 import { MakeStylesOptions, CSSClassesMapBySlot, CSSRulesByBucket } from './types';
 
@@ -37,7 +38,15 @@ export function __styles<Slots extends string>(
       insertionCache[rendererId] = true;
     }
 
-    return isLTR ? (ltrClassNamesForSlots as Record<Slots, string>) : (rtlClassNamesForSlots as Record<Slots, string>);
+    const classNamesForSlots = isLTR
+      ? (ltrClassNamesForSlots as Record<Slots, string>)
+      : (rtlClassNamesForSlots as Record<Slots, string>);
+
+    if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+      debugData.addSequenceDetails(classNamesForSlots!);
+    }
+
+    return classNamesForSlots;
   }
 
   return computeClasses;


### PR DESCRIPTION
When griffel webpack loader is used, classNames are pre-computed, and __styles.ts is used in runtime instead of makeStyles.ts.
Devtools collect information on classNames and slots in each makeStyles call. This was done in makeStyles.ts, but needs to be done for __styles.ts  as well, otherwise devtools will not show blank