### PR TITLE
fix: relax check in transform plugin

### DIFF
--- a/change/@griffel-babel-preset-1db4e3d4-8a02-4dca-ac78-a24a1dbaecb7.json
+++ b/change/@griffel-babel-preset-1db4e3d4-8a02-4dca-ac78-a24a1dbaecb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: relax check in transform plugin",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/__fixtures__/error-argument-type/fixture.js
+++ b/packages/babel-preset/__fixtures__/error-argument-type/fixture.js
@@ -1,4 +1,0 @@
-import { makeStyles } from '@griffel/react';
-
-// This file is .js intentionally to avoid TS compiler errors
-export const useStyles = makeStyles([]);

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -232,11 +232,6 @@ pluginTester({
       },
     },
     {
-      title: 'errors: throws on invalid argument type',
-      fixture: path.resolve(fixturesDir, 'error-argument-type', 'fixture.js'),
-      error: /function accepts only an object as a param/,
-    },
-    {
       title: 'errors: throws on invalid argument count',
       fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
       error: /function accepts only a single param/,

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -32,7 +32,7 @@ function getDefinitionPathFromCallExpression(
   functionKind: FunctionKinds,
   callExpression: NodePath<t.CallExpression>,
 ): NodePath<t.Expression | t.SpreadElement> {
-  const argumentPaths = callExpression.get('arguments') as NodePath<t.Node>[];
+  const argumentPaths = callExpression.get('arguments');
   const hasValidArguments = Array.isArray(argumentPaths) && argumentPaths.length === 1;
 
   if (!hasValidArguments) {
@@ -41,11 +41,11 @@ function getDefinitionPathFromCallExpression(
 
   const definitionsPath = argumentPaths[0];
 
-  if (!definitionsPath.isObjectExpression()) {
-    throw definitionsPath.buildCodeFrameError(`${functionKind}() function accepts only an object as a param`);
+  if (definitionsPath.isExpression() || definitionsPath.isSpreadElement()) {
+    return definitionsPath;
   }
 
-  return definitionsPath;
+  throw definitionsPath.buildCodeFrameError(`${functionKind}() function accepts only expressions and spreads`);
 }
 
 /**


### PR DESCRIPTION
Fixes a problem from https://github.com/microsoft/fluentui/pull/25216.

https://github.com/microsoft/griffel/blob/b360b562bc7180fa13c6d0a1979673983bfe5ee0/packages/babel-preset/src/transformPlugin.ts#L44-L46

The check that we have currently is too strict and breaks legit cases:

```
ERR! ERR! SyntaxError: /mnt/vss/_work/1/s/packages/react-components/react-button/src/components/Button/useButtonStyles.ts: makeResetStyles() function accepts only an object as a param
ERR! ERR!   13 | var buttonSpacingSmall = '3px';
ERR! ERR!   14 | var buttonSpacingMedium = '5px';
ERR! ERR! > 15 | var useBaseClassName = makeResetStyles(Object.assign({
ERR! ERR!      |                                        ^
ERR! ERR!   16 |   alignItems: 'center',
ERR! ERR!   17 |   boxSizing: 'border-box',
ERR! ERR!   18 |   display: 'inline-flex',
```

This PR simplifies it to match returned types. The test was removed as I can't build a compilable code to throw there: [`t.callExpression`](https://babeljs.io/docs/en/babel-types#callexpression) accepts `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>`, but I can't imagine/create a case when `JSXNamespacedName | ArgumentPlaceholder` will be arguments.