### PR TITLE
Add TSDoc to unsupported CSS properties

### DIFF
--- a/change/@griffel-core-7c2fb1fa-c42f-4195-8948-dbac68156b32.json
+++ b/change/@griffel-core-7c2fb1fa-c42f-4195-8948-dbac68156b32.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add TSDoc to unsupported CSS properties",
+  "packageName": "@griffel/core",
+  "email": "tigeroakes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-core-7c2fb1fa-c42f-4195-8948-dbac68156b32.json
+++ b/change/@griffel-core-7c2fb1fa-c42f-4195-8948-dbac68156b32.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add TSDoc to unsupported CSS properties",
+  "comment": "fix: add TSDoc to unsupported CSS properties",
   "packageName": "@griffel/core",
   "email": "tigeroakes@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,5 +1,4 @@
-import * as CSS from 'csstype';
-import { LookupItem, SequenceHash } from './types';
+import { GriffelStylesUnsupportedCSSProperties, LookupItem, SequenceHash } from './types';
 
 /** @internal */
 export const DATA_BUCKET_ATTR = 'data-make-styles-bucket';
@@ -35,7 +34,7 @@ export const LOOKUP_DIR_INDEX = 1;
 
 // This collection is a map simply for faster access when checking if a CSS property is unsupported
 /** @internal */
-export const UNSUPPORTED_CSS_PROPERTIES: Record<keyof CSS.StandardShorthandProperties, 1> = {
+export const UNSUPPORTED_CSS_PROPERTIES: Record<keyof GriffelStylesUnsupportedCSSProperties, 1> = {
   all: 1,
   animation: 1,
   background: 1,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,9 +1,108 @@
 import * as CSS from 'csstype';
-import { UNSUPPORTED_CSS_PROPERTIES } from './constants';
 
 export type GriffelStylesCSSValue = string | 0;
 
-export type GriffelStylesUnsupportedCSSProperties = Record<keyof typeof UNSUPPORTED_CSS_PROPERTIES, never>;
+/**
+ * Griffel doesn't support expansion of CSS shorthands.
+ * They can be replaced either with the corresponding longhand properties or with the `shorthands` helper functions.
+ * @see https://griffel.js.org/react/guides/limitations#css-shorthands-are-not-supported
+ */
+export interface GriffelStylesUnsupportedCSSProperties extends Record<keyof CSS.StandardShorthandProperties, never> {
+  /** @deprecated */
+  all: never;
+  /** @deprecated Use corresponding longhand properties such as `animationName` and `animationDuration` instead. */
+  animation: never;
+  /** @deprecated Use corresponding longhand properties such as `backgroundImage` and `backgroundSize` instead. */
+  background: never;
+  /** @deprecated Use corresponding longhand properties `backgroundPositionX` and `backgroundPositionY` instead. */
+  backgroundPosition: never;
+  /** @deprecated Use `shorthands.border()` instead. */
+  border: never;
+  /** @deprecated Use corresponding longhand properties such as `borderBlockStartColor` and `borderBlockEndStyle` instead. */
+  borderBlock: never;
+  /** @deprecated Use corresponding longhand properties such as `borderBlockEndColor` and `borderBlockEndStyle` instead. */
+  borderBlockEnd: never;
+  /** @deprecated Use corresponding longhand properties such as `borderBlockStartColor` and `borderBlockStartStyle` instead. */
+  borderBlockStart: never;
+  /** @deprecated Use `shorthands.borderBottom()` instead. */
+  borderBottom: never;
+  /** @deprecated Use `shorthands.borderColor()` instead. */
+  borderColor: never;
+  /** @deprecated Use corresponding longhand properties such as `borderImageSource` and `borderImageWidth` instead. */
+  borderImage: never;
+  /** @deprecated Use corresponding longhand properties such as `borderInlineStartColor` and `borderInlineEndStyle` instead. */
+  borderInline: never;
+  /** @deprecated Use corresponding longhand properties such as `borderInlineEndColor` and `borderInlineEndStyle` instead. */
+  borderInlineEnd: never;
+  /** @deprecated Use corresponding longhand properties such as `borderInlineStartColor` and `borderInlineStartStyle` instead. */
+  borderInlineStart: never;
+  /** @deprecated Use `shorthands.borderLeft()` instead. */
+  borderLeft: never;
+  /** @deprecated Use `shorthands.borderRadius()` instead. */
+  borderRadius: never;
+  /** @deprecated Use `shorthands.borderRight()` instead. */
+  borderRight: never;
+  /** @deprecated Use `shorthands.borderStyle()` instead. */
+  borderStyle: never;
+  /** @deprecated Use `shorthands.borderTop()` instead. */
+  borderTop: never;
+  /** @deprecated Use `shorthands.borderWidth()` instead. */
+  borderWidth: never;
+  /** @deprecated Use corresponding longhand properties `columnCount` and `columnWidth` instead. */
+  columns: never;
+  /** @deprecated Use corresponding longhand properties such as `columnRuleWidth` and `columnRuleColor` instead. */
+  columnRule: never;
+  /** @deprecated Use `shorthands.flex()` instead. */
+  flex: never;
+  /** @deprecated Use corresponding longhand properties `flexWrap` and `flexDirection` instead. */
+  flexFlow: never;
+  /** @deprecated Use corresponding longhand properties such as `fontFamily` and `fontSize` instead. */
+  font: never;
+  /** @deprecated Use `shorthands.gap()` instead. */
+  gap: never;
+  /** @deprecated Use corresponding longhand properties such as `gridTemplateColumns` and `gridAutoRows` instead. */
+  grid: never;
+  /** @deprecated Use `shorthands.gridArea()` instead. */
+  gridArea: never;
+  /** @deprecated Use corresponding longhand properties `gridColumnStart` and `gridColumnEnd` instead. */
+  gridColumn: never;
+  /** @deprecated Use corresponding longhand properties `gridRowStart` and `gridRowEnd` instead. */
+  gridRow: never;
+  /** @deprecated Use corresponding longhand properties such as `gridTemplateColumns` and `gridTemplateRows` instead. */
+  gridTemplate: never;
+  /** @deprecated */
+  lineClamp: never;
+  /** @deprecated Use corresponding longhand properties such as `listStyleType` instead. */
+  listStyle: never;
+  /** @deprecated Use `shorthands.margin()` instead. */
+  margin: never;
+  /** @deprecated Use corresponding longhand properties such as `maskImage` and `maskSize` instead. */
+  mask: never;
+  /** @deprecated Use corresponding longhand properties such as `maskBorderSource` and `maskBorderWidth` instead. */
+  maskBorder: never;
+  /** @deprecated */
+  motion: never;
+  /** @deprecated Use corresponding longhand properties such as `offsetPath` and `offsetDistance` instead. */
+  offset: never;
+  /** @deprecated Use corresponding longhand properties such as `outlineColor` and `outlineWidth` instead. */
+  outline: never;
+  /** @deprecated Use `shorthands.overflow()` instead. */
+  overflow: never;
+  /** @deprecated Use corresponding longhand properties `overscrollBehaviorX` and `overscrollBehaviorY` instead. */
+  overscrollBehavior: never;
+  /** @deprecated Use `shorthands.padding()` instead. */
+  padding: never;
+  /** @deprecated Use corresponding longhand properties `alignItems` and `justifyItems` instead. */
+  placeItems: never;
+  /** @deprecated Use corresponding longhand properties `alignSelf` and `justifySelf` instead. */
+  placeSelf: never;
+  /** @deprecated Use corresponding longhand properties such as `textDecorationColor` and `textDecorationLine` instead. */
+  textDecoration: never;
+  /** @deprecated Use corresponding longhand properties `textEmphasisColor` and `textEmphasisStyle` instead. */
+  textEmphasis: never;
+  /** @deprecated Use `shorthands.transition()` instead. */
+  transition: never;
+}
 
 export type ValueOrArray<T> = T | Array<T>;
 


### PR DESCRIPTION
When teammates on Loop start working with Griffel, the shorthand type errors confuse them. There's no clear reason why the error shows up unless you know to look at Griffel's docs ahead of time. As most developers are just working with the Fluent UI library, they don't know to check here.

Adding back an interface for the unsupported shorthand properties makes this documentation easier to discover, as using "Go to definition" will link developers to the interface. I've added TSDoc comments to the overall interface as well as to each property.

Ideally the comments on the properties would show up when using makeStyles too, but I couldn't get that to work in VSCode. Nevertheless, I think this change helps developers understand why Griffel shows type errors for shorthands.