### PR TITLE
fix: add export for __resetCSS

### DIFF
--- a/change/@griffel-react-0c417873-8b81-4a7e-b68a-6f5fc2eb229b.json
+++ b/change/@griffel-react-0c417873-8b81-4a7e-b68a-6f5fc2eb229b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add export for __resetCSS",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/__resetCSS.ts
+++ b/packages/react/src/__resetCSS.ts
@@ -7,7 +7,7 @@ import { useTextDirection } from './TextDirectionContext';
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function __resetStyles(ltrClassName: string, rtlClassName: string | null) {
+export function __resetCSS(ltrClassName: string, rtlClassName: string | null) {
   const getStyles = vanillaResetCSS(ltrClassName, rtlClassName);
 
   return function useClasses(): string {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,4 +12,5 @@ export { TextDirectionProvider } from './TextDirectionContext';
 // Private exports, are used by build time transforms
 export { __css } from './__css';
 export { __styles } from './__styles';
+export { __resetCSS } from './__resetCSS';
 export { __resetStyles } from './__resetStyles';


### PR DESCRIPTION
Follow up for #250.

- Fixes function name
- Exports `__resetCSS` function