### PR TITLE
fix(jest-serializer): handles whitespaces better

### DIFF
--- a/change/@griffel-jest-serializer-75c22504-bc4b-439e-8717-b91254c209e1.json
+++ b/change/@griffel-jest-serializer-75c22504-bc4b-439e-8717-b91254c209e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(jest-serializer): handles whitespaces better",
+  "packageName": "@griffel/jest-serializer",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jest-serializer/src/index.test.tsx
+++ b/packages/jest-serializer/src/index.test.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import { makeResetStyles, makeStyles, mergeClasses, TextDirectionProvider } from '@griffel/react';
 import { render } from '@testing-library/react';
 
 import { print, test } from './index';
-import { renderIntoDocument } from 'react-dom/test-utils';
 
 expect.addSnapshotSerializer({ print, test });
 

--- a/packages/jest-serializer/src/index.test.tsx
+++ b/packages/jest-serializer/src/index.test.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { makeResetStyles, makeStyles, mergeClasses, TextDirectionProvider } from '@griffel/react';
 import { render } from '@testing-library/react';
 
 import { print, test } from './index';
+import { renderIntoDocument } from 'react-dom/test-utils';
 
 expect.addSnapshotSerializer({ print, test });
 
@@ -28,7 +31,14 @@ const TestComponent: React.FC<{ id?: string }> = ({ id }) => {
   const styles1 = useStyles1();
   const styles2 = useStyles2();
   const styles3 = useStyles3();
-  const styles = mergeClasses('static-class', styles1.root, styles1.paddingLeft, styles2.paddingRight, styles3.display);
+  const styles = mergeClasses(
+    'class-a',
+    styles1.root,
+    styles1.paddingLeft,
+    styles2.paddingRight,
+    styles3.display,
+    'class-b',
+  );
 
   return <div data-testid={id} className={styles} />;
 };
@@ -37,7 +47,7 @@ const TestResetComponent: React.FC<{ id?: string }> = ({ id }) => {
   const classes = useStyles1();
   const baseClassName = useBaseStyles();
 
-  const className = mergeClasses('static-class', classes.paddingLeft, baseClassName);
+  const className = mergeClasses('class-a', classes.paddingLeft, baseClassName, 'class-b');
 
   return <div data-testid={id} className={className} />;
 };
@@ -71,27 +81,37 @@ describe('serializer', () => {
     });
   });
 
-  it('renders without generated classes', () => {
+  // Note: When HTML element is passed we will get a string with classes, not the whole snippet
+  it('handles classes strings', () => {
     expect(render(<TestComponent />).container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="static-class"
+        class="class-a class-b"
       />
     `);
     expect(render(<TestResetComponent />).container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="static-class"
+        class="class-a class-b"
       />
     `);
 
     expect(render(<TestComponent />, { wrapper: RtlWrapper }).container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="static-class"
+        class="class-a class-b"
       />
     `);
     expect(render(<TestResetComponent />, { wrapper: RtlWrapper }).container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="static-class"
+        class="class-a class-b"
       />
     `);
+  });
+
+  it('handles HTML strings', () => {
+    expect(render(<TestResetComponent />).container.innerHTML).toMatchInlineSnapshot(
+      `"<div class="class-a class-b"></div>"`,
+    );
+    expect(render(<TestResetComponent />).container.innerHTML).toMatchInlineSnapshot(
+      `"<div class="class-a class-b"></div>"`,
+    );
   });
 });

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -42,12 +42,12 @@ export function print(val: unknown) {
    * @example
    * regex = /f16th3vw|frdkuqy0|fat0sn40|fjseox00/
    */
-  const valStrippedClassNames = _val.replace(new RegExp(regexParts.join('|'), 'g'), '').trim();
+  const valStrippedClassNames = _val.replace(new RegExp(regexParts.map(p => `${p}\\s?`).join('|'), 'g'), '').trim();
 
   /**
    * Trim whitespace from className
    */
-  return `"${valStrippedClassNames.replace(/className="\s*(\w*)\s*"/, 'className="$1"')}"`;
+  return `"${valStrippedClassNames.replace(/(class|className)="([^"]*)\s+"/, '$1="$2"')}"`;
 }
 
 export function test(val: unknown) {


### PR DESCRIPTION
#260 added support for classes generated by `makeResetStyles`, the problem is that whitespaces were still present in output:

![image](https://user-images.githubusercontent.com/14183168/198242444-70d4baae-d52b-412a-947e-11ce5381126b.png)

This PR fixes it.
