### PR TITLE
fix(webpack-extraction-plugin): handle comments in output

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-9caf7232-4d9e-47bf-8052-2361d62a3790.json
+++ b/change/@griffel-webpack-extraction-plugin-9caf7232-4d9e-47bf-8052-2361d62a3790.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle comments in output",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -218,4 +218,7 @@ describe('webpackLoader', () => {
 
   // Custom filenames in mini-css-extract-plugin
   testFixture('config-name', { cssFilename: '[name].[contenthash].css' });
+
+  // "pathinfo" adds comments with paths to output
+  testFixture('basic-rules', { webpackConfig: { output: { pathinfo: true } } });
 });

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -135,4 +135,17 @@ describe('sortCSSRules', () => {
       }
     `);
   });
+
+  it('removes comments from output', () => {
+    const css = `
+      /* This is a comment in CSS */
+      .baz { color: orange; }
+    `;
+
+    expect(sortCSSRules(css, () => 0)).toMatchInlineSnapshot(`
+      .baz {
+        color: orange;
+      }
+    `);
+  });
 });

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -1,5 +1,5 @@
 import { getStyleBucketName, GriffelRenderer, StyleBucketName, styleBucketOrdering } from '@griffel/core';
-import { compile, Element, KEYFRAMES, MEDIA, RULESET, serialize, stringify, SUPPORTS, tokenize } from 'stylis';
+import { COMMENT, compile, Element, KEYFRAMES, MEDIA, RULESET, serialize, stringify, SUPPORTS, tokenize } from 'stylis';
 
 export function getSelectorFromElement(element: Element) {
   return tokenize(element.value).slice(1).join('');
@@ -55,12 +55,15 @@ export function getStyleBucketNameFromElement(element: Element): StyleBucketName
 }
 
 export function sortCSSRules(css: string, compareMediaQueries: GriffelRenderer['compareMediaQueries']): string {
-  const childElements = compile(css).map(element => ({
-    ...element,
-    bucketName: getStyleBucketNameFromElement(element),
-    metadata: getElementMetadata(element),
-    reference: getElementReference(element),
-  }));
+  const childElements = compile(css)
+    // Remove top level comments as it is unclear how to sort them
+    .filter(element => element.type !== COMMENT)
+    .map(element => ({
+      ...element,
+      bucketName: getStyleBucketNameFromElement(element),
+      metadata: getElementMetadata(element),
+      reference: getElementReference(element),
+    }));
   const uniqueElements = childElements.reduce<Record<string, typeof childElements[0]>>((acc, element) => {
     acc[element.reference] = element;
 


### PR DESCRIPTION
Fixes #160.

When Webpack emits assets it can add a comment to source if [`output.pathinfo`](https://webpack.js.org/configuration/output/#outputpathinfo) is enabled. This PR strips all top-level comments as there is no sense in them - they cannot be sorted in output anyway.