### PR TITLE
fix(devtools): show override when overriding rule is the same

### DIFF
--- a/change/@griffel-core-7824828a-f980-4c5d-ba33-06d73ffb351d.json
+++ b/change/@griffel-core-7824828a-f980-4c5d-ba33-06d73ffb351d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix devtools to show override when the overriding rule is the same",
+  "comment": "fix: update debug data collection to handle duplicate overrides",
   "packageName": "@griffel/core",
   "email": "yuanboxue@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@griffel-core-7824828a-f980-4c5d-ba33-06d73ffb351d.json
+++ b/change/@griffel-core-7824828a-f980-4c5d-ba33-06d73ffb351d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix devtools to show override when the overriding rule is the same",
+  "packageName": "@griffel/core",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-devtools-dcd68b39-8976-4d6a-9d04-5aa2e794d090.json
+++ b/change/@griffel-devtools-dcd68b39-8976-4d6a-9d04-5aa2e794d090.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix devtools to show override when the overriding rule is the same",
+  "packageName": "@griffel/devtools",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-devtools-dcd68b39-8976-4d6a-9d04-5aa2e794d090.json
+++ b/change/@griffel-devtools-dcd68b39-8976-4d6a-9d04-5aa2e794d090.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix devtools to show override when the overriding rule is the same",
+  "comment": "fix: show override for same rule, and highlight both selected rule and overriding rule on click; fix griffel className parsing",
   "packageName": "@griffel/devtools",
   "email": "yuanboxue@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/core/src/devtools/getDebugTree.test.ts
+++ b/packages/core/src/devtools/getDebugTree.test.ts
@@ -17,7 +17,7 @@ const options: MakeStylesOptions = {
 const findSequenceHash = (classNames: string) =>
   classNames.split(' ').find(className => className.startsWith(SEQUENCE_PREFIX));
 
-const souceURLregex = /.*\/.*:[0-9]+:[0-9]+/; // url with line and column number
+const sourceURLregex = /.*\/.*:[0-9]+:[0-9]+/; // url with line and column number
 
 describe('getDebugTree', () => {
   it.each<'ltr' | 'rtl'>(['ltr', 'rtl'])('returns styles merge tree when dir=%p', dir => {
@@ -51,7 +51,7 @@ describe('getDebugTree', () => {
           },
           sequenceHash: sequenceGrid,
           slot: 'grid',
-          sourceURL: expect.stringMatching(souceURLregex),
+          sourceURL: expect.stringMatching(sourceURLregex),
         },
         {
           children: [
@@ -69,7 +69,7 @@ describe('getDebugTree', () => {
               },
               sequenceHash: sequenceBlock,
               slot: 'block',
-              sourceURL: expect.stringMatching(souceURLregex),
+              sourceURL: expect.stringMatching(sourceURLregex),
             },
           ],
           debugClassNames: [
@@ -129,7 +129,7 @@ describe('getDebugTree', () => {
           },
           sequenceHash: sequenceBlueBlock,
           slot: 'blueBlock',
-          sourceURL: expect.stringMatching(souceURLregex),
+          sourceURL: expect.stringMatching(sourceURLregex),
         },
         {
           children: [
@@ -152,7 +152,7 @@ describe('getDebugTree', () => {
               },
               sequenceHash: sequenceRedBlock,
               slot: 'redBlock',
-              sourceURL: expect.stringMatching(souceURLregex),
+              sourceURL: expect.stringMatching(sourceURLregex),
             },
           ],
           debugClassNames: [

--- a/packages/core/src/devtools/getDebugTree.test.ts
+++ b/packages/core/src/devtools/getDebugTree.test.ts
@@ -38,6 +38,22 @@ describe('getDebugTree', () => {
     expect(getDebugTree(sequence2!)).toEqual({
       children: [
         {
+          children: [],
+          debugClassNames: [
+            {
+              className: 'f13qh94s',
+              overriddenBy: undefined,
+            },
+          ],
+          direction: dir,
+          rules: {
+            f13qh94s: '.f13qh94s{display:grid;}',
+          },
+          sequenceHash: sequenceGrid,
+          slot: 'grid',
+          sourceURL: expect.stringMatching(souceURLregex),
+        },
+        {
           children: [
             {
               children: [],
@@ -65,22 +81,6 @@ describe('getDebugTree', () => {
           direction: dir,
           sequenceHash: sequence1,
         },
-        {
-          children: [],
-          debugClassNames: [
-            {
-              className: 'f13qh94s',
-              overriddenBy: undefined,
-            },
-          ],
-          direction: dir,
-          rules: {
-            f13qh94s: '.f13qh94s{display:grid;}',
-          },
-          sequenceHash: sequenceGrid,
-          slot: 'grid',
-          sourceURL: expect.stringMatching(souceURLregex),
-        },
       ],
       debugClassNames: [
         {
@@ -89,6 +89,97 @@ describe('getDebugTree', () => {
         },
       ],
       direction: dir,
+      sequenceHash: sequence2,
+    });
+  });
+
+  it('returns correct merging tree when style and overriding style are the same', () => {
+    const classes = makeStyles({
+      redBlock: { display: 'block', color: 'red' },
+      blueBlock: { display: 'block', color: 'blue' },
+    })(options);
+
+    const sequenceRedBlock = findSequenceHash(classes.redBlock);
+    const sequenceBlueBlock = findSequenceHash(classes.blueBlock);
+
+    const className1 = mergeClasses('ui-button', classes.redBlock);
+    const className2 = mergeClasses(className1, classes.blueBlock);
+
+    const sequence1 = findSequenceHash(className1);
+    const sequence2 = findSequenceHash(className2);
+
+    expect(getDebugTree(sequence2!)).toEqual({
+      children: [
+        {
+          children: [],
+          debugClassNames: [
+            {
+              className: 'ftgm304',
+              overriddenBy: undefined,
+            },
+            {
+              className: 'f163i14w',
+              overriddenBy: undefined,
+            },
+          ],
+          direction: 'ltr',
+          rules: {
+            f163i14w: '.f163i14w{color:blue;}',
+            ftgm304: '.ftgm304{display:block;}',
+          },
+          sequenceHash: sequenceBlueBlock,
+          slot: 'blueBlock',
+          sourceURL: expect.stringMatching(souceURLregex),
+        },
+        {
+          children: [
+            {
+              children: [],
+              debugClassNames: [
+                {
+                  className: 'ftgm304',
+                  overriddenBy: 'ftgm304',
+                },
+                {
+                  className: 'fe3e8s9',
+                  overriddenBy: 'f163i14w',
+                },
+              ],
+              direction: 'ltr',
+              rules: {
+                fe3e8s9: '.fe3e8s9{color:red;}',
+                ftgm304: '.ftgm304{display:block;}',
+              },
+              sequenceHash: sequenceRedBlock,
+              slot: 'redBlock',
+              sourceURL: expect.stringMatching(souceURLregex),
+            },
+          ],
+          debugClassNames: [
+            {
+              className: 'ftgm304',
+              overriddenBy: 'ftgm304',
+            },
+            {
+              className: 'fe3e8s9',
+              overriddenBy: 'f163i14w',
+            },
+          ],
+          direction: 'ltr',
+          sequenceHash: sequence1,
+        },
+      ],
+      debugClassNames: [
+        {
+          className: 'ftgm304',
+          overriddenBy: undefined,
+        },
+        {
+          className: 'f163i14w',
+          overriddenBy: undefined,
+        },
+      ],
+      direction: 'ltr',
       sequenceHash: sequence2,
     });
   });

--- a/packages/core/src/devtools/getDebugTree.ts
+++ b/packages/core/src/devtools/getDebugTree.ts
@@ -11,7 +11,12 @@ export function getDebugTree(debugSequenceHash: SequenceHash, parentNode?: Debug
   }
 
   const parentLookupItem = parentNode ? DEFINITION_LOOKUP_TABLE[parentNode.sequenceHash] : undefined;
-  const debugClassNames = getDebugClassNames(lookupItem, parentLookupItem, parentNode?.debugClassNames);
+  const debugClassNames = getDebugClassNames(
+    lookupItem,
+    parentLookupItem,
+    parentNode?.debugClassNames,
+    parentNode?.children,
+  );
 
   const node: DebugSequence = {
     sequenceHash: debugSequenceHash,
@@ -21,12 +26,14 @@ export function getDebugTree(debugSequenceHash: SequenceHash, parentNode?: Debug
   };
 
   const childrenSequences = debugData.getChildrenSequences(node.sequenceHash);
-  childrenSequences.forEach((sequence: SequenceHash) => {
-    const child = getDebugTree(sequence, node);
-    if (child) {
-      node.children.push(child);
-    }
-  });
+  childrenSequences
+    .reverse() // first process the overriding children that are merged last
+    .forEach((sequence: SequenceHash) => {
+      const child = getDebugTree(sequence, node);
+      if (child) {
+        node.children.push(child);
+      }
+    });
 
   // if it's leaf (makeStyle node), get css rules
   if (!node.children.length) {

--- a/packages/core/src/devtools/store.test.ts
+++ b/packages/core/src/devtools/store.test.ts
@@ -60,14 +60,14 @@ describe('debugData', () => {
     const sequenceBlock = findSequenceHash(classes.block);
     const sequenceGrid = findSequenceHash(classes.grid);
 
-    const souceURLregex = /.*\/.*:[0-9]+:[0-9]+/; // url with line and column number
+    const sourceURLregex = /.*\/.*:[0-9]+:[0-9]+/; // url with line and column number
     expect(debugData.getSequenceDetails(sequenceBlock!)).toEqual({
       slotName: 'block',
-      sourceURL: expect.stringMatching(souceURLregex),
+      sourceURL: expect.stringMatching(sourceURLregex),
     });
     expect(debugData.getSequenceDetails(sequenceGrid!)).toEqual({
       slotName: 'grid',
-      sourceURL: expect.stringMatching(souceURLregex),
+      sourceURL: expect.stringMatching(sourceURLregex),
     });
   });
 });

--- a/packages/core/src/devtools/utils.test.ts
+++ b/packages/core/src/devtools/utils.test.ts
@@ -1,4 +1,5 @@
-import { LookupItem } from '../types';
+import type { LookupItem } from '../types';
+import type { DebugSequence } from './types';
 import { getDebugClassNames } from './utils';
 
 describe('getDebugClassNames', () => {
@@ -69,6 +70,36 @@ describe('getDebugClassNames', () => {
       {
         className: 'fdmssx0',
         overriddenBy: 'f3xbvq9',
+      },
+    ]);
+  });
+
+  it('handles parent debug node contains overriding style, but the overriding rule is the same', () => {
+    const lookupItem: LookupItem = [
+      {
+        De3pzq: 'fdmssx0',
+      },
+      'ltr',
+    ];
+    const parentlLookupItem: LookupItem = [
+      {
+        De3pzq: 'fdmssx0',
+      },
+      'ltr',
+    ];
+    const parentDebugClassNames = [{ className: 'fdmssx0', overriddenBy: undefined }];
+    const overridingSiblings: DebugSequence[] = [
+      {
+        sequenceHash: '___1abcdef_1abcdef',
+        direction: 'ltr',
+        children: [],
+        debugClassNames: [{ className: 'fdmssx0' }],
+      },
+    ];
+    expect(getDebugClassNames(lookupItem, parentlLookupItem, parentDebugClassNames, overridingSiblings)).toEqual([
+      {
+        className: 'fdmssx0',
+        overriddenBy: 'fdmssx0',
       },
     ]);
   });

--- a/packages/core/src/devtools/utils.test.ts
+++ b/packages/core/src/devtools/utils.test.ts
@@ -25,9 +25,9 @@ describe('getDebugClassNames', () => {
       },
       'ltr',
     ];
-    const parentlLookupItem: LookupItem = [...lookupItem];
+    const parentLookupItem: LookupItem = [...lookupItem];
     const parentDebugClassNames = [{ className: 'f3xbvq9', overriddenBy: undefined }];
-    expect(getDebugClassNames(lookupItem, parentlLookupItem, parentDebugClassNames)).toEqual([
+    expect(getDebugClassNames(lookupItem, parentLookupItem, parentDebugClassNames)).toEqual([
       {
         className: 'f3xbvq9',
         overriddenBy: undefined,
@@ -42,14 +42,14 @@ describe('getDebugClassNames', () => {
       },
       'ltr',
     ];
-    const parentlLookupItem: LookupItem = [
+    const parentLookupItem: LookupItem = [
       {
         De3pzq: 'f3xbvq9',
       },
       'ltr',
     ];
     const parentDebugClassNames = [{ className: 'f3xbvq9', overriddenBy: undefined }];
-    expect(getDebugClassNames(lookupItem, parentlLookupItem, parentDebugClassNames)).toEqual([
+    expect(getDebugClassNames(lookupItem, parentLookupItem, parentDebugClassNames)).toEqual([
       {
         className: 'fdmssx0',
         overriddenBy: 'f3xbvq9',
@@ -64,9 +64,9 @@ describe('getDebugClassNames', () => {
       },
       'ltr',
     ];
-    const parentlLookupItem: LookupItem = [...lookupItem];
+    const parentLookupItem: LookupItem = [...lookupItem];
     const parentDebugClassNames = [{ className: 'fdmssx0', overriddenBy: 'f3xbvq9' }];
-    expect(getDebugClassNames(lookupItem, parentlLookupItem, parentDebugClassNames)).toEqual([
+    expect(getDebugClassNames(lookupItem, parentLookupItem, parentDebugClassNames)).toEqual([
       {
         className: 'fdmssx0',
         overriddenBy: 'f3xbvq9',
@@ -81,7 +81,7 @@ describe('getDebugClassNames', () => {
       },
       'ltr',
     ];
-    const parentlLookupItem: LookupItem = [
+    const parentLookupItem: LookupItem = [
       {
         De3pzq: 'fdmssx0',
       },
@@ -96,7 +96,7 @@ describe('getDebugClassNames', () => {
         debugClassNames: [{ className: 'fdmssx0' }],
       },
     ];
-    expect(getDebugClassNames(lookupItem, parentlLookupItem, parentDebugClassNames, overridingSiblings)).toEqual([
+    expect(getDebugClassNames(lookupItem, parentLookupItem, parentDebugClassNames, overridingSiblings)).toEqual([
       {
         className: 'fdmssx0',
         overriddenBy: 'fdmssx0',

--- a/packages/core/src/devtools/utils.ts
+++ b/packages/core/src/devtools/utils.ts
@@ -29,12 +29,12 @@ export function getDebugClassNames(
         // parent node has current className (style), and has current selector:
         // case 1. style is not overriden during current merging; it may be overriden in higher level of merging
         // case 2. style is overriden in current merging by exactly the same rule in sibling nodes
-        const siblingHasSameRule = overridingSiblings?.filter(
-          overridingSibling =>
-            overridingSibling.debugClassNames.filter(
-              ({ className: siblingClassName }) => siblingClassName === className,
-            ).length > 0,
-        ).length > 0;
+        const siblingHasSameRule = overridingSiblings
+          ? overridingSiblings.filter(
+              ({ debugClassNames }) =>
+                debugClassNames.filter(({ className: siblingClassName }) => siblingClassName === className).length > 0,
+            ).length > 0
+          : false;
         overriddenBy = siblingHasSameRule
           ? matching.className // case 2
           : matching.overriddenBy; // case 1

--- a/packages/core/src/devtools/utils.ts
+++ b/packages/core/src/devtools/utils.ts
@@ -33,8 +33,8 @@ export function getDebugClassNames(
           overridingSibling =>
             overridingSibling.debugClassNames.filter(
               ({ className: siblingClassName }) => siblingClassName === className,
-            ).length,
-        ).length;
+            ).length > 0,
+        ).length > 0;
         overriddenBy = siblingHasSameRule
           ? matching.className // case 2
           : matching.overriddenBy; // case 1

--- a/packages/core/src/devtools/utils.ts
+++ b/packages/core/src/devtools/utils.ts
@@ -1,5 +1,5 @@
 import { CSSClasses, LookupItem } from '../types';
-import { DebugAtomicClassName } from './types';
+import { DebugAtomicClassName, DebugSequence } from './types';
 
 function getDirectionalClassName(classes: CSSClasses, direction: 'ltr' | 'rtl'): string {
   return Array.isArray(classes) ? (direction === 'rtl' ? classes[1] : classes[0]) : classes;
@@ -9,6 +9,7 @@ export function getDebugClassNames(
   lookupItem: LookupItem,
   parentLookupItem?: LookupItem,
   parentDebugClassNames?: DebugAtomicClassName[],
+  overridingSiblings?: DebugSequence[],
 ): DebugAtomicClassName[] {
   const classesMapping = lookupItem[0];
   const direction = lookupItem[1];
@@ -21,11 +22,30 @@ export function getDebugClassNames(
       const matching = parentDebugClassNames.find(({ className: parentClassName }) => parentClassName === className);
 
       if (!matching && parentLookupItem[0][propertyHash]) {
-        // style is overriden in current merging, by rules in parent debug node
+        // parent node does not have current className (style), but has current selector:
+        // style is overriden in current merging by another rule in sibling node
         overriddenBy = getDirectionalClassName(parentLookupItem[0][propertyHash], parentLookupItem[1]);
-      } else {
-        // overridden status come from higher level of merging
-        overriddenBy = matching?.overriddenBy;
+      } else if (matching && parentLookupItem[0][propertyHash]) {
+        // parent node has current className (style), and has current selector:
+        // case 1. style is not overriden during current merging; it may be overriden in higher level of merging
+        // case 2. style is overriden in current merging by exactly the same rule in sibling nodes
+        const siblingHasSameRule = overridingSiblings?.filter(
+          overridingSibling =>
+            overridingSibling.debugClassNames.filter(
+              ({ className: siblingClassName }) => siblingClassName === className,
+            ).length,
+        ).length;
+        overriddenBy = siblingHasSameRule
+          ? matching.className // case 2
+          : matching.overriddenBy; // case 1
+      } else if (!matching && !parentLookupItem[0][propertyHash]) {
+        // parent node does not have current className (style), and does not have current selector:
+        // this case is not possible
+        overriddenBy = undefined;
+      } else if (matching && !parentLookupItem[0][propertyHash]) {
+        // parent node has current className (style), but does not have current selector:
+        // this case is not possible
+        overriddenBy = undefined;
       }
     }
 

--- a/packages/devtools/src/MonolithicRulesView.tsx
+++ b/packages/devtools/src/MonolithicRulesView.tsx
@@ -30,12 +30,12 @@ const useSingleRuleStyles = makeStyles({
 const SingleRuleView: React.FC<{ rule: RuleDetail; indent?: boolean }> = ({ rule, indent }) => {
   const { highlightedClass, setHighlightedClass } = useViewContext();
 
-  const [clicked, setClicked] = React.useState(false);
+  const [selected, setSelected] = React.useState(false);
 
   const handleClick = (e: React.SyntheticEvent) => {
     e.stopPropagation();
     if (rule.overriddenBy) {
-      setClicked(true);
+      setSelected(true);
       setHighlightedClass(highlighted => (highlighted === rule.overriddenBy ? '' : rule.overriddenBy!));
     } else {
       setHighlightedClass('');
@@ -44,7 +44,7 @@ const SingleRuleView: React.FC<{ rule: RuleDetail; indent?: boolean }> = ({ rule
 
   React.useEffect(() => {
     if (!highlightedClass || highlightedClass !== rule.overriddenBy) {
-      setClicked(false);
+      setSelected(false);
     }
   }, [highlightedClass, rule.overriddenBy]);
 
@@ -52,7 +52,7 @@ const SingleRuleView: React.FC<{ rule: RuleDetail; indent?: boolean }> = ({ rule
   const className = mergeClasses(
     rule.overriddenBy && classes.overriden,
     indent && classes.indent,
-    (clicked || highlightedClass === rule.className) && classes.highlighted,
+    (selected || highlightedClass === rule.className) && classes.highlighted,
   );
 
   return (

--- a/packages/devtools/src/MonolithicRulesView.tsx
+++ b/packages/devtools/src/MonolithicRulesView.tsx
@@ -30,20 +30,29 @@ const useSingleRuleStyles = makeStyles({
 const SingleRuleView: React.FC<{ rule: RuleDetail; indent?: boolean }> = ({ rule, indent }) => {
   const { highlightedClass, setHighlightedClass } = useViewContext();
 
+  const [clicked, setClicked] = React.useState(false);
+
   const handleClick = (e: React.SyntheticEvent) => {
     e.stopPropagation();
     if (rule.overriddenBy) {
+      setClicked(true);
       setHighlightedClass(highlighted => (highlighted === rule.overriddenBy ? '' : rule.overriddenBy!));
     } else {
       setHighlightedClass('');
     }
   };
 
+  React.useEffect(() => {
+    if (!highlightedClass || highlightedClass !== rule.overriddenBy) {
+      setClicked(false);
+    }
+  }, [highlightedClass, rule.overriddenBy]);
+
   const classes = useSingleRuleStyles();
   const className = mergeClasses(
     rule.overriddenBy && classes.overriden,
     indent && classes.indent,
-    highlightedClass === rule.className && classes.highlighted,
+    (clicked || highlightedClass === rule.className) && classes.highlighted,
   );
 
   return (

--- a/packages/devtools/src/getMonolithicCSSRules.test.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.test.ts
@@ -158,7 +158,7 @@ describe('getMonolithicCSSRules', () => {
     });
   });
 
-  it.only('group atomic css when class name selector has selector in front', () => {
+  it('group atomic css when class name selector has selector in front', () => {
     const rules = [
       '[data-keyboard-nav] .fabcde0:focus{background-color:red;}',
       '[data-keyboard-nav] .fabcde1{color:red;}',

--- a/packages/devtools/src/getMonolithicCSSRules.test.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.test.ts
@@ -158,11 +158,12 @@ describe('getMonolithicCSSRules', () => {
     });
   });
 
-  it('group atomic css when class name selector has selector in front', () => {
+  it.only('group atomic css when class name selector has selector in front', () => {
     const rules = [
       '[data-keyboard-nav] .fabcde0:focus{background-color:red;}',
       '[data-keyboard-nav] .fabcde1{color:red;}',
       '[data-keyboard-nav] .fabcde1 .class1{padding-top:10px;}',
+      '[data-keyboard-nav] .fabcde1.class1{padding-bottom:10px;}',
     ].map(cssRule => ({ cssRule }));
     expect(getMonolithicCSSRules(rules)).toEqual({
       '[data-keyboard-nav] ': [
@@ -176,6 +177,13 @@ describe('getMonolithicCSSRules', () => {
         {
           className: 'fabcde1',
           css: 'padding-top:10px;',
+          overriddenBy: undefined,
+        },
+      ],
+      '[data-keyboard-nav] .class1': [
+        {
+          className: 'fabcde1',
+          css: 'padding-bottom:10px;',
           overriddenBy: undefined,
         },
       ],

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -1,7 +1,8 @@
 import * as stylis from 'stylis';
 import type { AtomicRules, MonolithicAtRules, MonolithicRules, RuleDetail } from './types';
 
-const griffelClassNameRegex = /^\.f[0-9a-z]+$/;
+// match className like '.fvnxzrg' or '.fvnxzrg.fui-focus-visible'
+const griffelClassNameRegex = /^\.(f[0-9a-z]+)(\..*|$)/;
 
 function parseRuleElement(element: stylis.Element, overriddenBy?: string) {
   // example of `value`: `.f3xbvq9:hover`
@@ -13,9 +14,10 @@ function parseRuleElement(element: stylis.Element, overriddenBy?: string) {
     const selector = stylis
       .tokenize(classNameSelector)
       .filter(token => {
-        if (griffelClassNameRegex.test(token)) {
-          className = token.slice(1);
-          return false;
+        const match = token.match(griffelClassNameRegex);
+        if (match?.[1]) {
+          className = match?.[1];
+          return match[2] ? true : false;
         }
         return true;
       })

--- a/packages/devtools/src/getMonolithicCSSRules.ts
+++ b/packages/devtools/src/getMonolithicCSSRules.ts
@@ -13,13 +13,13 @@ function parseRuleElement(element: stylis.Element, overriddenBy?: string) {
     let className: string | undefined;
     const selector = stylis
       .tokenize(classNameSelector)
-      .filter(token => {
+      .map(token => {
         const match = token.match(griffelClassNameRegex);
         if (match?.[1]) {
           className = match?.[1];
-          return match[2] ? true : false;
+          return match[2] ?? '';
         }
-        return true;
+        return token;
       })
       .join('');
     const rules: RuleDetail[] = children.map(child => ({

--- a/packages/devtools/src/utils.test.ts
+++ b/packages/devtools/src/utils.test.ts
@@ -6,14 +6,14 @@ describe('getRulesBySlots', () => {
   it('traverse debug result, gather and return all makeStyles slot name and rules', () => {
     const makeStylesNodes: DebugResult[] = [
       {
-        sequenceHash: '___abcdef0_0000000',
+        sequenceHash: '___abcdef2_0000000',
         direction: 'ltr',
         children: [],
-        debugClassNames: [{ className: 'fabcde0' }],
+        debugClassNames: [{ className: 'fabcde2' }],
         rules: {
-          fabcde0: '.fabcde0{background-color:transparent;}',
+          fabcde2: '.fabcde2{display:none;}',
         },
-        slot: 'root',
+        slot: 'slot2',
       },
       {
         sequenceHash: '___abcdef1_0000000',
@@ -26,14 +26,14 @@ describe('getRulesBySlots', () => {
         slot: 'slot1',
       },
       {
-        sequenceHash: '___abcdef2_0000000',
+        sequenceHash: '___abcdef0_0000000',
         direction: 'ltr',
         children: [],
-        debugClassNames: [{ className: 'fabcde2' }],
+        debugClassNames: [{ className: 'fabcde0' }],
         rules: {
-          fabcde2: '.fabcde2{display:none;}',
+          fabcde0: '.fabcde0{background-color:transparent;}',
         },
-        slot: 'slot2',
+        slot: 'root',
       },
     ];
     const debugResultRoot = {

--- a/packages/devtools/src/utils.ts
+++ b/packages/devtools/src/utils.ts
@@ -24,7 +24,7 @@ export function getRulesBySlots(node: DebugResult, result: SlotInfo[] = []): Slo
     ];
   }
 
-  return node.children.reverse().reduce((acc, child) => {
+  return node.children.reduce((acc, child) => {
     return [...acc, ...getRulesBySlots(child)];
   }, result);
 }


### PR DESCRIPTION
## This PR fix 2 problems in devtools.

Here's an example showing both problems: (using devtools on fluent v9 button component):

<img width="782" alt="Screenshot 2022-08-30 at 19 07 47" src="https://user-images.githubusercontent.com/28751745/187500558-fd12cf0c-4bb1-4361-82ec-4262b77801e5.png">

- Problem 1: when overriding rule is the same rule, devtools is not able to determine the overridng rule.
In the above example, 'medium' and the 'primary' slot contains the same style for focus. The one in 'medium' overrides the one in 'primary'. But devtools failed to detect it.

- Problem 2: when selector contains className like `.fxxxx.yyyy` where `.fxxxx` is the className used by griffel, devtools failed to parse this className

After this PR, both problems are fixed. 
Additionally, when clicking on a style, devtools highlights the overriding style. But in the case of problem 1 where both styles are the same, this highlighting feature highlights both styles (because they have the same griffel className). I like it. So I updated the highlighting to always highlight both the selected style, and the overriding style. I think it makes more sense than how it works before.

After PR: 
<img width="895" alt="Screenshot 2022-08-30 at 19 20 44" src="https://user-images.githubusercontent.com/28751745/187503283-7bf47d1e-ce9f-49bf-a16d-0a7d9d487076.png">

