### PR TITLE
chore: change github action for upload extension

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -58,11 +58,11 @@ jobs:
       - run: yarn nx run @griffel/devtools:pack-extension
 
       - name: Upload extension
-        uses: Passiverecords/chrome-extension-upload-action@1.4.1
+        uses: mobilefirstllc/cws-publish@latest
         with:
-          refresh-token: ${{ secrets.CHROME_EXT_REFRESH_TOKEN }}
-          client-id: ${{ secrets.CHROME_EXT_CLIENT_ID }}
-          client-secret: ${{ secrets.CHROME_EXT_CLIENT_SECRET }}
-          app-id: ${{ secrets.CHROME_EXT_APP_ID }}
-          file-name: ./dist/packages/ext.zip
-          publish: true
+          action: 'publish'
+          refresh_token: ${{ secrets.CHROME_EXT_REFRESH_TOKEN }}
+          client_id: ${{ secrets.CHROME_EXT_CLIENT_ID }}
+          client_secret: ${{ secrets.CHROME_EXT_CLIENT_SECRET }}
+          extension_id: ${{ secrets.CHROME_EXT_APP_ID }}
+          zip_file: ./dist/packages/ext.zip


### PR DESCRIPTION
Chrome extension publish pipeline is showing green but silently failing:
<img width="560" alt="Screenshot 2022-10-04 at 15 44 13" src="https://user-images.githubusercontent.com/28751745/193835832-d623c2ff-1abe-4721-ba90-df3a4b18f416.png">
example run: https://github.com/microsoft/griffel/actions/runs/3180680715/jobs/5184550511

This PR change the github action for upload/publish extension to be https://github.com/marketplace/actions/publish-chrome-extension-to-chrome-web-store
This one will fail pipeline instead of failing silently:
<img width="877" alt="Screenshot 2022-10-04 at 15 19 21" src="https://user-images.githubusercontent.com/28751745/193836267-d23d8ebe-091e-49d5-b562-e6b9ea6721bb.png">
example run: https://github.com/YuanboXue-Amber/griffel/actions/runs/3182423308/jobs/5188347275