### PR TITLE
feat: re-export GriffelRenderer from @griffel/react

### DIFF
--- a/change/@griffel-react-dec49600-8627-49d4-8e4d-a37852ccb6b6.json
+++ b/change/@griffel-react-dec49600-8627-49d4-8e4d-a37852ccb6b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: re-export GriffelRenderer type",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-export { shorthands, mergeClasses, createDOMRenderer } from '@griffel/core';
+export { shorthands, mergeClasses, createDOMRenderer, GriffelRenderer } from '@griffel/core';
 export type { GriffelStyle, CreateDOMRendererOptions } from '@griffel/core';
 
 export { makeStyles } from './makeStyles';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
-export { shorthands, mergeClasses, createDOMRenderer, GriffelRenderer } from '@griffel/core';
-export type { GriffelStyle, CreateDOMRendererOptions } from '@griffel/core';
+export { shorthands, mergeClasses, createDOMRenderer } from '@griffel/core';
+export type { GriffelStyle, CreateDOMRendererOptions, GriffelRenderer } from '@griffel/core';
 
 export { makeStyles } from './makeStyles';
 export { makeStaticStyles } from './makeStaticStyles';


### PR DESCRIPTION
`GriffelRenderer` type is needed to defined proper custom types to be used in Next.js (see https://github.com/microsoft/fluentui/issues/24158, https://github.com/microsoft/fluentui/pull/24202).