### PR TITLE
react: adding missing definition for "children" in props

### DIFF
--- a/apps/benchmark/src/components/Select.tsx
+++ b/apps/benchmark/src/components/Select.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 interface SelectProps {
+  children: React.ReactNode;
   label: string;
 }
 

--- a/apps/benchmark/src/implementations/types.ts
+++ b/apps/benchmark/src/implementations/types.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export interface BoxProps {
   color: 0 | 1 | 2 | 3 | 4 | 5;
   fixed: boolean;
@@ -9,5 +11,6 @@ export interface DotProps {
   size: number;
   x: number;
   y: number;
+  children: React.ReactNode;
   color: string;
 }

--- a/change/@griffel-react-eb078e75-469e-4056-b2e9-7293b007f909.json
+++ b/change/@griffel-react-eb078e75-469e-4056-b2e9-7293b007f909.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Adding children to prop type definitions",
+  "comment": "fix: Adding children to prop type definitions for React 18",
   "packageName": "@griffel/react",
   "email": "liukerry@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@griffel-react-eb078e75-469e-4056-b2e9-7293b007f909.json
+++ b/change/@griffel-react-eb078e75-469e-4056-b2e9-7293b007f909.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding children to prop type definitions",
+  "packageName": "@griffel/react",
+  "email": "liukerry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/RendererContext.tsx
+++ b/packages/react/src/RendererContext.tsx
@@ -10,6 +10,11 @@ export interface RendererProviderProps {
    * Document used to insert CSS variables to head
    */
   targetDocument?: Document;
+
+  /**
+   * Content wrapped by the RendererProvider
+   */
+  children: React.ReactNode;
 }
 
 /**

--- a/packages/react/src/TextDirectionContext.tsx
+++ b/packages/react/src/TextDirectionContext.tsx
@@ -3,6 +3,11 @@ import * as React from 'react';
 export interface TextDirectionProviderProps {
   /** Indicates the directionality of the element's text. */
   dir: 'ltr' | 'rtl';
+
+  /**
+   * Content wrapped by the TextDirectionProvider.
+   */
+  children: React.ReactNode;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/microsoft/griffel/issues/214