### PR TITLE
fix: handle nesting in comma separated selectors

### DIFF
--- a/change/@griffel-core-7e54114a-1960-4f4b-8fa5-2ac00bc9b673.json
+++ b/change/@griffel-core-7e54114a-1960-4f4b-8fa5-2ac00bc9b673.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle nesting in comma separated selectors",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-extraction-plugin-c462c63b-aec2-416d-a448-8006eee784c5.json
+++ b/change/@griffel-webpack-extraction-plugin-c462c63b-aec2-416d-a448-8006eee784c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adopt API changes from @griffel/core",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/compileCSS.test.ts
+++ b/packages/core/src/runtime/compileCSS.test.ts
@@ -1,21 +1,23 @@
 import { compileCSS, CompileCSSOptions, normalizePseudoSelector } from './compileCSS';
 
-const defaultOptions: Pick<CompileCSSOptions, 'rtlClassName' | 'className' | 'media' | 'pseudo' | 'support' | 'layer'> =
-  {
-    className: 'foo',
-    rtlClassName: 'rtl-foo',
-    media: '',
-    pseudo: '',
-    support: '',
-    layer: '',
-  };
+const defaultOptions: Pick<
+  CompileCSSOptions,
+  'rtlClassName' | 'className' | 'media' | 'selectors' | 'support' | 'layer'
+> = {
+  className: 'foo',
+  rtlClassName: 'rtl-foo',
+  media: '',
+  selectors: [],
+  support: '',
+  layer: '',
+};
 
 describe('compileCSS', () => {
   it('handles pseudo', () => {
     expect(
       compileCSS({
         ...defaultOptions,
-        pseudo: ':hover',
+        selectors: [':hover'],
         property: 'color',
         value: 'red',
       }),
@@ -27,7 +29,7 @@ describe('compileCSS', () => {
     expect(
       compileCSS({
         ...defaultOptions,
-        pseudo: ':focus:hover',
+        selectors: [':focus:hover'],
         property: 'color',
         value: 'red',
       }),
@@ -98,11 +100,11 @@ describe('compileCSS', () => {
     `);
   });
 
-  it('handles rtl properties with preudo selectors', () => {
+  it('handles rtl properties with pseudo selectors', () => {
     expect(
       compileCSS({
         ...defaultOptions,
-        pseudo: ':before',
+        selectors: [':before'],
 
         property: 'paddingLeft',
         value: '10px',
@@ -140,7 +142,7 @@ describe('compileCSS', () => {
       expect(
         compileCSS({
           ...defaultOptions,
-          pseudo: ':global(body)',
+          selectors: [':global(body)'],
           property: 'color',
           value: 'red',
         }),
@@ -152,13 +154,13 @@ describe('compileCSS', () => {
       expect(
         compileCSS({
           ...defaultOptions,
-          pseudo: ':global(body) &',
+          selectors: [':global(.fui-FluentProvider)', '& .focus:hover'],
           property: 'color',
           value: 'red',
         }),
       ).toMatchInlineSnapshot(`
       Array [
-        "body .foo{color:red;}",
+        ".fui-FluentProvider .foo .focus:hover{color:red;}",
       ]
     `);
     });
@@ -167,7 +169,7 @@ describe('compileCSS', () => {
       expect(
         compileCSS({
           ...defaultOptions,
-          pseudo: ':global(body)',
+          selectors: [':global(body)'],
           property: 'paddingLeft',
           value: '10px',
 

--- a/packages/core/src/runtime/getStyleBucketName.test.ts
+++ b/packages/core/src/runtime/getStyleBucketName.test.ts
@@ -2,19 +2,22 @@ import { getStyleBucketName } from './getStyleBucketName';
 
 describe('getStyleBucketName', () => {
   it('returns bucketName based on mapping', () => {
-    expect(getStyleBucketName(' :link', '', '', '')).toBe('l');
-    expect(getStyleBucketName(' :hover ', '', '', '')).toBe('h');
+    expect(getStyleBucketName([], '', '', '')).toBe('d');
+    expect(getStyleBucketName(['.foo'], '', '', '')).toBe('d');
 
-    expect(getStyleBucketName(':link', '', '', '')).toBe('l');
-    expect(getStyleBucketName(':visited', '', '', '')).toBe('v');
-    expect(getStyleBucketName(':focus-within', '', '', '')).toBe('w');
-    expect(getStyleBucketName(':focus', '', '', '')).toBe('f');
-    expect(getStyleBucketName(':focus-visible', '', '', '')).toBe('i');
-    expect(getStyleBucketName(':hover', '', '', '')).toBe('h');
-    expect(getStyleBucketName(':active', '', '', '')).toBe('a');
+    expect(getStyleBucketName([' :link'], '', '', '')).toBe('l');
+    expect(getStyleBucketName([' :hover '], '', '', '')).toBe('h');
 
-    expect(getStyleBucketName(':active', 'theme', '', '')).toBe('t');
-    expect(getStyleBucketName(':active', '', '(max-width: 100px)', '')).toBe('m');
-    expect(getStyleBucketName(':active', '', '', '(display: table-cell)')).toBe('t');
+    expect(getStyleBucketName([':link'], '', '', '')).toBe('l');
+    expect(getStyleBucketName([':visited'], '', '', '')).toBe('v');
+    expect(getStyleBucketName([':focus-within'], '', '', '')).toBe('w');
+    expect(getStyleBucketName([':focus'], '', '', '')).toBe('f');
+    expect(getStyleBucketName([':focus-visible'], '', '', '')).toBe('i');
+    expect(getStyleBucketName([':hover'], '', '', '')).toBe('h');
+    expect(getStyleBucketName([':active'], '', '', '')).toBe('a');
+
+    expect(getStyleBucketName([':active'], 'theme', '', '')).toBe('t');
+    expect(getStyleBucketName([':active'], '', '(max-width: 100px)', '')).toBe('m');
+    expect(getStyleBucketName([':active'], '', '', '(display: table-cell)')).toBe('t');
   });
 });

--- a/packages/core/src/runtime/getStyleBucketName.ts
+++ b/packages/core/src/runtime/getStyleBucketName.ts
@@ -42,7 +42,12 @@ const pseudosMap: Record<string, StyleBucketName | undefined> = {
  *
  * @internal
  */
-export function getStyleBucketName(pseudo: string, layer: string, media: string, support: string): StyleBucketName {
+export function getStyleBucketName(
+  selectors: string[],
+  layer: string,
+  media: string,
+  support: string,
+): StyleBucketName {
   if (media) {
     return 'm';
   }
@@ -52,20 +57,22 @@ export function getStyleBucketName(pseudo: string, layer: string, media: string,
     return 't';
   }
 
-  const normalizedPseudo = pseudo.trim();
+  if (selectors.length > 0) {
+    const normalizedPseudo = selectors[0].trim();
 
-  if (normalizedPseudo.charCodeAt(0) === 58 /* ":" */) {
-    // We send through a subset of the string instead of the full pseudo name.
-    // For example:
-    // - `"focus-visible"` name would instead of `"us-v"`.
-    // - `"focus"` name would instead of `"us"`.
-    // Return a mapped pseudo else default bucket.
+    if (normalizedPseudo.charCodeAt(0) === 58 /* ":" */) {
+      // We send through a subset of the string instead of the full pseudo name.
+      // For example:
+      // - `"focus-visible"` name would instead of `"us-v"`.
+      // - `"focus"` name would instead of `"us"`.
+      // Return a mapped pseudo else default bucket.
 
-    return (
-      pseudosMap[normalizedPseudo.slice(4, 8)] /* allows to avoid collisions between "focus-visible" & "focus" */ ||
-      pseudosMap[normalizedPseudo.slice(3, 5)] ||
-      'd'
-    );
+      return (
+        pseudosMap[normalizedPseudo.slice(4, 8)] /* allows to avoid collisions between "focus-visible" & "focus" */ ||
+        pseudosMap[normalizedPseudo.slice(3, 5)] ||
+        'd'
+      );
+    }
   }
 
   // Return default bucket

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -412,6 +412,21 @@ describe('resolveStyleRules', () => {
           padding-right: 10px;
         }
       `);
+
+      expect(
+        resolveStyleRules({
+          ':hover,:focus-within': {
+            '::before': {
+              color: 'orange',
+            },
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        .fij4gri:hover::before,
+        .fij4gri:focus-within::before {
+          color: orange;
+        }
+      `);
     });
 
     it('handles media queries', () => {
@@ -576,18 +591,6 @@ describe('resolveStyleRules', () => {
     it('handles :global selector', () => {
       expect(
         resolveStyleRules({
-          ':global(body) &': { color: 'green' },
-        }),
-      ).toMatchInlineSnapshot(`
-        body .fm1e7ra {
-          color: green;
-        }
-      `);
-    });
-
-    it('handles :global selector', () => {
-      expect(
-        resolveStyleRules({
           ':global(body)': {
             ':focus': {
               color: 'green',
@@ -609,34 +612,38 @@ describe('resolveStyleRules', () => {
       `);
       expect(
         resolveStyleRules({
+          ':global(body):focus': { color: 'pink' },
           ':global(body) :focus': { color: 'green' },
           ':global(body) :focus:hover': { color: 'blue' },
           ':global(body) :focus .foo': { color: 'yellow' },
         }),
       ).toMatchInlineSnapshot(`
-        body .frou13r:focus {
+        body .fug6i29:focus {
+          color: pink;
+        }
+        body .frou13r :focus {
           color: green;
         }
-        body .f1emv7y1:focus:hover {
+        body .f1emv7y1 :focus:hover {
           color: blue;
         }
-        body .f1g015sp:focus .foo {
+        body .f1g015sp :focus .foo {
           color: yellow;
         }
       `);
     });
 
-    // it.todo('supports :global as a nested selector', () => {
-    //   expect(
-    //     resolveStyleRules({
-    //       ':focus': { ':global(body)': { color: 'green' } },
-    //     }),
-    //   ).toMatchInlineSnapshot(`
-    //     body .fm1e7ra0:focus {
-    //       color: green;
-    //     }
-    //   `);
-    // });
+    it('supports :global as a nested selector', () => {
+      expect(
+        resolveStyleRules({
+          ':focus': { ':global(body)': { color: 'green' } },
+        }),
+      ).toMatchInlineSnapshot(`
+        body .fz7er5p:focus {
+          color: green;
+        }
+      `);
+    });
   });
 
   describe('keyframes', () => {

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -68,7 +68,7 @@ function pushToCSSRules(
  */
 export function resolveStyleRules(
   styles: GriffelStyle,
-  pseudo = '',
+  selectors: string[] = [],
   media = '',
   layer = '',
   support = '',
@@ -105,13 +105,13 @@ export function resolveStyleRules(
 
     if (typeof value === 'string' || typeof value === 'number') {
       // uniq key based on a hash of property & selector, used for merging later
-      const key = hashPropertyKey(pseudo, media, support, property);
+      const key = hashPropertyKey(selectors, media, support, property);
       const className = hashClassName({
         media,
         layer,
         value: value.toString(),
         support,
-        pseudo,
+        selectors,
         property,
       });
 
@@ -122,7 +122,7 @@ export function resolveStyleRules(
         ? hashClassName({
             value: rtlDefinition.value.toString(),
             property: rtlDefinition.key,
-            pseudo,
+            selectors,
             media,
             layer,
             support,
@@ -136,12 +136,12 @@ export function resolveStyleRules(
           }
         : undefined;
 
-      const styleBucketName = getStyleBucketName(pseudo, layer, media, support);
+      const styleBucketName = getStyleBucketName(selectors, layer, media, support);
       const [ltrCSS, rtlCSS] = compileCSS({
         className,
         media,
         layer,
-        pseudo,
+        selectors,
         property,
         support,
         value,
@@ -191,7 +191,7 @@ export function resolveStyleRules(
 
       resolveStyleRules(
         { animationName: animationNames.join(', ') },
-        pseudo,
+        selectors,
         media,
         layer,
         support,
@@ -210,13 +210,13 @@ export function resolveStyleRules(
         continue;
       }
 
-      const key = hashPropertyKey(pseudo, media, support, property);
+      const key = hashPropertyKey(selectors, media, support, property);
       const className = hashClassName({
         media,
         layer,
         value: value.map(v => (v ?? '').toString()).join(';'),
         support,
-        pseudo,
+        selectors,
         property,
       });
 
@@ -239,7 +239,7 @@ export function resolveStyleRules(
         ? hashClassName({
             value: rtlDefinitions.map(v => (v?.value ?? '').toString()).join(';'),
             property: rtlDefinitions[0].key,
-            pseudo,
+            selectors,
             layer,
             media,
             support,
@@ -254,12 +254,12 @@ export function resolveStyleRules(
           }
         : undefined;
 
-      const styleBucketName = getStyleBucketName(pseudo, layer, media, support);
+      const styleBucketName = getStyleBucketName(selectors, layer, media, support);
       const [ltrCSS, rtlCSS] = compileCSS({
         className,
         media,
         layer,
-        pseudo,
+        selectors,
         property,
         support,
         value: value as Array<string | number>,
@@ -272,7 +272,7 @@ export function resolveStyleRules(
       if (isNestedSelector(property)) {
         resolveStyleRules(
           value as GriffelStyle,
-          pseudo + normalizeNestedProperty(property),
+          selectors.concat(normalizeNestedProperty(property)),
           media,
           layer,
           support,
@@ -284,7 +284,7 @@ export function resolveStyleRules(
 
         resolveStyleRules(
           value as GriffelStyle,
-          pseudo,
+          selectors,
           combinedMediaQuery,
           layer,
           support,
@@ -296,7 +296,7 @@ export function resolveStyleRules(
 
         resolveStyleRules(
           value as GriffelStyle,
-          pseudo,
+          selectors,
           media,
           combinedLayerQuery,
           support,
@@ -308,7 +308,7 @@ export function resolveStyleRules(
 
         resolveStyleRules(
           value as GriffelStyle,
-          pseudo,
+          selectors,
           media,
           layer,
           combinedSupportQuery,

--- a/packages/core/src/runtime/utils/hashClassName.ts
+++ b/packages/core/src/runtime/utils/hashClassName.ts
@@ -4,15 +4,15 @@ import { HASH_PREFIX } from '../../constants';
 export interface HashedClassNameParts {
   property: string;
   value: string;
-  pseudo: string;
+  selectors: string[];
   media: string;
   layer: string;
   support: string;
 }
 
-export function hashClassName({ media, layer, property, pseudo, support, value }: HashedClassNameParts): string {
+export function hashClassName({ media, layer, property, selectors, support, value }: HashedClassNameParts): string {
   // Trimming of value is required to generate consistent hashes
-  const classNameHash = hashString(pseudo + media + layer + support + property + value.trim());
+  const classNameHash = hashString(selectors.join('') + media + layer + support + property + value.trim());
 
   return HASH_PREFIX + classNameHash;
 }

--- a/packages/core/src/runtime/utils/hashPropertyKey.test.ts
+++ b/packages/core/src/runtime/utils/hashPropertyKey.test.ts
@@ -2,10 +2,10 @@ import { hashPropertyKey } from './hashPropertyKey';
 
 describe('hashPropertyKey', () => {
   it('generates hashes that always start with letters', () => {
-    expect(hashPropertyKey('', '', '', 'color')).toBe('sj55zd');
-    expect(hashPropertyKey('', '', '', 'display')).toBe('mc9l5x');
+    expect(hashPropertyKey([''], '', '', 'color')).toBe('sj55zd');
+    expect(hashPropertyKey([''], '', '', 'display')).toBe('mc9l5x');
 
-    expect(hashPropertyKey('', '', '', 'backgroundColor')).toBe('De3pzq');
-    expect(hashPropertyKey(':hover', '', '', 'color')).toBe('Bi91k9c');
+    expect(hashPropertyKey([''], '', '', 'backgroundColor')).toBe('De3pzq');
+    expect(hashPropertyKey([':hover'], '', '', 'color')).toBe('Bi91k9c');
   });
 });

--- a/packages/core/src/runtime/utils/hashPropertyKey.ts
+++ b/packages/core/src/runtime/utils/hashPropertyKey.ts
@@ -1,9 +1,9 @@
 import hash from '@emotion/hash';
 import { PropertyHash } from '../../types';
 
-export function hashPropertyKey(pseudo: string, media: string, support: string, property: string): PropertyHash {
+export function hashPropertyKey(selectors: string[], media: string, support: string, property: string): PropertyHash {
   // uniq key based on property & selector, used for merging later
-  const computedKey = pseudo + media + support + property;
+  const computedKey = selectors.join('') + media + support + property;
 
   // "key" can be really long as it includes selectors, we use hashes to reduce sizes of keys
   // ".foo :hover" => "abcd"

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -47,7 +47,7 @@ export function getStyleBucketNameFromElement(element: Element): StyleBucketName
   }
 
   return getStyleBucketName(
-    getSelectorFromElement(element),
+    [getSelectorFromElement(element)],
     element.type === '@layer' ? element.value : '',
     element.type === MEDIA ? element.value : '',
     element.type === SUPPORTS ? element.value : '',


### PR DESCRIPTION
Fixes #204.
Fixes #206.

---

## Changes in selectors handling

In `resolveStyleRules()` & `compileCSS()` I renamed `pseudo` to `selectors` and changed their type to be `string[]`:
- To reflect what it contains as `selectors` can contain not only pseudo selectors.
- To handle selectors properly as it was a problem without a solution:
  ```ts
  makeStyles({
    ":hover,:focus-within": {
      "::before": {
        color: "orange"
      }
    }
  });
  ```

  Before we were concatenating inputs with selectors and getting `":hover,:focus-within::before"` that will be compiled by Stylis to:
  ```css
  .class:hover,.class:focus-within::before {}
  ```
  And without proper wrapping with curly braces we cannot handle it. With selectors as an array with can send as input `:hover,:focus-within { ::before { } }` that will be handled properly.

## Changes in `:global()` handling

Because before we didn't know scopes of selectors we were doing `.trim()` and were losing `" "` in rules (#206):

https://github.com/microsoft/griffel/blob/0e358cbda0f663246ed7c1cc1ad7db0bdc86c22c/packages/core/src/runtime/compileCSS.ts#L92-L93

Currently I kept existing hack with `:global()` in place to avoid more changes in this PR, but in a follow up - I will replace it with a Stylis plugin.