### PR TITLE
fix(devtools): normalize relative path in source url

### DIFF
--- a/change/@griffel-devtools-32883921-647e-4e71-8659-54152995e3e5.json
+++ b/change/@griffel-devtools-32883921-647e-4e71-8659-54152995e3e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix devtools to resolve relative source url",
+  "packageName": "@griffel/devtools",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/devtools/src/sourceMap/loadOriginalSourceLoc.ts
+++ b/packages/devtools/src/sourceMap/loadOriginalSourceLoc.ts
@@ -33,7 +33,19 @@ function parseSourceUrl(sourceUrlWithLoc: string): MappedPosition | null {
   const paths = sourceUrlWithLoc.split(':');
   const column = Number(paths.pop());
   const line = Number(paths.pop());
-  const source = paths.join(':');
+
+  let source = paths.join(':');
+  try {
+    // url can contain relative path when webpack is used; normalize it
+    const { protocol, pathname } = new URL(source);
+    if (!protocol.startsWith('http')) {
+      const absPathname = new URL(`http://${pathname}`).pathname; // URL only normalizes pathname for http/https
+      source = `${protocol}//${absPathname}`;
+    }
+  } catch (error) {
+    console.warn(error);
+  }
+
   if (Number.isNaN(line) || Number.isNaN(column)) {
     return null;
   }


### PR DESCRIPTION
Devtools read source url from error stack. Sometimes these urls contain relative path, depending on how the app is bundled. However chrome always store resources using absolute path. This PR normalizes the source url so we can find it and read it using chrome resources API.

<img width="915" alt="Screenshot 2022-08-30 at 9 51 17" src="https://user-images.githubusercontent.com/28751745/187484082-98eea091-95b5-4505-a06f-b92f287aebae.png">
