### PR TITLE
chore: increase timeouts for tests in webpack-extraction-plugin #2

### DIFF
--- a/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
@@ -175,14 +175,10 @@ function testFixture(fixtureName: string, options: CompileOptions = {}) {
     if (expectedError) {
       expect(resultError.message).toMatch(expectedError.default);
     }
-  });
+  }, 15000);
 }
 
 describe('webpackLoader', () => {
-  beforeEach(() => {
-    jest.setTimeout(15000);
-  });
-
   // Basic assertions
   testFixture('basic-rules');
 


### PR DESCRIPTION
Even if it passes in the original PR #144 it means nothing 🙃

![image](https://user-images.githubusercontent.com/14183168/174785849-02be4d60-da31-44ba-8d1d-a6205a767872.png)

For unknown reason `beforeEach` does apply timeouts properly:

```ts
describe('webpackLoader', () => {
  beforeEach(() => {
    jest.setTimeout(100);
  });

 // 💥 is still passing
})
```

```ts
describe('webpackLoader', () => {

    jest.setTimeout(100);


 // fails as expected
})
```