### PR TITLE
fix: export `CreateDOMRendererOptions` from `@griffel/react`

### DIFF
--- a/change/@griffel-react-d55dcfa4-30d9-446f-9472-ae032925fbe4.json
+++ b/change/@griffel-react-d55dcfa4-30d9-446f-9472-ae032925fbe4.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: export `CreateDOMRendererOptions` from `@griffel/react`",
+  "comment": "feat: export `CreateDOMRendererOptions` from `@griffel/react`",
   "packageName": "@griffel/react",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@griffel-react-d55dcfa4-30d9-446f-9472-ae032925fbe4.json
+++ b/change/@griffel-react-d55dcfa4-30d9-446f-9472-ae032925fbe4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export `CreateDOMRendererOptions` from `@griffel/react`",
+  "packageName": "@griffel/react",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 export { shorthands, mergeClasses, createDOMRenderer } from '@griffel/core';
-export type { GriffelStyle } from '@griffel/core';
+export type { GriffelStyle, CreateDOMRendererOptions } from '@griffel/core';
 
 export { makeStyles } from './makeStyles';
 export { makeStaticStyles } from './makeStaticStyles';


### PR DESCRIPTION
Useful to export this type for users that want to declare options for `createDOMRenderer` outside of the actual function call

```ts
const options: CreateDOMRendererOptions = {
  compareMediaQueries: (a, b) => a < b;
}

createDOMRenderer(document, options)
```