### PR TITLE
feat: add Webpack plugin for CSS extraction

### DIFF
--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/code.ts
@@ -1,0 +1,24 @@
+import { __styles } from '@griffel/react';
+
+const styles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+    icon: {
+      De3pzq: 'fcnqdeg',
+      Bi91k9c: 'faf35ka',
+    },
+  },
+  {
+    d: [
+      '.fe3e8s9{color:red;}',
+      '.fycuoez{padding-left:4px;}',
+      '.f8wuabp{padding-right:4px;}',
+      '.fcnqdeg{background-color:green;}',
+    ],
+  },
+);
+
+console.log(styles);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -1,0 +1,16 @@
+import { __styles, __css } from '@griffel/react';
+
+const styles = __css({
+  root: {
+    sj55zd: 'fe3e8s9',
+    uwmqm3: ['fycuoez', 'f8wuabp'],
+  },
+  icon: {
+    De3pzq: 'fcnqdeg',
+    Bi91k9c: 'faf35ka',
+  },
+});
+
+console.log(styles);
+
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/code.ts
@@ -1,0 +1,23 @@
+import { __styles } from '@griffel/react';
+
+export const stylesA = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+
+export const stylesB = __styles(
+  {
+    root: {
+      De3pzq: 'fcnqdeg',
+    },
+  },
+  {
+    d: ['.fcnqdeg{background-color:green;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -1,0 +1,13 @@
+import { __styles, __css } from '@griffel/react';
+export const stylesA = __css({
+  root: {
+    sj55zd: 'fe3e8s9',
+  },
+});
+export const stylesB = __css({
+  root: {
+    De3pzq: 'fcnqdeg',
+  },
+});
+
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -11,9 +11,12 @@
   "dependencies": {
     "@babel/core": "^7.12.13",
     "@babel/helper-plugin-utils": "^7.12.13",
+    "loader-utils": "^2.0.0",
+    "schema-utils": "^3.1.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@griffel/core": "^1.3.1"
+    "@griffel/core": "^1.3.1",
+    "webpack": "^5"
   }
 }

--- a/packages/webpack-extraction-plugin/project.json
+++ b/packages/webpack-extraction-plugin/project.json
@@ -32,6 +32,11 @@
             "glob": "LICENSE.md",
             "input": ".",
             "output": "."
+          },
+          {
+            "glob": "*.{js,css}",
+            "input": "packages/webpack-extraction-plugin/virtual-loader",
+            "output": "./virtual-loader"
           }
         ]
       }

--- a/packages/webpack-extraction-plugin/src/schema.ts
+++ b/packages/webpack-extraction-plugin/src/schema.ts
@@ -1,0 +1,9 @@
+import type { JSONSchema7 } from 'json-schema';
+
+export const configSchema: JSONSchema7 = {
+  $schema: 'http://json-schema.org/schema',
+  $id: 'webpackLoader-options',
+
+  properties: {},
+  additionalProperties: false,
+};

--- a/packages/webpack-extraction-plugin/src/transformSync.ts
+++ b/packages/webpack-extraction-plugin/src/transformSync.ts
@@ -1,0 +1,57 @@
+import * as Babel from '@babel/core';
+import { babelPluginStripGriffelRuntime, StripRuntimeBabelPluginMetadata } from './babelPluginStripGriffelRuntime';
+
+export type TransformOptions = {
+  filename: string;
+
+  inputSourceMap: Babel.TransformOptions['inputSourceMap'];
+  enableSourceMaps: boolean;
+};
+
+export type TransformResult = {
+  code: string;
+  cssRules: string[] | undefined;
+  sourceMap: NonNullable<Babel.BabelFileResult['map']> | undefined;
+};
+
+/**
+ * Transforms passed source code with Babel, uses user's config for parsing, but ignores it for transforms.
+ */
+export function transformSync(sourceCode: string, options: TransformOptions): TransformResult {
+  // Parse the code first so Babel will use user's babel config for parsing
+  // During transforms we don't want to use user's config
+  const babelAST = Babel.parseSync(sourceCode, {
+    caller: { name: 'griffel' },
+
+    filename: options.filename,
+    inputSourceMap: options.inputSourceMap,
+    sourceMaps: options.enableSourceMaps,
+  });
+
+  if (babelAST === null) {
+    throw new Error(`Failed to create AST for "${options.filename}" due unknown Babel error...`);
+  }
+
+  const babelFileResult = Babel.transformFromAstSync(babelAST, sourceCode, {
+    // Ignore all user's configs and apply only our plugin
+    babelrc: false,
+    configFile: false,
+    plugins: [babelPluginStripGriffelRuntime],
+
+    filename: options.filename,
+
+    sourceMaps: options.enableSourceMaps,
+    sourceFileName: options.filename,
+    inputSourceMap: options.inputSourceMap,
+  });
+
+  if (babelFileResult === null) {
+    throw new Error(`Failed to transform "${options.filename}" due unknown Babel error...`);
+  }
+
+  return {
+    code: babelFileResult.code as string,
+    cssRules: (babelFileResult.metadata as unknown as StripRuntimeBabelPluginMetadata).cssRules,
+    sourceMap: babelFileResult.map === null ? undefined : babelFileResult.map,
+  };
+}

--- a/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
@@ -1,0 +1,189 @@
+import * as fs from 'fs';
+import { createFsFromVolume, Volume } from 'memfs';
+import * as path from 'path';
+import * as prettier from 'prettier';
+import * as webpack from 'webpack';
+import { merge } from 'webpack-merge';
+
+import webpackLoader from './webpackLoader';
+
+type CompileOptions = {
+  webpackConfig?: webpack.Configuration;
+};
+
+const prettierConfig = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../.prettierrc'), { encoding: 'utf-8' }),
+);
+
+async function compileSourceWithWebpack(entryPath: string, options: CompileOptions): Promise<{ moduleSource: string }> {
+  const defaultConfig: webpack.Configuration = {
+    context: __dirname,
+    entry: entryPath,
+
+    mode: 'development',
+
+    output: {
+      path: path.resolve(__dirname),
+      filename: 'bundle.js',
+      pathinfo: false,
+    },
+
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx|txt)$/,
+          include: path.dirname(entryPath),
+          use: {
+            loader: path.resolve(__dirname, './webpackLoader.ts'),
+          },
+        },
+        {
+          test: /\.css$/,
+          use: 'css-loader',
+        },
+      ],
+    },
+
+    resolve: {
+      alias: {
+        '@griffel/core': path.resolve(__dirname, '..', '..', '..', 'dist', 'packages', 'react', 'index.esm.js'),
+        '@griffel/react': path.resolve(__dirname, '..', '..', '..', 'dist', 'packages', 'react', 'index.esm.js'),
+      },
+      extensions: ['.js', '.ts'],
+    },
+  };
+
+  const webpackConfig = merge(defaultConfig, options.webpackConfig || {});
+  const compiler = webpack(webpackConfig);
+
+  const virtualFsVolume = createFsFromVolume(new Volume());
+
+  compiler.outputFileSystem = virtualFsVolume;
+  compiler.outputFileSystem.join = path.join.bind(path);
+
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      if (typeof stats === 'undefined') {
+        reject(new Error('"stats" from Webpack are not available, unknown error...'));
+        return;
+      }
+
+      const jsonStats = stats.toJson({ source: true });
+
+      if (stats.hasErrors()) {
+        reject(stats.toJson().errors![0]);
+        return;
+      }
+
+      if (!Array.isArray(jsonStats.modules)) {
+        reject(new Error(`"stats.toJson().modules" should be an array, this could be a compilation error...`));
+        return;
+      }
+
+      const entryModule = jsonStats.modules.find(module => module.nameForCondition === entryPath);
+
+      if (!entryModule) {
+        reject(new Error(`Failed to find a fixture in "stats.toJson().modules", this could be a compilation error...`));
+        return;
+      }
+
+      resolve({ moduleSource: entryModule.source as string });
+    });
+  });
+}
+
+function fixLineEndings(value: string) {
+  return String(value).replace(/\r?\n/g, '\n').trim();
+}
+
+/**
+ * Test utility similar to "babel-plugin-tester".
+ *
+ * See https://webpack.js.org/contribute/writing-a-loader/#testing.
+ */
+function testFixture(fixtureName: string, options: CompileOptions = {}) {
+  it(`"${fixtureName}" fixture`, async () => {
+    const fixturePath = path.resolve(__dirname, '..', '__fixtures__', 'webpack', fixtureName);
+
+    const tsCodePath = path.resolve(fixturePath, 'code.ts');
+    const tsxCodePath = path.resolve(fixturePath, 'code.tsx');
+    // Specially for cases when "code" contains syntax errors
+    const txtCodePath = path.resolve(fixturePath, 'code.txt');
+
+    const tsOutputPath = path.resolve(fixturePath, 'output.ts');
+    const tsxOutputPath = path.resolve(fixturePath, 'output.tsx');
+
+    const inputPath = [
+      fs.existsSync(tsCodePath) && tsCodePath,
+      fs.existsSync(tsxCodePath) && tsxCodePath,
+      fs.existsSync(txtCodePath) && txtCodePath,
+    ].find(Boolean);
+    const outputPath = [
+      fs.existsSync(tsOutputPath) && tsOutputPath,
+      fs.existsSync(tsxOutputPath) && tsxOutputPath,
+    ].find(Boolean);
+
+    const errorPath = path.resolve(fixturePath, 'error.ts');
+    const expectedError = fs.existsSync(errorPath) && require(errorPath);
+
+    if (!inputPath) {
+      throw new Error(`Failed to find "code.{js,ts,tsx}" in "${fixturePath}"`);
+    }
+
+    if (!outputPath && !expectedError) {
+      throw new Error(`Failed to find "output.{js,ts,tsx}" or "error.ts" in "${fixturePath}"`);
+    }
+
+    if (expectedError) {
+      if (!expectedError.default) {
+        throw new Error(
+          `Please check that "error.ts" contains a default export with an error or regex in "${fixturePath}"`,
+        );
+      }
+    }
+
+    let resultModule = '';
+    let resultError: Error | webpack.StatsError = new Error();
+
+    try {
+      const result = await compileSourceWithWebpack(inputPath, options);
+
+      resultModule = fixLineEndings(
+        prettier.format(result.moduleSource, {
+          ...prettierConfig,
+          parser: 'typescript',
+        }),
+      );
+    } catch (err) {
+      if (expectedError) {
+        resultError = err as webpack.StatsError;
+      } else {
+        throw err;
+      }
+    }
+
+    if (outputPath) {
+      const moduleOutput = fixLineEndings(await fs.promises.readFile(outputPath, { encoding: 'utf8' }));
+
+      expect(resultModule).toBe(moduleOutput);
+      return;
+    }
+
+    if (expectedError) {
+      expect(resultError.message).toMatch(expectedError.default);
+    }
+  });
+}
+
+describe('webpackLoader', () => {
+  // Basic assertions
+  testFixture('basic-rules');
+
+  // Multiple
+  testFixture('multiple');
+});

--- a/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
@@ -5,8 +5,6 @@ import * as prettier from 'prettier';
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import webpackLoader from './webpackLoader';
-
 type CompileOptions = {
   webpackConfig?: webpack.Configuration;
 };

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -1,0 +1,97 @@
+import { getOptions } from 'loader-utils';
+import * as path from 'path';
+import { validate } from 'schema-utils';
+import * as webpack from 'webpack';
+
+import { transformSync, TransformResult, TransformOptions } from './transformSync';
+import { configSchema } from './schema';
+
+type WebpackLoaderOptions = never;
+
+type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLoaderOptions>>;
+
+const virtualLoaderPath = path.resolve(__dirname, '..', 'virtual-loader', 'index.js');
+const resourcePath = path.resolve(__dirname, '..', 'virtual-loader', 'griffel.css');
+
+function toURIComponent(rule: string): string {
+  return encodeURIComponent(rule).replace(/!/g, '%21');
+}
+
+function shouldTransformSourceCode(sourceCode: string): boolean {
+  return sourceCode.indexOf('__styles') !== -1;
+}
+
+/**
+ * Webpack can also pass sourcemaps as a string, Babel accepts only objects.
+ * See https://github.com/babel/babel-loader/pull/889.
+ */
+function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOptions['inputSourceMap'] {
+  try {
+    if (typeof inputSourceMap === 'string') {
+      return JSON.parse(inputSourceMap) as TransformOptions['inputSourceMap'];
+    }
+
+    return inputSourceMap as TransformOptions['inputSourceMap'];
+  } catch (err) {
+    return undefined;
+  }
+}
+
+function webpackLoader(
+  this: webpack.LoaderContext<never>,
+  sourceCode: WebpackLoaderParams[0],
+  inputSourceMap: WebpackLoaderParams[1],
+) {
+  this.async();
+  // Loaders are cacheable by default, but in edge cases/bugs when caching does not work until it's specified:
+  // https://github.com/webpack/webpack/issues/14946
+  this.cacheable();
+
+  const options = getOptions(this) as WebpackLoaderOptions;
+
+  validate(configSchema, options, {
+    name: '@griffel/webpack-extraction-plugin/loader',
+    baseDataPath: 'options',
+  });
+
+  // Early return to handle cases when __styles() calls are not present, allows skipping expensive invocation of Babel
+  if (!shouldTransformSourceCode(sourceCode)) {
+    this.callback(null, sourceCode, inputSourceMap);
+    return;
+  }
+
+  let result: TransformResult | null = null;
+  let error: Error | null = null;
+
+  try {
+    result = transformSync(sourceCode, {
+      filename: path.relative(process.cwd(), this.resourcePath),
+
+      enableSourceMaps: this.sourceMap || false,
+      inputSourceMap: parseSourceMap(inputSourceMap),
+    });
+  } catch (err) {
+    error = err as Error;
+  }
+
+  if (result) {
+    if (result.cssRules) {
+      const request = `import ${JSON.stringify(
+        this.utils.contextify(
+          this.context || this.rootContext,
+          `griffel.css!=!${virtualLoaderPath}!${resourcePath}?style=${toURIComponent(result.cssRules.join('\n'))}`,
+        ),
+      )};`;
+
+      this.callback(null, `${result.code}\n\n${request};`, result.sourceMap);
+      return;
+    }
+
+    this.callback(null, result.code, result.sourceMap);
+    return;
+  }
+
+  this.callback(error);
+}
+
+export default webpackLoader;

--- a/packages/webpack-extraction-plugin/tsconfig.json
+++ b/packages/webpack-extraction-plugin/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
+    "checkJs": true,
+    "lib": ["es2019", "dom"],
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/packages/webpack-extraction-plugin/tsconfig.lib.json
+++ b/packages/webpack-extraction-plugin/tsconfig.lib.json
@@ -7,5 +7,5 @@
     "types": ["node", "environment"]
   },
   "exclude": ["__fixtures__/**/*/*.ts", "**/*.spec.ts", "**/*.test.ts"],
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "virtual-loader/index.js"]
 }

--- a/packages/webpack-extraction-plugin/virtual-loader/griffel.css
+++ b/packages/webpack-extraction-plugin/virtual-loader/griffel.css
@@ -1,0 +1,2 @@
+/* This is a noop file for extracted CSS source to point to */
+/* Webpack requires a file to exist on disk for virtual source files */

--- a/packages/webpack-extraction-plugin/virtual-loader/index.js
+++ b/packages/webpack-extraction-plugin/virtual-loader/index.js
@@ -1,0 +1,14 @@
+const { URLSearchParams } = require('url');
+
+/**
+ * @this {import('webpack').LoaderContext<unknown>}
+ * @return {String}
+ */
+function virtualLoader() {
+  const query = new URLSearchParams(this.resourceQuery);
+  const styleRule = query.get('style');
+
+  return styleRule || '';
+}
+
+module.exports = virtualLoader;

--- a/packages/webpack-extraction-plugin/virtual-loader/index.js
+++ b/packages/webpack-extraction-plugin/virtual-loader/index.js
@@ -8,7 +8,7 @@ function virtualLoader() {
   const query = new URLSearchParams(this.resourceQuery);
   const styleRule = query.get('style');
 
-  return styleRule || '';
+  return styleRule ?? '';
 }
 
 module.exports = virtualLoader;


### PR DESCRIPTION
This PR adds a Webpack loader that invokes Babel plugin (#135) and performs CSS extraction.

P.S. The next PR will contain a Webpack plugin to concatenate and deduplicate rules.