### PR TITLE
chore: increase timeouts for tests in webpack-extraction-plugin

### DIFF
--- a/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
@@ -179,6 +179,10 @@ function testFixture(fixtureName: string, options: CompileOptions = {}) {
 }
 
 describe('webpackLoader', () => {
+  beforeEach(() => {
+    jest.setTimeout(15000);
+  });
+
   // Basic assertions
   testFixture('basic-rules');
 


### PR DESCRIPTION
Fixes the flacky tests from #139.

![image](https://user-images.githubusercontent.com/14183168/174775146-b4790ed6-7cf2-4d51-9bf1-7f59d824271b.png)
