### PR TITLE
chore: rework tests CSS extraction

### DIFF
--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .fp00rh9 {
   background-image: url(blank.jpg), url(empty.jpg);
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .fnwsaxv {
   background-image: url(blank.jpg);
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/code.ts
@@ -1,6 +1,6 @@
 import { __styles } from '@griffel/react';
 
-const styles = __styles(
+export const styles = __styles(
   {
     root: {
       sj55zd: 'fe3e8s9',
@@ -20,5 +20,3 @@ const styles = __styles(
     ],
   },
 );
-
-console.log(styles);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .fe3e8s9 {
   color: red;
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -1,6 +1,5 @@
 import { __styles, __css } from '@griffel/react';
-
-const styles = __css({
+export const styles = __css({
   root: {
     sj55zd: 'fe3e8s9',
     uwmqm3: ['fycuoez', 'f8wuabp'],
@@ -10,7 +9,5 @@ const styles = __css({
     Bi91k9c: 'faf35ka',
   },
 });
-
-console.log(styles);
 
 import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
@@ -1,3 +1,4 @@
+/** griffel.e44646c584b8724e9528.css **/
 .fe3e8s9 {
   color: red;
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .rjefjbm {
   color: red;
   padding-left: 4px;

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .fe3e8s9 {
   color: red;
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .ra9m047 {
   background-image: url(blank.jpg);
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .rjefjbm {
   color: red;
   padding-left: 4px;

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/code.ts
@@ -1,6 +1,6 @@
 import { __styles } from '@griffel/react';
 
-const styles1 = __styles(
+export const styles1 = __styles(
   {
     root: {
       sj55zd: 'fe3e8s9',
@@ -12,7 +12,7 @@ const styles1 = __styles(
   },
 );
 
-const styles2 = __styles(
+export const styles2 = __styles(
   {
     root: {
       sj55zd: 'fe3e8s9',
@@ -23,5 +23,3 @@ const styles2 = __styles(
     d: ['.fe3e8s9{color:red;}', '.fcnqdeg{background-color:green;}'],
   },
 );
-
-console.log(styles1, styles2);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/rules-deduplication/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .fe3e8s9 {
   color: red;
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
@@ -1,6 +1,6 @@
 import { __styles } from '@griffel/react';
 
-const styles = __styles(
+export const styles = __styles(
   {},
   // Classes in this test are intentionally not realistic to simplify snapshots
   {
@@ -13,6 +13,7 @@ const styles = __styles(
     h: ['.color-yellow:hover { color: yellow; }'],
     a: ['.color-black:active { color: black; }'],
     k: ['@keyframes foo { from{ transform:rotate(0deg); } to { transform:rotate(360deg); } }'],
+    t: ['@supports (display: table-cell){.foo{color:red;}}', '@layer color {.f1hjcal7 {color: red;}}'],
     m: [
       [
         '@media (forced-colors: active) { .color-magenta { color: magenta; } }',
@@ -23,5 +24,3 @@ const styles = __styles(
     ],
   },
 );
-
-console.log(styles);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/output.css
@@ -1,3 +1,4 @@
+/** griffel.css **/
 .color-red {
   color: red;
 }
@@ -31,6 +32,16 @@
   }
   to {
     transform: rotate(360deg);
+  }
+}
+@supports (display: table-cell) {
+  .foo {
+    color: red;
+  }
+}
+@layer color {
+  .f1hjcal7 {
+    color: red;
   }
 }
 @media (forced-colors: active) {

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkA.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkA.css
@@ -1,0 +1,6 @@
+.foo {
+  color: red;
+}
+.bar {
+  color: yellow;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkA.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkA.ts
@@ -1,10 +1,9 @@
 import { __styles } from '@griffel/react';
+import './chunkA.css';
 
 export const styles = __styles(
   {
-    root: {
-      sj55zd: 'fe3e8s9',
-    },
+    root: { sj55zd: 'fe3e8s9' },
   },
   {
     d: ['.fe3e8s9{color:red;}'],

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkB.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkB.css
@@ -1,0 +1,3 @@
+.baz {
+  color: blue;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkB.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/chunkB.ts
@@ -1,10 +1,9 @@
 import { __styles } from '@griffel/react';
+import './chunkB.css';
 
 export const styles = __styles(
   {
-    root: {
-      sj55zd: 'fe3e8s9',
-    },
+    root: { sj55zd: 'fe3e8s9' },
   },
   {
     d: ['.fe3e8s9{color:red;}'],

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/code.ts
@@ -1,0 +1,25 @@
+import { __styles } from '@griffel/react';
+
+export const styles = __styles(
+  {
+    root: {
+      Bi91k9c: 'faf35ka',
+    },
+  },
+  {
+    d: ['.fcnqdeg{background-color:green;}'],
+  },
+);
+
+export async function loadStyles() {
+  const { styles: stylesA } = await import(
+    /* webpackChunkName: "chunkA" */
+    './chunkA'
+  );
+  const { styles: stylesB } = await import(
+    /* webpackChunkName: "chunkB" */
+    './chunkB'
+  );
+
+  return [stylesA, stylesB];
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "chunkA.bundle.js", "chunkA.css", "chunkB.bundle.js", "chunkB.css", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/output.css
@@ -1,0 +1,20 @@
+/** chunkA.css **/
+.foo {
+  color: red;
+}
+.bar {
+  color: yellow;
+}
+
+/** chunkB.css **/
+.baz {
+  color: blue;
+}
+
+/** griffel.css **/
+.fcnqdeg {
+  background-color: green;
+}
+.fe3e8s9 {
+  color: red;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/code.ts
@@ -1,10 +1,9 @@
 import { __styles } from '@griffel/react';
+import './input.css';
 
-export const styles = __styles(
+export const styles1 = __styles(
   {
-    root: {
-      sj55zd: 'fe3e8s9',
-    },
+    root: { sj55zd: 'fe3e8s9' },
   },
   {
     d: ['.fe3e8s9{color:red;}'],

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.css", "main.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/input.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/input.css
@@ -1,0 +1,6 @@
+.foo {
+  color: red;
+}
+.bar {
+  color: yellow;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/output.css
@@ -1,0 +1,11 @@
+/** griffel.css **/
+.fe3e8s9 {
+  color: red;
+}
+/** main.css **/
+.foo {
+  color: red;
+}
+.bar {
+  color: yellow;
+}


### PR DESCRIPTION
This PR:
- removes usages of `console.log` to prefer usages of `export`
- adds a comment to `output.css` to identify from which files CSS comes
- updates `style-buckets` to include `@layer` & `@supports`
- adds `with-chunks` to assert chunks behavior
- adds `with-css` to ensure that we don't affect third-parties