### PR TITLE
fix: handle asset names in extraction plugin

### DIFF
--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/code.ts
@@ -1,0 +1,14 @@
+import { __styles } from '@griffel/react';
+
+const styles = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+
+console.log(styles);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.e44646c584b8724e9528.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
@@ -1,0 +1,3 @@
+.fe3e8s9 {
+  color: red;
+}

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -54,16 +54,18 @@ export class GriffelCSSExtractionPlugin {
           stage: Compilation.PROCESS_ASSETS_STAGE_PRE_PROCESS,
         },
         assets => {
-          const griffelAsset = assets['griffel.css'];
+          const griffelAsset = Object.entries(assets).find(([assetName]) => assetName.includes('griffel'));
 
           if (!griffelAsset) {
             return;
           }
 
-          const unsortedCSSRules = getAssetSourceContents(griffelAsset);
+          const [assetName, assetSource] = griffelAsset;
+
+          const unsortedCSSRules = getAssetSourceContents(assetSource);
           const sortedCSSRules = sortCSSRules(unsortedCSSRules, this.compareMediaQueries);
 
-          compilation.updateAsset('griffel.css', new compiler.webpack.sources.RawSource(sortedCSSRules));
+          compilation.updateAsset(assetName, new compiler.webpack.sources.RawSource(sortedCSSRules));
         },
       );
     });


### PR DESCRIPTION
I was testing the plugin before publish and discovered that the plugin does not handle cases when [`filename`](https://webpack.js.org/plugins/mini-css-extract-plugin/#filename) is specified in `mini-css-extract-plugin`. This PR fixes it.