### PR TITLE
Fix(RTL): Flip CSS properties even if they contain CSS variables

### DIFF
--- a/change/@griffel-core-c60d0c4f-e496-4ec4-bb67-fae7384bfbe1.json
+++ b/change/@griffel-core-c60d0c4f-e496-4ec4-bb67-fae7384bfbe1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(RTL): Flip CSS properties even if they contain CSS variables",
+  "packageName": "@griffel/core",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-core-c60d0c4f-e496-4ec4-bb67-fae7384bfbe1.json
+++ b/change/@griffel-core-c60d0c4f-e496-4ec4-bb67-fae7384bfbe1.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(RTL): Flip CSS properties even if they contain CSS variables",
+  "comment": "fix: flip CSS properties even if they contain CSS variables",
   "packageName": "@griffel/core",
   "email": "miroslav.stastny@microsoft.com",
   "dependentChangeType": "patch"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "csstype": "^3.0.10",
     "enhanced-resolve": "^5.8.2",
     "loader-utils": "^2.0.0",
-    "rtl-css-js": "^1.15.0",
+    "rtl-css-js": "^1.16.0",
     "schema-utils": "^3.1.1",
     "stylis": "^4.0.13",
     "tslib": "^2.1.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/hash": "^0.8.0",
     "csstype": "^3.0.10",
-    "rtl-css-js": "^1.15.0",
+    "rtl-css-js": "^1.16.0",
     "stylis": "^4.0.13",
     "tslib": "^2.1.0"
   }

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -189,15 +189,64 @@ describe('resolveStyleRules', () => {
       );
     });
 
-    it('handles RTL', () => {
-      expect(resolveStyleRules({ left: '5px' })).toMatchInlineSnapshot(`
-        .f5b3q4t {
-          left: 5px;
-        }
-        .flgfsvn {
-          right: 5px;
-        }
-      `);
+    describe('handles RTL', () => {
+      it('property flipping', () => {
+        expect(resolveStyleRules({ left: '5px' })).toMatchInlineSnapshot(`
+          .f5b3q4t {
+            left: 5px;
+          }
+          .flgfsvn {
+            right: 5px;
+          }
+        `);
+      });
+
+      it('boxShadow with strings', () => {
+        expect(
+          resolveStyleRules({
+            boxShadow: 'inset 2rem 0rem 0.4rem -1rem #eee',
+          }),
+        ).toMatchInlineSnapshot(`
+                  .fissx19 {
+                    box-shadow: inset 2rem 0rem 0.4rem -1rem #eee;
+                  }
+                  .f14ydmub {
+                    box-shadow: inset -2rem 0rem 0.4rem -1rem #eee;
+                  }
+              `);
+      });
+
+      it('boxShadow with CSS variable', () => {
+        expect(
+          resolveStyleRules({
+            boxShadow: 'inset 2rem 0rem 0.4rem -1rem var(--colorToken)',
+          }),
+        ).toMatchInlineSnapshot(`
+                  .fko8do5 {
+                    box-shadow: inset 2rem 0rem 0.4rem -1rem var(--colorToken);
+                  }
+                  .fvdav93 {
+                    box-shadow: inset -2rem 0rem 0.4rem -1rem var(--colorToken);
+                  }
+              `);
+      });
+
+      it('boxShadow with multiple values', () => {
+        expect(
+          resolveStyleRules({
+            boxShadow: 'inset 2rem 0rem 0.4rem -1rem var(--colorToken), 4px 0rem 0.4rem 2rem var(--anotherToken)',
+          }),
+        ).toMatchInlineSnapshot(`
+          .frvj0nn {
+            box-shadow: inset 2rem 0rem 0.4rem -1rem var(--colorToken),
+              4px 0rem 0.4rem 2rem var(--anotherToken);
+          }
+          .fzr4yxb {
+            box-shadow: inset -2rem 0rem 0.4rem -1rem var(--colorToken),
+              -4px 0rem 0.4rem 2rem var(--anotherToken);
+          }
+        `);
+      });
     });
 
     it('handles RTL @noflip', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13719,7 +13719,7 @@ __metadata:
     react: 17.0.2
     react-dom: 17.0.2
     react-test-renderer: 17.0.2
-    rtl-css-js: ^1.15.0
+    rtl-css-js: ^1.16.0
     schema-utils: ^3.1.1
     simple-git-hooks: 2.7.0
     stylis: ^4.0.13
@@ -21173,12 +21173,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rtl-css-js@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "rtl-css-js@npm:1.15.0"
+"rtl-css-js@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "rtl-css-js@npm:1.16.0"
   dependencies:
     "@babel/runtime": ^7.1.2
-  checksum: e18a7b30b847def79e14636ee2096185881c4b8bab93dbb20fac2227b5a4d404a5a48d48cf357b618e113a5ebc027394f5c23ccd6f71ff0abc018a7ddbb8db54
+  checksum: 51756329f691cacd3e1b48f0f9d04a69338a90013f2d2942ca1ae3b069c952f70055f5fd76c66921e9a5cb956276252376a847c3294bd0ee54be9ceb32ea868c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What**
Allow RTL flipping of CSS properties even if they reference CSS variables.

```js
boxShadow: '6px 3px 8px 5px var(--css-variable)';

/* ⬇️ now flips offset-x in RTL ⬇️ */

boxShadow: '-6px 3px 8px 5px var(--css-variable)';
```

**Why**

Previously, CSS properties which contained `var()` were not flipped.

There are cases where, when a CSS variable is used, there is no way how the value can be flipped:

```js
padding: 'var(--foo)'; /* 🔴 No way how to flip - foo can be a single value as well as four? */
```

On the other hand, there are other use cases, where the flipping is possible and meaningful:
```js
padding: margin: '1px var(--token) 3px 4px'; /* ✅ should be flipped to '1px 4px 3px var(--token)' */
boxShadow: '6px 3px 8px 5px var(--css-variable);' /* ✅ CSS variable used only for color, offset can be safely flipped */
```

**Caveats**
If CSS variable is used for the first value in `shadow`, the flipped result might be wrong:
```js
boxShadow: 'var(--token) 3px 4px red' /* 💥 3px is considered the first number and is flipped to -3px */
```
This is the expected result if the `--token` resolves to `inset` but incorrect if it resolves to a number. In that case the `3px` is `offset-y` which should not have been flipped.

Takeaway: flipping values which contain CSS variables is problematic, styles authors must know what they are doing. As there are still valid and safe use cases, this behavior is better than just strictly disallowing anything what contains a CSS variable to be flipped.
