### PR TITLE
chore(extension workflow): always run deploy when triggering manually

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -30,7 +30,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: check
-    if: needs.check.outputs.status == 'true'
+    if: ${{ needs.check.outputs.status == 'true' || github.event_name == 'workflow_dispatch' }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
In extension.yml, I added a condition to only run deploy when `packages/devtools/package.json` is updated. This is nice, but it should be disabled when the workflow is triggered manually.