### PR TITLE
test: add a test to ensure that "&" is handled equally

### DIFF
--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -877,5 +877,13 @@ describe('resolveStyleRules', () => {
         uwmqm3: ['frdkuqy', 'f81rol6'],
       });
     });
+
+    it('handles "&" in pseudo selectors equally', () => {
+      const caseA = resolveStyleRules({ ':hover': { color: 'red' } });
+      const caseB = resolveStyleRules({ '&:hover': { color: 'red' } });
+
+      expect(caseA[0]).toEqual(caseB[0]);
+      expect(caseA[1]).toEqual(caseB[1]);
+    });
   });
 });


### PR DESCRIPTION
This PR adds a test to ensure that `:hover` & `&:hover` handled equally and will work in consistently in style overrides.