### PR TITLE
docs: improve try out experience

### DIFF
--- a/apps/website/docs/try-it-out/try-it-out.mdx
+++ b/apps/website/docs/try-it-out/try-it-out.mdx
@@ -7,9 +7,7 @@ import Playground from '../../src/components/Playground';
 
 # Try it out
 
-Don't know how to get started writing styles in Griffel ?
-
-Having trouble getting your styles to work the way you want to ?
+Don't know how to get started writing styles in Griffel? Having trouble getting your styles to work the way you want to?
 
 Use the editor below to try it out! Griffel on the left, CSS on the right. There are a collection
 of templates on the sidebar to get you started.

--- a/apps/website/docusaurus.config.js
+++ b/apps/website/docusaurus.config.js
@@ -12,11 +12,13 @@ const config = {
   onBrokenMarkdownLinks: 'throw',
 
   title: 'Griffel',
-  tagline: 'Dinosaurs are cool',
+  // tagline: 'Dinosaurs are cool',
 
   url: 'https://griffel.js.org',
   baseUrl: '/',
   // favicon: 'img/favicon.ico',
+
+  plugins: [require.resolve('./src/components/Playground/docusaurusPlugin')],
 
   presets: [
     [

--- a/apps/website/sidebars.js
+++ b/apps/website/sidebars.js
@@ -5,54 +5,55 @@ const babel = require('@babel/core');
 function generateTryItOutSidebar() {
   const playgroundTemplatePath = path.join(__dirname, '/src/components/Playground/code/templates');
   const templateFiles = fs.readdirSync(playgroundTemplatePath);
-  const sidebarItems = [];
 
-  templateFiles.forEach(templateFile => {
-    const id = path.parse(templateFile).name;
-    const templatePath = path.join(playgroundTemplatePath, templateFile);
+  return templateFiles
+    .reduce((sidebarItems, templateFile) => {
+      const id = path.parse(templateFile).name;
+      const templatePath = path.join(playgroundTemplatePath, templateFile);
 
-    const code = fs.readFileSync(templatePath, { encoding: 'utf-8' });
-    const res = babel.parseSync(code, { filename: templateFile });
-    const meta = { name: id };
+      const code = fs.readFileSync(templatePath, { encoding: 'utf-8' });
+      const res = babel.parseSync(code, { filename: templateFile });
+      const meta = { name: id };
 
-    babel.traverse(res, {
-      VariableDeclarator(path) {
-        const idPath = path.get('id');
-        const initPath = path.get('init');
+      babel.traverse(res, {
+        VariableDeclarator(path) {
+          const idPath = path.get('id');
+          const initPath = path.get('init');
 
-        if (idPath.isIdentifier({ name: 'meta' }) && initPath.isObjectExpression) {
-          const properties = initPath.get('properties');
+          if (idPath.isIdentifier({ name: 'meta' }) && initPath.isObjectExpression) {
+            const properties = initPath.get('properties');
 
-          if (Array.isArray(properties)) {
-            properties.forEach(propertyPath => {
-              if (propertyPath.isObjectProperty()) {
-                const keyPath = propertyPath.get('key');
-                const valuePath = propertyPath.get('value');
+            if (Array.isArray(properties)) {
+              properties.forEach(propertyPath => {
+                if (propertyPath.isObjectProperty()) {
+                  const keyPath = propertyPath.get('key');
+                  const valuePath = propertyPath.get('value');
 
-                if (
-                  keyPath.isIdentifier() &&
-                  (valuePath.isStringLiteral() || valuePath.isBooleanLiteral() || valuePath.isNumericLiteral())
-                ) {
-                  meta[keyPath.node.name] = valuePath.node.value;
+                  if (
+                    keyPath.isIdentifier() &&
+                    (valuePath.isStringLiteral() || valuePath.isBooleanLiteral() || valuePath.isNumericLiteral())
+                  ) {
+                    meta[keyPath.node.name] = valuePath.node.value;
+                  }
                 }
-              }
-            });
+              });
+            }
           }
-        }
-      },
-    });
+        },
+      });
 
-    /** @type {{ type: 'link'; label: string; href: string }} */
-    const sidebarItem = {
-      type: 'link',
-      label: meta.name,
-      href: `/try-it-out#${id}`,
-    };
+      /** @type {{ type: 'link'; label: string; href: string }} */
+      const sidebarItem = {
+        type: 'link',
+        label: meta.name,
+        href: `/try-it-out#${id}`,
+      };
 
-    sidebarItems[meta.position] = sidebarItem;
-  });
+      sidebarItems[meta.position] = sidebarItem;
 
-  return sidebarItems.filter(Boolean);
+      return sidebarItems;
+    }, [])
+    .filter(Boolean);
 }
 
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */

--- a/apps/website/src/components/OutputTitle/index.tsx
+++ b/apps/website/src/components/OutputTitle/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { CogsIcon } from '../icons';
 import styles from './styles.module.css';
 
-const OutpuTitle: React.FC = props => {
+const OutputTitle: React.FC = props => {
   return (
     <div className={styles['container']}>
       <CogsIcon />
@@ -12,4 +12,4 @@ const OutpuTitle: React.FC = props => {
   );
 };
 
-export default OutpuTitle;
+export default OutputTitle;

--- a/apps/website/src/components/Playground/code/app.js
+++ b/apps/website/src/components/Playground/code/app.js
@@ -1,5 +1,3 @@
-//@ts-check
-
 import hljs from 'highlight.js/lib/core';
 import 'highlight.js/styles/vs.css';
 import beautify from 'js-beautify';
@@ -11,14 +9,20 @@ hljs.registerLanguage('css', css);
 export default function App() {
   const [rules, setRules] = React.useState('');
   const ref = React.useRef(null);
+
   React.useEffect(() => {
     /** @type import('@griffel/core').GriffelRenderer */
     const playgroundRenderer = {
       id: 'playground',
       insertCSSRules(cssRules) {
         const raw = Object.values(cssRules)
-          .reduce((acc, val) => acc.concat(val), [])
+          .reduce(
+            (acc, bucketRules) =>
+              acc.concat(bucketRules.map(cssRule => (Array.isArray(cssRule) ? cssRule[0] : cssRule))),
+            [],
+          )
           .join('\n');
+
         const prettified = beautify.css_beautify(raw, { indent_size: 2 });
         setRules(prettified);
       },

--- a/apps/website/src/components/Playground/code/styles.js
+++ b/apps/website/src/components/Playground/code/styles.js
@@ -1,4 +1,3 @@
-//@ts-check
 import { makeStyles, shorthands } from '@griffel/core';
 
 export default makeStyles({

--- a/apps/website/src/components/Playground/code/templates/border.js
+++ b/apps/website/src/components/Playground/code/templates/border.js
@@ -17,4 +17,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Border',
+  position: 3,
 };

--- a/apps/website/src/components/Playground/code/templates/global.js
+++ b/apps/website/src/components/Playground/code/templates/global.js
@@ -10,4 +10,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Global styles',
+  position: 9,
 };

--- a/apps/website/src/components/Playground/code/templates/margin.js
+++ b/apps/website/src/components/Playground/code/templates/margin.js
@@ -19,4 +19,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Margin',
+  position: 1,
 };

--- a/apps/website/src/components/Playground/code/templates/media.js
+++ b/apps/website/src/components/Playground/code/templates/media.js
@@ -15,4 +15,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Media queries',
+  position: 8,
 };

--- a/apps/website/src/components/Playground/code/templates/nested.js
+++ b/apps/website/src/components/Playground/code/templates/nested.js
@@ -14,4 +14,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Nested selectors',
+  position: 7,
 };

--- a/apps/website/src/components/Playground/code/templates/padding.js
+++ b/apps/website/src/components/Playground/code/templates/padding.js
@@ -19,4 +19,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Padding',
+  position: 2,
 };

--- a/apps/website/src/components/Playground/code/templates/pseudo-elements.js
+++ b/apps/website/src/components/Playground/code/templates/pseudo-elements.js
@@ -19,4 +19,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Pseudo-elements',
+  position: 5,
 };

--- a/apps/website/src/components/Playground/code/templates/pseudo-selectors.js
+++ b/apps/website/src/components/Playground/code/templates/pseudo-selectors.js
@@ -22,4 +22,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Pseudo-selectors',
+  position: 4,
 };

--- a/apps/website/src/components/Playground/code/templates/selectors.js
+++ b/apps/website/src/components/Playground/code/templates/selectors.js
@@ -28,4 +28,5 @@ export default makeStyles({
 
 export const meta = {
   name: 'Selectors',
+  position: 6,
 };

--- a/apps/website/src/components/Playground/docusaurusPlugin.js
+++ b/apps/website/src/components/Playground/docusaurusPlugin.js
@@ -11,8 +11,13 @@ module.exports = function () {
           rules: [
             {
               test: /\.js$/,
+              include: path.resolve(__dirname, 'code'),
+              use: [{ loader: 'raw-loader' }],
+            },
+            {
+              test: /\.js$/,
               include: path.resolve(__dirname, 'code', 'templates'),
-              use: [{ loader: 'raw-loader' }, { loader: require.resolve('./webpackLoader') }],
+              use: [{ loader: require.resolve('./webpackLoader') }],
             },
           ],
         },

--- a/apps/website/src/components/Playground/docusaurusPlugin.js
+++ b/apps/website/src/components/Playground/docusaurusPlugin.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+// Docusaurus plugin that modifies Webpack config to process files in "templates" folder.
+/** @type {import('@docusaurus/types').PluginModule} */
+module.exports = function () {
+  return {
+    name: 'playground-docusaurus-plugin',
+    configureWebpack() {
+      return {
+        module: {
+          rules: [
+            {
+              test: /\.js$/,
+              include: path.resolve(__dirname, 'code', 'templates'),
+              use: [{ loader: 'raw-loader' }, { loader: require.resolve('./webpackLoader') }],
+            },
+          ],
+        },
+      };
+    },
+  };
+};

--- a/apps/website/src/components/Playground/index.tsx
+++ b/apps/website/src/components/Playground/index.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { SandpackProvider, SandpackLayout, SandpackCodeEditor, SandpackPreview } from '@codesandbox/sandpack-react';
 import { useColorMode } from '@docusaurus/theme-common';
 import { useLocation } from '@docusaurus/router';
+
 import AppCode from '!!raw-loader!./code/app.js';
 import DefaultStylesCode from '!!raw-loader!./code/styles.js';
 
-const ctx = require.context('!!raw-loader!./code/templates', false, /\.js$/);
+const ctx = require.context('./code/templates', false, /\.js$/);
 
 const templates: Record<string, string> = ctx.keys().reduce((acc, modulePath) => {
   if (modulePath.includes('app')) {
@@ -20,10 +21,12 @@ const templates: Record<string, string> = ctx.keys().reduce((acc, modulePath) =>
 const PLAYGROUND_HEIGHT = 400;
 
 export default function Playground() {
-  const { isDarkTheme } = useColorMode();
-  const sandpackTheme = isDarkTheme ? 'dark' : 'github-light';
+  const { colorMode } = useColorMode();
+
+  const sandpackTheme = colorMode === 'dark' ? 'dark' : 'github-light';
   const location = useLocation();
   const template = templates[location.hash.slice(1)] ?? DefaultStylesCode;
+
   return (
     <SandpackProvider
       template="react"

--- a/apps/website/src/components/Playground/index.tsx
+++ b/apps/website/src/components/Playground/index.tsx
@@ -3,8 +3,8 @@ import { SandpackProvider, SandpackLayout, SandpackCodeEditor, SandpackPreview }
 import { useColorMode } from '@docusaurus/theme-common';
 import { useLocation } from '@docusaurus/router';
 
-import AppCode from '!!raw-loader!./code/app.js';
-import DefaultStylesCode from '!!raw-loader!./code/styles.js';
+import AppCode from './code/app';
+import DefaultStylesCode from './code/styles';
 
 const ctx = require.context('./code/templates', false, /\.js$/);
 
@@ -33,9 +33,13 @@ export default function Playground() {
       customSetup={{
         dependencies: { '@griffel/core': 'latest', 'highlight.js': 'latest', 'js-beautify': 'latest' },
         files: {
-          '/App.js': { code: AppCode, hidden: true },
+          '/App.js': {
+            // "AppCode" is a string as it's processed by "raw-loader", see "webpackLoader.js"
+            code: AppCode as unknown as string,
+            hidden: true,
+          },
           // Template files are in JS but type checked, don't want unnecessary comments leaking into docs
-          '/styles.js': { code: template.replace('//@ts-check\n', ''), active: true },
+          '/styles.js': { code: template, active: true },
         },
       }}
     >

--- a/apps/website/src/components/Playground/webpackLoader.js
+++ b/apps/website/src/components/Playground/webpackLoader.js
@@ -1,4 +1,6 @@
 /**
+ * Custom Webpack loader that removes "export const meta = {}" from code.
+ *
  * @param {String} sourceCode
  * @return {String}
  */

--- a/apps/website/src/components/Playground/webpackLoader.js
+++ b/apps/website/src/components/Playground/webpackLoader.js
@@ -1,0 +1,7 @@
+/**
+ * @param {String} sourceCode
+ * @return {String}
+ */
+module.exports = function webpackLoader(sourceCode) {
+  return sourceCode.replace(/export const meta = {(.|\n)+};/, '').trim();
+};


### PR DESCRIPTION
This PR implements fixes and enhancements for docs.

### Fixes media query output issue

After recent changes we have a strange output:

![image](https://user-images.githubusercontent.com/14183168/179707420-60dc752a-76cc-49f7-b8fe-1d81101be8d7.png)

### Implements ordering in try out

Before templates in playground were ordered based on names, not based on usage/complexity. This led to confusion as "Global selector" goes before actual "Selectors"...

### `meta` is removed from templates

![image](https://user-images.githubusercontent.com/14183168/179707827-bce61b6d-761f-4968-acdf-f6483f7dfcaf.png)

Our templates had utility information that is redundant for users, now it's gone.