### PR TITLE
fix(webpack-extraction-plugin): Inject griffel styles in babelPluginStripGriffelRuntime instead of webpackLoader

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-c8f9cd03-61de-49c3-8a75-107c2c9dd507.json
+++ b/change/@griffel-webpack-extraction-plugin-c8f9cd03-61de-49c3-8a75-107c2c9dd507.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Inject griffel styles in babelPluginStripGriffelRuntime instead of webpackLoader",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "dwlad90@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@testing-library/react-hooks": "7.0.2",
     "@tsconfig/docusaurus": "^1.0.4",
     "@types/babel__helper-plugin-utils": "7.10.0",
+    "@types/babel__template": "^7.4.1",
     "@types/chrome": "0.0.180",
     "@types/d3-scale-chromatic": "^3.0.0",
     "@types/jest": "27.0.2",

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
@@ -9,4 +9,4 @@ export const styles = __css({
     Bi91k9c: 'faf35ka',
   },
 });
-import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
@@ -9,4 +9,4 @@ export const styles = __css({
     Bi91k9c: 'faf35ka',
   },
 });
-import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
@@ -9,3 +9,4 @@ export const styles = __css({
     Bi91k9c: 'faf35ka',
   },
 });
+import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
@@ -9,4 +9,4 @@ export const stylesB = __css({
     De3pzq: 'fcnqdeg',
   },
 });
-import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
@@ -9,3 +9,4 @@ export const stylesB = __css({
     De3pzq: 'fcnqdeg',
   },
 });
+import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
@@ -9,4 +9,4 @@ export const stylesB = __css({
     De3pzq: 'fcnqdeg',
   },
 });
-import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
@@ -4,5 +4,4 @@ export const useStyles = __css({
     Bcmaq0h: 'fnwsaxv',
   },
 });
-
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D';
+import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
@@ -4,4 +4,4 @@ export const useStyles = __css({
     Bcmaq0h: 'fnwsaxv',
   },
 });
-import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D';
+import '../../../virtual-loader!../../../virtual-loader/griffel.css?style=.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
@@ -4,4 +4,4 @@ export const useStyles = __css({
     Bcmaq0h: 'fnwsaxv',
   },
 });
-import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D';
+import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -12,4 +12,4 @@ const styles = __css({
 });
 
 console.log(styles);
-import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -12,5 +12,4 @@ const styles = __css({
 });
 
 console.log(styles);
-
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -12,4 +12,4 @@ const styles = __css({
 });
 
 console.log(styles);
-import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -9,4 +9,4 @@ export const stylesB = __css({
     De3pzq: 'fcnqdeg',
   },
 });
-import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -9,5 +9,4 @@ export const stylesB = __css({
     De3pzq: 'fcnqdeg',
   },
 });
-
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -9,4 +9,4 @@ export const stylesB = __css({
     De3pzq: 'fcnqdeg',
   },
 });
-import '@griffel/webpack-extraction-plugin/virtual-loader/index.js!@griffel/webpack-extraction-plugin/virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import '../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@babel/core": "^7.12.13",
     "@babel/helper-plugin-utils": "^7.12.13",
+    "@babel/template": "^7.12.13",
     "loader-utils": "^2.0.0",
     "schema-utils": "^3.1.1",
     "stylis": "^4.0.13",

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -208,7 +208,7 @@ function testFixture(fixtureName: string, options: CompileOptions = {}) {
   }, 15000);
 }
 
-describe('webpackLoader', () => {
+describe('babelPluginStripGriffelRuntime', () => {
   // Basic assertions
   testFixture('basic-rules');
 

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -20,7 +20,7 @@ function forceCSSIntoOneStyleSheet(compiler: Compiler) {
     name: `griffel`,
     type: 'css/mini-extract',
     chunks: 'all',
-    test: /griffel.css/,
+    test: /virtual-loader\/griffel\.css$/,
     enforce: true,
   };
 }

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
@@ -4,8 +4,13 @@ import { CSSRulesByBucket, normalizeCSSBucketEntry } from '@griffel/core';
 import * as path from 'path';
 import template from '@babel/template';
 
-const virtualLoaderPath = '@griffel/webpack-extraction-plugin/virtual-loader/index.js';
-const resourcePath = '@griffel/webpack-extraction-plugin/virtual-loader/griffel.css';
+const resourceDirectory =
+  process.env.NODE_ENV === 'test'
+    ? path.relative(__dirname, 'virtual-loader')
+    : '@griffel/webpack-extraction-plugin/virtual-loader';
+
+const virtualLoaderPath = `${resourceDirectory}/index.js`;
+const resourcePath = `${resourceDirectory}/griffel.css`;
 
 type StripRuntimeBabelPluginOptions = {
   /** A directory that contains fake .css file used for CSS extraction */

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
@@ -4,13 +4,12 @@ import { CSSRulesByBucket, normalizeCSSBucketEntry } from '@griffel/core';
 import * as path from 'path';
 import template from '@babel/template';
 
-const resourceDirectory =
+const virtualLoaderPath =
   process.env.NODE_ENV === 'test'
     ? path.relative(__dirname, 'virtual-loader')
     : '@griffel/webpack-extraction-plugin/virtual-loader';
 
-const virtualLoaderPath = `${resourceDirectory}/index.js`;
-const resourcePath = `${resourceDirectory}/griffel.css`;
+const resourcePath = `${virtualLoaderPath}/griffel.css`;
 
 type StripRuntimeBabelPluginOptions = {
   /** A directory that contains fake .css file used for CSS extraction */

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -12,9 +12,6 @@ type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLo
 
 const resourceDirectory = path.resolve(__dirname, '..', 'virtual-loader');
 
-const virtualLoaderPath = path.resolve(resourceDirectory, 'index.js');
-const resourcePath = path.resolve(resourceDirectory, 'griffel.css');
-
 function toURIComponent(rule: string): string {
   return encodeURIComponent(rule).replace(/!/g, '%21');
 }
@@ -78,18 +75,6 @@ function webpackLoader(
   }
 
   if (result) {
-    if (result.cssRules) {
-      const request = `import ${JSON.stringify(
-        this.utils.contextify(
-          this.context || this.rootContext,
-          `griffel.css!=!${virtualLoaderPath}!${resourcePath}?style=${toURIComponent(result.cssRules.join('\n'))}`,
-        ),
-      )};`;
-
-      this.callback(null, `${result.code}\n\n${request};`, result.sourceMap);
-      return;
-    }
-
     this.callback(null, result.code, result.sourceMap);
     return;
   }

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -12,10 +12,6 @@ type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLo
 
 const resourceDirectory = path.resolve(__dirname, '..', 'virtual-loader');
 
-function toURIComponent(rule: string): string {
-  return encodeURIComponent(rule).replace(/!/g, '%21');
-}
-
 function shouldTransformSourceCode(sourceCode: string): boolean {
   return sourceCode.indexOf('__styles') !== -1;
 }

--- a/packages/webpack-extraction-plugin/tsconfig.spec.json
+++ b/packages/webpack-extraction-plugin/tsconfig.spec.json
@@ -16,6 +16,7 @@
     "**/*.spec.js",
     "**/*.test.jsx",
     "**/*.spec.jsx",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "src/webpackLoader.tes.ts"
   ]
 }

--- a/packages/webpack-extraction-plugin/virtual-loader/index.js
+++ b/packages/webpack-extraction-plugin/virtual-loader/index.js
@@ -11,4 +11,26 @@ function virtualLoader() {
   return styleRule ?? '';
 }
 
-module.exports = virtualLoader;
+exports.default = virtualLoader;
+
+/**
+ * Moves CSSloader to the end of the loader queue so it runs first.
+ */
+/**
+ * @this {import('webpack').LoaderContext<unknown>}
+ * @return {void}
+ */
+function pitch() {
+  if (this.loaders[0].pitch !== pitch) {
+    // If the first loader isn't this one - skip.
+    return;
+  }
+  // The first loader is Griffel's css-loader - we need to shift
+  // it to be at the end of the loader chain so it runs first (instead of last).
+  const firstLoader = this.loaders.shift();
+
+  if (typeof firstLoader !== 'undefined') {
+    this.loaders.push(firstLoader);
+  }
+}
+exports.pitch = pitch;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,8 @@
       "@griffel/eslint-plugin": ["packages/eslint-plugin/src/index.ts"],
       "@griffel/jest-serializer": ["packages/jest-serializer/src/index.ts"],
       "@griffel/react": ["packages/react/src/index.ts"],
-      "@griffel/webpack-loader": ["packages/webpack-loader/src/index.ts"]
+      "@griffel/webpack-loader": ["packages/webpack-loader/src/index.ts"],
+      "@griffel/webpack-extraction-plugin/virtual-loader/*": ["packages/webpack-extraction-plugin/virtual-loader/*"]
     },
     "typeRoots": ["node_modules/@types", "./typings"]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5930,7 +5930,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__template@npm:*":
+"@types/babel__template@npm:*, @types/babel__template@npm:^7.4.1":
   version: 7.4.1
   resolution: "@types/babel__template@npm:7.4.1"
   dependencies:
@@ -13669,6 +13669,7 @@ __metadata:
     "@testing-library/react-hooks": 7.0.2
     "@tsconfig/docusaurus": ^1.0.4
     "@types/babel__helper-plugin-utils": 7.10.0
+    "@types/babel__template": ^7.4.1
     "@types/chrome": 0.0.180
     "@types/d3-scale-chromatic": ^3.0.0
     "@types/jest": 27.0.2


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/microsoft/griffel/issues/154)