### PR TITLE
feat(devtools): fix duplicated key + make input stick to top + fix [data-key-nav] selector

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -10,6 +10,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@emotion/hash": "^0.8.0",
     "@griffel/react": "^1.1.0",
     "js-beautify": "^1.14.0",
     "prism-react-renderer": "1.2.1",

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -98,9 +98,9 @@ export const FlattenView: React.FC<FlattenViewProps> = props => {
       </div>
       <div className={classes.rules}>
         <ViewContext.Provider value={contextValue}>
-          {filteredSlots.map(({ slot, rules, sourceURL }) => {
+          {filteredSlots.map(({ slot, rules }) => {
             const key = hash(slot + rules.map(rule => rule.cssRule).join(''));
-            return <SlotCSSRules key={key} slot={slot} atomicRules={rules} sourceURL={sourceURL} />;
+            return <SlotCSSRules key={key} slot={slot} atomicRules={rules} />;
           })}
         </ViewContext.Provider>
       </div>

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
 
     position: 'sticky',
     top: 0,
-    zIndex: 99,
+    zIndex: 1,
     backgroundColor: tokens.background,
   },
   input: {

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -20,6 +20,10 @@ const useStyles = makeStyles({
     columnGap: '4px',
     fontFamily: 'system-ui',
     fontSize: '12px',
+
+    position: 'sticky',
+    top: 0,
+    zIndex: 99,
   },
   input: {
     color: 'inherit',

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -99,7 +99,7 @@ export const FlattenView: React.FC<FlattenViewProps> = props => {
       <div className={classes.rules}>
         <ViewContext.Provider value={contextValue}>
           {filteredSlots.map(({ slot, rules }) => {
-            const key = hash(slot + rules.map(rule => rule.cssRule).join(''));
+            const key = slot + rules.map(rule => rule.cssRule).join('');
             return <SlotCSSRules key={key} slot={slot} atomicRules={rules} />;
           })}
         </ViewContext.Provider>

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -24,6 +24,7 @@ const useStyles = makeStyles({
     position: 'sticky',
     top: 0,
     zIndex: 99,
+    backgroundColor: tokens.background,
   },
   input: {
     color: 'inherit',
@@ -97,9 +98,9 @@ export const FlattenView: React.FC<FlattenViewProps> = props => {
       </div>
       <div className={classes.rules}>
         <ViewContext.Provider value={contextValue}>
-          {filteredSlots.map(({ slot, rules }) => {
+          {filteredSlots.map(({ slot, rules, sourceURL }) => {
             const key = hash(slot + rules.map(rule => rule.cssRule).join(''));
-            return <SlotCSSRules key={key} slot={slot} atomicRules={rules} />;
+            return <SlotCSSRules key={key} slot={slot} atomicRules={rules} sourceURL={sourceURL} />;
           })}
         </ViewContext.Provider>
       </div>

--- a/packages/devtools/src/FlattenView.tsx
+++ b/packages/devtools/src/FlattenView.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import hash from '@emotion/hash';
 import { makeStaticStyles, makeStyles, shorthands } from '@griffel/react';
 
 import { SlotCSSRules } from './SlotCSSRules';
@@ -92,9 +93,10 @@ export const FlattenView: React.FC<FlattenViewProps> = props => {
       </div>
       <div className={classes.rules}>
         <ViewContext.Provider value={contextValue}>
-          {filteredSlots.map(({ slot, rules }) => (
-            <SlotCSSRules key={slot} slot={slot} atomicRules={rules} />
-          ))}
+          {filteredSlots.map(({ slot, rules }) => {
+            const key = hash(slot + rules.map(rule => rule.cssRule).join(''));
+            return <SlotCSSRules key={key} slot={slot} atomicRules={rules} />;
+          })}
         </ViewContext.Provider>
       </div>
     </div>

--- a/packages/devtools/src/getMonolithicCSSRules.test.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.test.ts
@@ -145,4 +145,27 @@ describe('getMonolithicCSSRules', () => {
       },
     });
   });
+
+  it('group atomic css when class name selector has selector in front', () => {
+    const rules = [
+      '[data-keyboard-nav] .abcdef0:focus{background-color:red;}',
+      '[data-keyboard-nav] .abcdef1{color:red;}',
+    ].map(cssRule => ({ cssRule }));
+    expect(getMonolithicCSSRules(rules)).toEqual({
+      '[data-keyboard-nav] ': [
+        {
+          className: 'abcdef1',
+          css: 'color:red;',
+          overriddenBy: undefined,
+        },
+      ],
+      '[data-keyboard-nav] :focus': [
+        {
+          className: 'abcdef0',
+          css: 'background-color:red;',
+          overriddenBy: undefined,
+        },
+      ],
+    });
+  });
 });

--- a/packages/devtools/src/getMonolithicCSSRules.test.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.test.ts
@@ -17,6 +17,18 @@ describe('getMonolithicCSSRules', () => {
     });
   });
 
+  it('group atomic css with child class names selector', () => {
+    const rules = ['.f1dx00p .class1{padding-right: 10px;}'].map(cssRule => ({ cssRule }));
+    expect(getMonolithicCSSRules(rules)).toEqual({
+      ' .class1': [
+        {
+          className: 'f1dx00p',
+          css: 'padding-right:10px;',
+        },
+      ],
+    });
+  });
+
   it('separate atomic css with class names selector and pseudo selector', () => {
     const rules = [
       '.fabcde0{background-color:red;}',

--- a/packages/devtools/src/getMonolithicCSSRules.test.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.test.ts
@@ -2,15 +2,15 @@ import { getMonolithicCSSRules } from './getMonolithicCSSRules';
 
 describe('getMonolithicCSSRules', () => {
   it('group atomic css with class names selector', () => {
-    const rules = ['.abcdef0{background-color:red;}', '.abcdef1{color:red;}'].map(cssRule => ({ cssRule }));
+    const rules = ['.fabcde0{background-color:red;}', '.fabcde1{color:red;}'].map(cssRule => ({ cssRule }));
     expect(getMonolithicCSSRules(rules)).toEqual({
       '': [
         {
-          className: 'abcdef0',
+          className: 'fabcde0',
           css: 'background-color:red;',
         },
         {
-          className: 'abcdef1',
+          className: 'fabcde1',
           css: 'color:red;',
         },
       ],
@@ -19,29 +19,29 @@ describe('getMonolithicCSSRules', () => {
 
   it('separate atomic css with class names selector and pseudo selector', () => {
     const rules = [
-      '.abcdef0{background-color:red;}',
-      '.abcdef1{display:block;}',
-      '.abcdef2:hover{display:none;}',
-      '.abcdef3:hover{color:red;}',
+      '.fabcde0{background-color:red;}',
+      '.fabcde1{display:block;}',
+      '.fabcde2:hover{display:none;}',
+      '.fabcde3:hover{color:red;}',
     ].map(cssRule => ({ cssRule }));
     expect(getMonolithicCSSRules(rules)).toEqual({
       '': [
         {
-          className: 'abcdef0',
+          className: 'fabcde0',
           css: 'background-color:red;',
         },
         {
-          className: 'abcdef1',
+          className: 'fabcde1',
           css: 'display:block;',
         },
       ],
       ':hover': [
         {
-          className: 'abcdef2',
+          className: 'fabcde2',
           css: 'display:none;',
         },
         {
-          className: 'abcdef3',
+          className: 'fabcde3',
           css: 'color:red;',
         },
       ],
@@ -50,30 +50,30 @@ describe('getMonolithicCSSRules', () => {
 
   it('group atomic css with media selector', () => {
     const rules = [
-      '.abcdef0{background-color:red;}',
-      '.abcdef1{display:block;}',
-      '.abcdef2:hover{display:none;}',
-      '.abcdef3:hover{color:red;}',
+      '.fabcde0{background-color:red;}',
+      '.fabcde1{display:block;}',
+      '.fabcde2:hover{display:none;}',
+      '.fabcde3:hover{color:red;}',
     ].map(cssRule => ({ cssRule: `@media screen and (max-width: 992px){${cssRule}}` }));
     expect(getMonolithicCSSRules(rules)).toEqual({
       '@media screen and (max-width: 992px)': {
         '': [
           {
-            className: 'abcdef0',
+            className: 'fabcde0',
             css: 'background-color:red;',
           },
           {
-            className: 'abcdef1',
+            className: 'fabcde1',
             css: 'display:block;',
           },
         ],
         ':hover': [
           {
-            className: 'abcdef2',
+            className: 'fabcde2',
             css: 'display:none;',
           },
           {
-            className: 'abcdef3',
+            className: 'fabcde3',
             css: 'color:red;',
           },
         ],
@@ -83,21 +83,21 @@ describe('getMonolithicCSSRules', () => {
 
   it('separate atomic css with different media selector', () => {
     const rules = [
-      '.abcdef0{background-color:red;}',
-      '@media screen and (max-width: 992px){.abcdef0{background-color:blue;}}',
-      '@media screen and (max-width: 1024px){.abcdef0{background-color:green;}}',
+      '.fabcde0{background-color:red;}',
+      '@media screen and (max-width: 992px){.fabcde0{background-color:blue;}}',
+      '@media screen and (max-width: 1024px){.fabcde0{background-color:green;}}',
     ].map(cssRule => ({ cssRule }));
     expect(getMonolithicCSSRules(rules)).toEqual({
       '': [
         {
-          className: 'abcdef0',
+          className: 'fabcde0',
           css: 'background-color:red;',
         },
       ],
       '@media screen and (max-width: 1024px)': {
         '': [
           {
-            className: 'abcdef0',
+            className: 'fabcde0',
             css: 'background-color:green;',
           },
         ],
@@ -105,7 +105,7 @@ describe('getMonolithicCSSRules', () => {
       '@media screen and (max-width: 992px)': {
         '': [
           {
-            className: 'abcdef0',
+            className: 'fabcde0',
             css: 'background-color:blue;',
           },
         ],
@@ -115,21 +115,21 @@ describe('getMonolithicCSSRules', () => {
 
   it('pass on overriddenBy information from atomic css to monolithic css', () => {
     const rules = [
-      { cssRule: '.abcdef0{background-color:red;}', overriddenBy: 'bcdefg0' },
-      { cssRule: '.abcdef0>div{color:green;}', overriddenBy: 'bcdefg1' },
-      { cssRule: '@media screen and (max-width: 992px){.abcdef0{background-color:blue;}}', overriddenBy: 'bcdefg2' },
+      { cssRule: '.fabcde0{background-color:red;}', overriddenBy: 'bcdefg0' },
+      { cssRule: '.fabcde0>div{color:green;}', overriddenBy: 'bcdefg1' },
+      { cssRule: '@media screen and (max-width: 992px){.fabcde0{background-color:blue;}}', overriddenBy: 'bcdefg2' },
     ];
     expect(getMonolithicCSSRules(rules)).toEqual({
       '': [
         {
-          className: 'abcdef0',
+          className: 'fabcde0',
           css: 'background-color:red;',
           overriddenBy: 'bcdefg0',
         },
       ],
       '>div': [
         {
-          className: 'abcdef0',
+          className: 'fabcde0',
           css: 'color:green;',
           overriddenBy: 'bcdefg1',
         },
@@ -137,7 +137,7 @@ describe('getMonolithicCSSRules', () => {
       '@media screen and (max-width: 992px)': {
         '': [
           {
-            className: 'abcdef0',
+            className: 'fabcde0',
             css: 'background-color:blue;',
             overriddenBy: 'bcdefg2',
           },
@@ -148,20 +148,28 @@ describe('getMonolithicCSSRules', () => {
 
   it('group atomic css when class name selector has selector in front', () => {
     const rules = [
-      '[data-keyboard-nav] .abcdef0:focus{background-color:red;}',
-      '[data-keyboard-nav] .abcdef1{color:red;}',
+      '[data-keyboard-nav] .fabcde0:focus{background-color:red;}',
+      '[data-keyboard-nav] .fabcde1{color:red;}',
+      '[data-keyboard-nav] .fabcde1 .class1{padding-top:10px;}',
     ].map(cssRule => ({ cssRule }));
     expect(getMonolithicCSSRules(rules)).toEqual({
       '[data-keyboard-nav] ': [
         {
-          className: 'abcdef1',
+          className: 'fabcde1',
           css: 'color:red;',
+          overriddenBy: undefined,
+        },
+      ],
+      '[data-keyboard-nav]  .class1': [
+        {
+          className: 'fabcde1',
+          css: 'padding-top:10px;',
           overriddenBy: undefined,
         },
       ],
       '[data-keyboard-nav] :focus': [
         {
-          className: 'abcdef0',
+          className: 'fabcde0',
           css: 'background-color:red;',
           overriddenBy: undefined,
         },

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -1,7 +1,7 @@
 import * as stylis from 'stylis';
 import type { AtomicRules, MonolithicAtRules, MonolithicRules, RuleDetail } from './types';
 
-const griffelClassNameRegex = /\.[0-9a-z]+/;
+const griffelClassNameRegex = /^\.[0-9a-z]+$/;
 
 function parseRuleElement(element: stylis.Element, overriddenBy?: string) {
   // example of `value`: `.f3xbvq9:hover`

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -1,7 +1,7 @@
 import * as stylis from 'stylis';
 import type { AtomicRules, MonolithicAtRules, MonolithicRules, RuleDetail } from './types';
 
-const griffelClassNameRegex = /^\.[0-9a-z]+$/;
+const griffelClassNameRegex = /^\.f[0-9a-z]+$/;
 
 function parseRuleElement(element: stylis.Element, overriddenBy?: string) {
   // example of `value`: `.f3xbvq9:hover`

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -1,16 +1,28 @@
 import * as stylis from 'stylis';
 import type { AtomicRules, MonolithicAtRules, MonolithicRules, RuleDetail } from './types';
 
+const griffelClassNameRegex = /\.[0-9a-z]+/;
+
 function parseRuleElement(element: stylis.Element, overriddenBy?: string) {
   // example of `value`: `.f3xbvq9:hover`
   // `children` contains all CSS rules under the `value` selector
   const { value: classNameSelector, children } = element;
 
   if (Array.isArray(children)) {
-    const selector = stylis.tokenize(classNameSelector).slice(1).join('');
+    let className: string | undefined;
+    const selector = stylis
+      .tokenize(classNameSelector)
+      .filter(token => {
+        if (griffelClassNameRegex.test(token)) {
+          className = token.slice(1);
+          return false;
+        }
+        return true;
+      })
+      .join('');
     const rules: RuleDetail[] = children.map(child => ({
       css: child.value,
-      className: stylis.tokenize(classNameSelector)[0].slice(1),
+      className: className ?? stylis.tokenize(classNameSelector)[0].slice(1),
       overriddenBy,
     }));
     return {

--- a/packages/devtools/src/stories/FlattenView.stories.tsx
+++ b/packages/devtools/src/stories/FlattenView.stories.tsx
@@ -79,7 +79,7 @@ const debugResultRoot: DebugResult = {
         f7wpa5l: '@media screen and (max-width: 992px){.f7wpa5l:hover{color:red;}}',
         fy4xd57: '@media screen and (max-width: 992px){.fy4xd57:hover{background-color:blue;}}',
       },
-      slot: 'primaryRed',
+      slot: 'primary',
     },
   ],
   debugClassNames: [
@@ -105,6 +105,8 @@ export const Default: Story<{ theme: 'dark' | 'light' }> = ({ theme }) => {
         ...tokens,
         border: '3px solid gray',
         width: 400,
+        height: 600,
+        overflowY: 'auto',
       }}
     >
       <FlattenView debugResultRoot={debugResultRoot} />


### PR DESCRIPTION
- fix key: previously slot name was used as key for `SlotCSSRules` component but slot name can be the same and causing issue
- make input bar stick to top
   <img width="446" alt="image" src="https://user-images.githubusercontent.com/28751745/175259766-a772c8b8-3408-49eb-ba56-1b7b7b08e72e.png">
- fix parsing of css rule selector when the rules are like `[data-key-nav] .fxxxx{color:red}`. 
   Before: 
    <img width="423" alt="Screenshot 2022-06-23 at 13 38 05" src="https://user-images.githubusercontent.com/28751745/175290371-c618e569-869c-4fe4-8505-5a7b8393cce6.png">
   After: 
    <img width="430" alt="Screenshot 2022-06-23 at 13 37 46" src="https://user-images.githubusercontent.com/28751745/175290384-2800fd5b-fb0a-48b5-beee-71f609ee1b49.png">
