### PR TITLE
chore: add __css() functions for upcoming CSS extraction

### DIFF
--- a/change/@griffel-core-4ea31e7f-39dc-486b-8a22-3545f609a5cb.json
+++ b/change/@griffel-core-4ea31e7f-39dc-486b-8a22-3545f609a5cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add __css() functions for upcoming CSS extraction",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-react-8818a204-4697-4df6-8848-771f49c2bfdb.json
+++ b/change/@griffel-react-8818a204-4697-4df6-8848-771f49c2bfdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add __css() functions for upcoming CSS extraction",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/__css.ts
+++ b/packages/core/src/__css.ts
@@ -1,0 +1,40 @@
+import { debugData, isDevToolsEnabled } from './devtools';
+import { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
+import { MakeStylesOptions, CSSClassesMapBySlot } from './types';
+
+/**
+ * A version of makeStyles() that accepts build output as an input and skips all runtime transforms & DOM insertion.
+ *
+ * @internal
+ */
+export function __css<Slots extends string>(classesMapBySlot: CSSClassesMapBySlot<Slots>) {
+  let ltrClassNamesForSlots: Record<Slots, string> | null = null;
+  let rtlClassNamesForSlots: Record<Slots, string> | null = null;
+
+  function computeClasses(options: Pick<MakeStylesOptions, 'dir'>): Record<Slots, string> {
+    const { dir } = options;
+    const isLTR = dir === 'ltr';
+
+    if (isLTR) {
+      if (ltrClassNamesForSlots === null) {
+        ltrClassNamesForSlots = reduceToClassNameForSlots(classesMapBySlot, dir);
+      }
+    } else {
+      if (rtlClassNamesForSlots === null) {
+        rtlClassNamesForSlots = reduceToClassNameForSlots(classesMapBySlot, dir);
+      }
+    }
+
+    const classNamesForSlots = isLTR
+      ? (ltrClassNamesForSlots as Record<Slots, string>)
+      : (rtlClassNamesForSlots as Record<Slots, string>);
+
+    if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+      debugData.addSequenceDetails(classNamesForSlots!);
+    }
+
+    return classNamesForSlots;
+  }
+
+  return computeClasses;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,8 @@ export { makeStyles } from './makeStyles';
 export { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
 
 // Private exports, are used by build time transforms
+export { __css } from './__css';
+export { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
 export { resolveStyleRules } from './runtime/resolveStyleRules';
 export { __styles } from './__styles';
 

--- a/packages/react/bundle-size/__css.fixture.js
+++ b/packages/react/bundle-size/__css.fixture.js
@@ -1,0 +1,7 @@
+import { __css, mergeClasses } from '@griffel/react';
+
+console.log(__css, mergeClasses);
+
+export default {
+  name: '__css + mergeClasses (build time)',
+};

--- a/packages/react/bundle-size/__styles.fixture.js
+++ b/packages/react/bundle-size/__styles.fixture.js
@@ -3,5 +3,5 @@ import { __styles, mergeClasses } from '@griffel/react';
 console.log(__styles, mergeClasses);
 
 export default {
-  name: 'makeStyles + mergeClasses (build time)',
+  name: '__styles + mergeClasses (build time)',
 };

--- a/packages/react/src/__css.ts
+++ b/packages/react/src/__css.ts
@@ -1,0 +1,20 @@
+import { __css as vanillaCSS } from '@griffel/core';
+import type { CSSClassesMapBySlot } from '@griffel/core';
+
+import { useTextDirection } from './TextDirectionContext';
+
+/**
+ * A version of makeStyles() that accepts build output as an input and skips all runtime transforms & DOM insertion.
+ *
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function __css<Slots extends string>(classesMapBySlot: CSSClassesMapBySlot<Slots>) {
+  const getStyles = vanillaCSS(classesMapBySlot);
+
+  return function useClasses(): Record<Slots, string> {
+    const dir = useTextDirection();
+
+    return getStyles({ dir });
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,4 +9,5 @@ export { RendererProvider, useRenderer as useRenderer_unstable } from './Rendere
 export { TextDirectionProvider } from './TextDirectionContext';
 
 // Private exports, are used by build time transforms
+export { __css } from './__css';
 export { __styles } from './__styles';


### PR DESCRIPTION
This PR adds new `__css` functions to `@griffel/core` & `@griffel/react`.

The difference to existing `__styles` is that the part related to CSS insertion is completely stripped.