### PR TITLE
fix: add css rules to devtools extension debugger when pass renderer on SSR

### DIFF
--- a/change/@griffel-core-2d973eb8-c6f3-4e30-882c-2590b8ff4e1b.json
+++ b/change/@griffel-core-2d973eb8-c6f3-4e30-882c-2590b8ff4e1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add css rules to devtools extension debugger when pass renderer on SSR",
+  "packageName": "@griffel/core",
+  "email": "dwlad90@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-devtools-afaa43f6-11f2-4c19-a3bf-a8f6ce282256.json
+++ b/change/@griffel-devtools-afaa43f6-11f2-4c19-a3bf-a8f6ce282256.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add css rules to devtools extension debugger when pass renderer on SSR",
+  "packageName": "@griffel/devtools",
+  "email": "dwlad90@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/devtools/store.ts
+++ b/packages/core/src/devtools/store.ts
@@ -41,4 +41,7 @@ export const debugData = {
   getSequenceDetails: (sequenceHash: SequenceHash): typeof sequenceDetails[string] | undefined => {
     return sequenceDetails[sequenceHash];
   },
+  hasCSSRule: (rule: string): boolean => {
+    return cssRules.includes(rule);
+  },
 };

--- a/packages/core/src/devtools/store.ts
+++ b/packages/core/src/devtools/store.ts
@@ -4,7 +4,7 @@ import { mergeClassesCachedResults } from '../mergeClasses';
 
 const sequenceDetails: Record<SequenceHash, { slotName: string; sourceURL?: string }> = {};
 
-const cssRules: string[] = [];
+const cssRules = new Set<string>();
 
 export const debugData = {
   getChildrenSequences: (debugSequenceHash: SequenceHash): SequenceHash[] => {
@@ -24,7 +24,7 @@ export const debugData = {
   },
 
   addCSSRule: (rule: string) => {
-    cssRules.push(rule);
+    cssRules.add(rule);
   },
   addSequenceDetails: <Slots extends string | number>(
     classNamesForSlots: Record<Slots, string>,
@@ -36,12 +36,9 @@ export const debugData = {
   },
 
   getCSSRules: (): string[] => {
-    return cssRules;
+    return Array.from(cssRules);
   },
   getSequenceDetails: (sequenceHash: SequenceHash): typeof sequenceDetails[string] | undefined => {
     return sequenceDetails[sequenceHash];
-  },
-  hasCSSRule: (rule: string): boolean => {
-    return cssRules.includes(rule);
   },
 };

--- a/packages/core/src/renderer/createDOMRenderer.ts
+++ b/packages/core/src/renderer/createDOMRenderer.ts
@@ -67,14 +67,17 @@ export function createDOMRenderer(
             metadata,
           );
 
+          if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+            if (!debugData.hasCSSRule(ruleCSS)) {
+              debugData.addCSSRule(ruleCSS);
+            }
+          }
+
           if (renderer.insertionCache[ruleCSS]) {
             continue;
           }
 
           renderer.insertionCache[ruleCSS] = styleBucketName as StyleBucketName;
-          if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
-            debugData.addCSSRule(ruleCSS);
-          }
 
           try {
             if (unstable_filterCSSRule) {

--- a/packages/core/src/renderer/createDOMRenderer.ts
+++ b/packages/core/src/renderer/createDOMRenderer.ts
@@ -67,17 +67,14 @@ export function createDOMRenderer(
             metadata,
           );
 
-          if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
-            if (!debugData.hasCSSRule(ruleCSS)) {
-              debugData.addCSSRule(ruleCSS);
-            }
-          }
-
           if (renderer.insertionCache[ruleCSS]) {
             continue;
           }
 
           renderer.insertionCache[ruleCSS] = styleBucketName as StyleBucketName;
+          if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+            debugData.addCSSRule(ruleCSS);
+          }
 
           try {
             if (unstable_filterCSSRule) {

--- a/packages/core/src/renderer/rehydrateRendererCache.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.ts
@@ -1,5 +1,6 @@
 import { GriffelRenderer, StyleBucketName } from '../types';
 import { createIsomorphicStyleSheetFromElement } from './createIsomorphicStyleSheet';
+import { isDevToolsEnabled, debugData } from '../devtools';
 
 // Regexps to extract names of classes and animations
 // https://github.com/styletron/styletron/blob/e0fcae826744eb00ce679ac613a1b10d44256660/packages/styletron-engine-atomic/src/client/client.js#L8
@@ -43,6 +44,10 @@ export function rehydrateRendererCache(
         const [cssRule] = match;
 
         renderer.insertionCache[cssRule] = bucketName;
+
+        if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+          debugData.addCSSRule(cssRule);
+        }
       }
     });
   }

--- a/packages/devtools/src/utils.ts
+++ b/packages/devtools/src/utils.ts
@@ -10,12 +10,14 @@ export function getRulesBySlots(node: DebugResult, result: SlotInfo[] = []): Slo
       {
         slot,
         sourceURL,
-        rules: debugClassNames.map(({ className, overriddenBy }) => {
-          return {
-            cssRule: rules![className],
-            overriddenBy,
-          };
-        }),
+        rules: debugClassNames
+          .filter(({ className }) => !!rules?.[className])
+          .map(({ className, overriddenBy }) => {
+            return {
+              cssRule: rules![className],
+              overriddenBy,
+            };
+          }),
       },
     ];
   }

--- a/packages/devtools/src/utils.ts
+++ b/packages/devtools/src/utils.ts
@@ -1,5 +1,5 @@
 import type { DebugResult } from '@griffel/core';
-import { SlotInfo } from './types';
+import type { SlotInfo, AtomicRules } from './types';
 
 export function getRulesBySlots(node: DebugResult, result: SlotInfo[] = []): SlotInfo[] {
   if (node.children.length === 0 && node.slot) {
@@ -10,14 +10,16 @@ export function getRulesBySlots(node: DebugResult, result: SlotInfo[] = []): Slo
       {
         slot,
         sourceURL,
-        rules: debugClassNames
-          .filter(({ className }) => !!rules?.[className])
-          .map(({ className, overriddenBy }) => {
-            return {
+        rules: debugClassNames.reduce((acc, { className, overriddenBy }) => {
+          if (className) {
+            acc.push({
               cssRule: rules![className],
               overriddenBy,
-            };
-          }),
+            });
+          }
+
+          return acc;
+        }, [] as AtomicRules[]),
       },
     ];
   }


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/griffel/issues/173.