### PR TITLE
fix(webpack-extraction-plugin): improve getElementReference() to handle multiple children

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-2264cf3b-bf8b-4a75-b908-a443cccfca4e.json
+++ b/change/@griffel-webpack-extraction-plugin-2264cf3b-bf8b-4a75-b908-a443cccfca4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: improve getElementReference() to handle multiple childen",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -208,6 +208,25 @@ describe('resolveStyleRules', () => {
       `);
     });
 
+    it('handles media queries with flipping values', () => {
+      expect(
+        resolveStyleRules({
+          '@media screen and (max-width: 992px)': {
+            textAlign: 'left',
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        @media screen and (max-width: 992px) {
+          .f1f6067w {
+            text-align: left;
+          }
+          .f133ge8t {
+            text-align: right;
+          }
+        }
+      `);
+    });
+
     it('RTL @noflip will generate a different className', () => {
       const classnamesSet = new Set<string>();
 

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -22,11 +22,13 @@ expect.addSnapshotSerializer(cssSerializer);
 
 describe('getElementReference', () => {
   it.each`
-    css                                                                                       | reference
-    ${'.foo { color: red; }'}                                                                 | ${'.foo'}
-    ${'.foo:hover { color: red; }'}                                                           | ${'.foo:hover'}
-    ${'@media (max-width: 2px) { .foo { color: blue; } }'}                                    | ${'.foo@media (max-width: 2px)'}
-    ${'@keyframes foo { from { transform:rotate(0deg); } to { transform:rotate(360deg); } }'} | ${'@keyframes foo'}
+    css                                                                                              | reference
+    ${'.foo { color: red; }'}                                                                        | ${'.foo'}
+    ${'.foo:hover { color: red; }'}                                                                  | ${'.foo:hover'}
+    ${'@media (max-width: 2px) { .foo { color: blue; } }'}                                           | ${'@media (max-width: 2px)[.foo]'}
+    ${'@keyframes foo { from { transform:rotate(0deg); } to { transform:rotate(360deg); } }'}        | ${'@keyframes foo'}
+    ${'@media screen and (max-width: 992px) { .a { text-align: left; } .b { text-align: right; } }'} | ${'@media screen and (max-width: 992px)[.a,.b]'}
+    ${'@media (max-width: 2px) { @supports (display: grid) { .a { color: blue; } } }'}               | ${'@media (max-width: 2px)[@supports (display: grid)[.a]]'}
   `('returns "$reference" for "$css"', ({ css, reference }: { css: string; reference: string }) => {
     const element = compile(css)[0];
 

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -18,8 +18,8 @@ export function getElementReference(element: Element, suffix = ''): string {
     return element.value + suffix;
   }
 
-  if (Array.isArray(element.children) && element.children.length === 1) {
-    return getElementReference(element.children[0], element.value + suffix);
+  if (Array.isArray(element.children)) {
+    return element.value + '[' + element.children.map(child => getElementReference(child, suffix)).join(',') + ']';
   }
 
   function removeRootProperty(element: Element): unknown {


### PR DESCRIPTION
This PR fixes handling of multiple CSS rules inside `element.children` for `getElementReference()`. This happens for cases when Griffel emits rules that flip in RTL.

```css
@media screen and (max-width: 992px) {
  .f1f6067w {
    text-align: left;
  }
  .f133ge8t {
    text-align: right;
  }
}
```
