### PR TITLE
feat: add Babel plugin for CSS extraction

### DIFF
--- a/packages/webpack-extraction-plugin/__fixtures__/babel/basic/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/basic/code.ts
@@ -1,0 +1,22 @@
+import { __styles } from '@griffel/react';
+
+export const styles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+    icon: {
+      De3pzq: 'fcnqdeg',
+      Bi91k9c: 'faf35ka',
+    },
+  },
+  {
+    d: [
+      '.fe3e8s9{color:red;}',
+      '.fycuoez{padding-left:4px;}',
+      '.f8wuabp{padding-right:4px;}',
+      '.fcnqdeg{background-color:green;}',
+    ],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
@@ -1,0 +1,11 @@
+import { __styles, __css } from '@griffel/react';
+export const styles = __css({
+  root: {
+    sj55zd: 'fe3e8s9',
+    uwmqm3: ['fycuoez', 'f8wuabp'],
+  },
+  icon: {
+    De3pzq: 'fcnqdeg',
+    Bi91k9c: 'faf35ka',
+  },
+});

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/code.ts
@@ -1,0 +1,23 @@
+import { __styles } from '@griffel/react';
+
+export const stylesA = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+
+export const stylesB = __styles(
+  {
+    root: {
+      De3pzq: 'fcnqdeg',
+    },
+  },
+  {
+    d: ['.fcnqdeg{background-color:green;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
@@ -1,0 +1,11 @@
+import { __styles, __css } from '@griffel/react';
+export const stylesA = __css({
+  root: {
+    sj55zd: 'fe3e8s9',
+  },
+});
+export const stylesB = __css({
+  root: {
+    De3pzq: 'fcnqdeg',
+  },
+});

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -7,5 +7,13 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/griffel"
+  },
+  "dependencies": {
+    "@babel/core": "^7.12.13",
+    "@babel/helper-plugin-utils": "^7.12.13",
+    "tslib": "^2.1.0"
+  },
+  "peerDependencies": {
+    "@griffel/core": "^1.3.1"
   }
 }

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.test.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.test.ts
@@ -1,0 +1,36 @@
+import pluginTester, { prettierFormatter } from 'babel-plugin-tester';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { babelPluginStripGriffelRuntime } from './babelPluginStripGriffelRuntime';
+
+const prettierConfig = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../.prettierrc'), { encoding: 'utf-8' }),
+);
+const fixturesDir = path.join(__dirname, '..', '__fixtures__', 'babel');
+
+pluginTester({
+  babelOptions: {
+    parserOpts: {
+      plugins: ['typescript'],
+    },
+  },
+  pluginOptions: {
+    babelOptions: {
+      presets: ['@babel/typescript'],
+    },
+  },
+  formatResult: code =>
+    prettierFormatter(code, {
+      config: {
+        ...prettierConfig,
+        parser: 'typescript',
+      },
+    }),
+
+  fixtures: fixturesDir,
+  tests: [],
+
+  plugin: babelPluginStripGriffelRuntime,
+  pluginName: '@griffel/webpack-extraction-plugin/babel',
+});

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
@@ -79,6 +79,7 @@ export const babelPluginStripGriffelRuntime = declare<
                 );
               }
 
+              // Returns the styles as a JavaScript object
               const evaluationResult = argumentPaths[1].evaluate();
 
               if (!evaluationResult.confident) {

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
@@ -1,0 +1,106 @@
+import { NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
+import { declare } from '@babel/helper-plugin-utils';
+import type { CSSRulesByBucket } from '@griffel/core';
+
+type StripRuntimeBabelPluginOptions = never;
+
+type StripRuntimeBabelPluginState = PluginPass & {
+  cssRules?: string[];
+};
+
+export type StripRuntimeBabelPluginMetadata = {
+  cssRules: string[];
+};
+
+export const babelPluginStripGriffelRuntime = declare<
+  Partial<StripRuntimeBabelPluginOptions>,
+  PluginObj<StripRuntimeBabelPluginState>
+>(api => {
+  api.assertVersion(7);
+
+  return {
+    name: '@griffel/webpack-extraction-plugin/babel',
+    pre() {
+      this.cssRules = [];
+    },
+    post() {
+      (this.file.metadata as unknown as StripRuntimeBabelPluginMetadata).cssRules = this.cssRules!;
+    },
+
+    visitor: {
+      Program: {
+        exit(path, state) {
+          path.traverse({
+            ImportSpecifier(path) {
+              const importedPath = path.get('imported');
+
+              if (!importedPath.isIdentifier({ name: '__styles' })) {
+                return;
+              }
+
+              const declarationPath = path.findParent(p =>
+                p.isImportDeclaration(),
+              ) as NodePath<t.ImportDeclaration> | null;
+
+              if (declarationPath === null) {
+                throw path.buildCodeFrameError(
+                  [
+                    'Failed to find "ImportDeclaration" path for an "ImportSpecifier".',
+                    'Please report a bug (https://github.com/microsoft/griffel/issues) if this error happens',
+                  ].join(' '),
+                );
+              }
+
+              declarationPath.pushContainer('specifiers', t.identifier('__css'));
+            },
+
+            /**
+             * Visits all call expressions (__styles function calls):
+             * - replaces "__styles" calls "__css"
+             * - removes CSS rules from "__styles" calls
+             */
+            CallExpression(path) {
+              const calleePath = path.get('callee');
+
+              if (!calleePath.isIdentifier({ name: '__styles' })) {
+                return;
+              }
+
+              calleePath.replaceWith(t.identifier('__css'));
+
+              const argumentPaths = path.get('arguments');
+
+              if (argumentPaths.length !== 2) {
+                throw calleePath.buildCodeFrameError(
+                  [
+                    '"__styles" function call should have exactly two arguments.',
+                    'Please report a bug (https://github.com/microsoft/griffel/issues) if this error happens',
+                  ].join(' '),
+                );
+              }
+
+              const evaluationResult = argumentPaths[1].evaluate();
+
+              if (!evaluationResult.confident) {
+                throw argumentPaths[1].buildCodeFrameError(
+                  [
+                    'Failed to evaluate CSS rules from "__styles" call.',
+                    'Please report a bug (https://github.com/microsoft/griffel/issues) if this error happens',
+                  ].join(' '),
+                );
+              }
+
+              const cssRulesByBucket = evaluationResult.value as CSSRulesByBucket;
+
+              Object.values(cssRulesByBucket).forEach(cssRules => {
+                state.cssRules!.push(...cssRules);
+              });
+
+              argumentPaths[1].remove();
+            },
+          });
+        },
+      },
+    },
+  };
+});

--- a/packages/webpack-extraction-plugin/tsconfig.lib.json
+++ b/packages/webpack-extraction-plugin/tsconfig.lib.json
@@ -6,6 +6,6 @@
     "declaration": true,
     "types": ["node", "environment"]
   },
-  "exclude": ["__fixtures__/*/*.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "exclude": ["__fixtures__/**/*/*.ts", "**/*.spec.ts", "**/*.test.ts"],
   "include": ["**/*.ts"]
 }

--- a/packages/webpack-extraction-plugin/tsconfig.spec.json
+++ b/packages/webpack-extraction-plugin/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["jest", "node", "environment"]
   },
   "include": [
-    "__fixtures__/*/code.ts",
+    "__fixtures__/**/*/code.ts",
     "**/*.test.ts",
     "**/*.spec.ts",
     "**/*.test.tsx",


### PR DESCRIPTION
This PR implements the Babel plugin that will be used for CSS extraction.

This plugin replaces `__styles` with `__css` function and removes CSS rules from output:

```tsx
import { __styles } from '@griffel/react';

export const stylesA = __styles(
  {
    root: {
      sj55zd: 'fe3e8s9',
    },
  },
  {
    d: ['.fe3e8s9{color:red;}'],
  },
);

export const stylesB = __styles(
  {
    root: {
      De3pzq: 'fcnqdeg',
    },
  },
  {
    d: ['.fcnqdeg{background-color:green;}'],
  },
);

//
// ⬇️⬇️⬇️
//

import { __styles, __css } from '@griffel/react';

export const stylesA = __css({
  root: {
    sj55zd: 'fe3e8s9',
  },
});

export const stylesB = __css({
  root: {
    De3pzq: 'fcnqdeg',
  },
});
```

CSS rules are returned as part of `meta` informantion.

