### PR TITLE
fix: do not emit sequence hashes for empty sets

### DIFF
--- a/change/@griffel-core-7e21a596-c13f-4428-a875-d535f075b2c3.json
+++ b/change/@griffel-core-7e21a596-c13f-4428-a875-d535f075b2c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: do not emit sequence hashes for empty sets",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/makeStyles.test.ts
+++ b/packages/core/src/makeStyles.test.ts
@@ -17,6 +17,13 @@ describe('makeStyles', () => {
     document.head.innerHTML = '';
   });
 
+  it('returns an empty classname for an empty style set', () => {
+    const computeClasses = makeStyles({
+      root: {},
+    });
+    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('');
+  });
+
   it('returns a single classname for a single style', () => {
     const computeClasses = makeStyles({
       root: {

--- a/packages/core/src/runtime/reduceToClassNameForSlots.ts
+++ b/packages/core/src/runtime/reduceToClassNameForSlots.ts
@@ -42,16 +42,16 @@ export function reduceToClassNameForSlots<Slots extends string | number>(
 
   // eslint-disable-next-line guard-for-in
   for (const slotName in classesMapBySlot) {
-    const classnamesForSlot = reduceToClassName(classesMapBySlot[slotName], dir);
+    const slotClasses = reduceToClassName(classesMapBySlot[slotName], dir);
 
     // Handles a case when there are no classes in a set i.e. "makeStyles({ root: {} })"
-    if (classnamesForSlot === '') {
+    if (slotClasses === '') {
       classNamesForSlots[slotName] = '';
       continue;
     }
 
-    const sequenceHash = hashSequence(classnamesForSlot, dir);
-    const resultSlotClasses = sequenceHash + ' ' + classnamesForSlot;
+    const sequenceHash = hashSequence(slotClasses, dir);
+    const resultSlotClasses = sequenceHash + ' ' + slotClasses;
 
     DEFINITION_LOOKUP_TABLE[sequenceHash] = [classesMapBySlot[slotName], dir];
     classNamesForSlots[slotName] = resultSlotClasses;

--- a/packages/core/src/runtime/reduceToClassNameForSlots.ts
+++ b/packages/core/src/runtime/reduceToClassNameForSlots.ts
@@ -44,6 +44,12 @@ export function reduceToClassNameForSlots<Slots extends string | number>(
   for (const slotName in classesMapBySlot) {
     const classnamesForSlot = reduceToClassName(classesMapBySlot[slotName], dir);
 
+    // Handles a case when there are no classes in a set i.e. "makeStyles({ root: {} })"
+    if (classnamesForSlot === '') {
+      classNamesForSlots[slotName] = '';
+      continue;
+    }
+
     const sequenceHash = hashSequence(classnamesForSlot, dir);
     const resultSlotClasses = sequenceHash + ' ' + classnamesForSlot;
 


### PR DESCRIPTION
There are cases when a style set is [empty intentionally](https://github.com/microsoft/fluentui/blob/21af8da1d98c070a682b26b7d56775d43a749b3d/packages/react-components/react-button/src/components/Button/useButtonStyles.ts#L122-L124):

```ts
makeStyles({
  root: { /* no rules */ },
})
```

This PR fixes the implementation to not emit a class in such cases to avoid it in DOM & useless class merging if it's passed to `mergeClasses()`.