### PR TITLE
chore: add __resetStyles functions to core & react

### DIFF
--- a/change/@griffel-core-8763d483-ffa6-4c7f-828d-2c0ddf69f21d.json
+++ b/change/@griffel-core-8763d483-ffa6-4c7f-828d-2c0ddf69f21d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add __resetStyles (internal function)",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-react-1918fb6d-fdf8-469b-bd51-b049339020e2.json
+++ b/change/@griffel-react-1918fb6d-fdf8-469b-bd51-b049339020e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add __resetStyles (internal function)",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/__resetStyles.ts
+++ b/packages/core/src/__resetStyles.ts
@@ -1,0 +1,25 @@
+import type { MakeStylesOptions } from './types';
+
+/**
+ * @internal
+ */
+export function __resetStyles(ltrClassName: string, rtlClassName: string | null, cssRules: string[]) {
+  const insertionCache: Record<string, boolean> = {};
+
+  function computeClassName(options: MakeStylesOptions): string {
+    const { dir, renderer } = options;
+
+    const isLTR = dir === 'ltr';
+    // As RTL classes are different they should have a different cache key for insertion
+    const rendererId = isLTR ? renderer.id : renderer.id + 'r';
+
+    if (insertionCache[rendererId] === undefined) {
+      renderer.insertCSSRules({ r: cssRules! });
+      insertionCache[rendererId] = true;
+    }
+
+    return isLTR ? ltrClassName : rtlClassName || ltrClassName;
+  }
+
+  return computeClassName;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
 // Private exports, are used by build time transforms or other tools
 export { __css } from './__css';
 export { __styles } from './__styles';
+export { __resetStyles } from './__resetStyles';
 
 export { normalizeCSSBucketEntry } from './runtime/utils/normalizeCSSBucketEntry';
 export { styleBucketOrdering } from './renderer/getStyleSheetForBucket';

--- a/packages/react/src/__resetStyles.ts
+++ b/packages/react/src/__resetStyles.ts
@@ -1,0 +1,21 @@
+import { __resetStyles as vanillaResetStyles } from '@griffel/core';
+
+import { useRenderer } from './RendererContext';
+import { useTextDirection } from './TextDirectionContext';
+
+/**
+ * A version of makeResetStyles() that accepts build output as an input and skips all runtime transforms.
+ *
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function __resetStyles(ltrClassName: string, rtlClassName: string | null, cssRules: string[]) {
+  const getStyles = vanillaResetStyles(ltrClassName, rtlClassName, cssRules);
+
+  return function useClasses(): string {
+    const dir = useTextDirection();
+    const renderer = useRenderer();
+
+    return getStyles({ dir, renderer });
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,3 +12,4 @@ export { TextDirectionProvider } from './TextDirectionContext';
 // Private exports, are used by build time transforms
 export { __css } from './__css';
 export { __styles } from './__styles';
+export { __resetStyles } from './__resetStyles';


### PR DESCRIPTION
A preparation for #236.

This PR adds `__resetStyles` to `@griffel/core` & `@griffel/react`. It works in the same way as existing `__styles` and is equal to `makeResetStyles`, but skips runtime work done in `resolveResetStyles`.