### PR TITLE
docs: fix breadcrumbs on try out pages

### DIFF
--- a/.yarn/patches/@docusaurus-theme-common-npm-2.1.0-d5ae2a9539.patch
+++ b/.yarn/patches/@docusaurus-theme-common-npm-2.1.0-d5ae2a9539.patch
@@ -1,0 +1,36 @@
+diff --git a/lib/utils/docsUtils.js b/lib/utils/docsUtils.js
+index 61d72a3300b94904c8809503360206081e1c029c..43d75f84e8fc18e023ebb91afc17bd7354d9be27 100644
+--- a/lib/utils/docsUtils.js
++++ b/lib/utils/docsUtils.js
+@@ -105,13 +105,13 @@ export function isActiveSidebarItem(item, activePath) {
+  * Get the sidebar the breadcrumbs for a given pathname
+  * Ordered from top to bottom
+  */
+-function getSidebarBreadcrumbs({ sidebarItems, pathname, onlyCategories = false, }) {
++function getSidebarBreadcrumbs({ sidebarItems, pathname, hash = '', onlyCategories = false, }) {
+     const breadcrumbs = [];
+     function extract(items) {
+         for (const item of items) {
+             if ((item.type === 'category' &&
+-                (isSamePath(item.href, pathname) || extract(item.items))) ||
+-                (item.type === 'link' && isSamePath(item.href, pathname))) {
++                (isSamePath(item.href, pathname + hash) || extract(item.items))) ||
++                (item.type === 'link' && isSamePath(item.href, pathname + hash))) {
+                 const filtered = onlyCategories && item.type !== 'category';
+                 if (!filtered) {
+                     breadcrumbs.unshift(item);
+@@ -130,12 +130,12 @@ function getSidebarBreadcrumbs({ sidebarItems, pathname, onlyCategories = false,
+  */
+ export function useSidebarBreadcrumbs() {
+     const sidebar = useDocsSidebar();
+-    const { pathname } = useLocation();
++    const { pathname, hash } = useLocation();
+     const breadcrumbsOption = useActivePlugin()?.pluginData.breadcrumbs;
+     if (breadcrumbsOption === false || !sidebar) {
+         return null;
+     }
+-    return getSidebarBreadcrumbs({ sidebarItems: sidebar.items, pathname });
++    return getSidebarBreadcrumbs({ sidebarItems: sidebar.items, hash, pathname });
+ }
+ /**
+  * "Version candidates" are mostly useful for the layout components, which must

--- a/apps/website/sidebars.js
+++ b/apps/website/sidebars.js
@@ -6,7 +6,7 @@ function generateTryItOutSidebar() {
   const playgroundTemplatePath = path.join(__dirname, '/src/components/Playground/code/templates');
   const templateFiles = fs.readdirSync(playgroundTemplatePath);
 
-  return templateFiles
+  const items = templateFiles
     .reduce((sidebarItems, templateFile) => {
       const id = path.parse(templateFile).name;
       const templatePath = path.join(playgroundTemplatePath, templateFile);
@@ -54,6 +54,20 @@ function generateTryItOutSidebar() {
       return sidebarItems;
     }, [])
     .filter(Boolean);
+
+  return [
+    {
+      type: 'category',
+      label: 'Try it out',
+      link: {
+        type: 'doc',
+        id: 'try-it-out/try-it-out',
+      },
+      collapsible: false,
+      collapsed: false,
+      items,
+    },
+  ];
 }
 
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@nrwl/workspace": "patch:@nrwl/workspace@npm:13.4.5#.yarn/patches/@nrwl-workspace-npm-13.4.5-233a3ec85c",
     "beachball": "patch:beachball@npm:2.21.0#.yarn/patches/beachball-npm-2.21.0-85c8ba3d6b",
     "monosize@0.0.3": "patch:monosize@npm:0.0.3#.yarn/patches/monosize-npm-0.0.3-9b650c3f51",
-    "source-map-js@1.0.2": "patch:source-map-js@npm:1.0.2#.yarn/patches/source-map-js-npm-1.0.2-ee4f9f9b30.patch"
+    "source-map-js@1.0.2": "patch:source-map-js@npm:1.0.2#.yarn/patches/source-map-js-npm-1.0.2-ee4f9f9b30.patch",
+    "@docusaurus/theme-common@2.1.0": "patch:@docusaurus/theme-common@npm:2.1.0#.yarn/patches/@docusaurus-theme-common-npm-2.1.0-d5ae2a9539.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,6 +2519,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/theme-common@patch:@docusaurus/theme-common@npm:2.1.0#.yarn/patches/@docusaurus-theme-common-npm-2.1.0-d5ae2a9539.patch::locator=griffel-repository%40workspace%3A.":
+  version: 2.1.0
+  resolution: "@docusaurus/theme-common@patch:@docusaurus/theme-common@npm%3A2.1.0#.yarn/patches/@docusaurus-theme-common-npm-2.1.0-d5ae2a9539.patch::version=2.1.0&hash=9c5bd1&locator=griffel-repository%40workspace%3A."
+  dependencies:
+    "@docusaurus/mdx-loader": 2.1.0
+    "@docusaurus/module-type-aliases": 2.1.0
+    "@docusaurus/plugin-content-blog": 2.1.0
+    "@docusaurus/plugin-content-docs": 2.1.0
+    "@docusaurus/plugin-content-pages": 2.1.0
+    "@docusaurus/utils": 2.1.0
+    "@types/history": ^4.7.11
+    "@types/react": "*"
+    "@types/react-router-config": "*"
+    clsx: ^1.2.1
+    parse-numeric-range: ^1.3.0
+    prism-react-renderer: ^1.3.5
+    tslib: ^2.4.0
+    utility-types: ^3.10.0
+  peerDependencies:
+    react: ^16.8.4 || ^17.0.0
+    react-dom: ^16.8.4 || ^17.0.0
+  checksum: a64130306aa4d5b103d5c613019b7e3d6be3f1226d910e10109eaa21c278e8dc4cea9eee8cfc9d2e8df7e6ada1423ebd1c74119da6139009736b705829f3ecd5
+  languageName: node
+  linkType: hard
+
 "@docusaurus/theme-search-algolia@npm:2.1.0":
   version: 2.1.0
   resolution: "@docusaurus/theme-search-algolia@npm:2.1.0"


### PR DESCRIPTION
Depends on #215. Fixes breabcrumbs on Try out page.

### Details

The PR adds a patch to `@docusaurus/theme-common` to handle hashes as a part of URL (I am not aware about any other way to handle it except ejecting the whole breadcrumb component).

It also changes items in a custom sidebar to group them into "Try out" category that will be used in breadcrumbs.

### Before

![image](https://user-images.githubusercontent.com/14183168/191260762-c770df4a-8fa8-43a9-a7ad-386e55135f5b.png)

### After

![image](https://user-images.githubusercontent.com/14183168/191260855-4a5c04e0-8f81-4576-b00c-f15bd3ad33b0.png)




