### PR TITLE
fix: use style buckets in CSS extraction

### DIFF
--- a/change/@griffel-core-da60ef94-dd69-4128-9f8f-53fceb3ec3c3.json
+++ b/change/@griffel-core-da60ef94-dd69-4128-9f8f-53fceb3ec3c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: export \"CSSBucketEntry\" type for internal usage",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-extraction-plugin-b995688a-9700-4878-8832-49047eed3bb3.json
+++ b/change/@griffel-webpack-extraction-plugin-b995688a-9700-4878-8832-49047eed3bb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use style buckets in CSS extraction",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export type {
   // Internal types
   CSSClasses,
   CSSClassesMapBySlot,
+  CSSBucketEntry,
   CSSRulesByBucket,
   StyleBucketName,
   // Util

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -316,6 +316,7 @@ export type CSSRulesByBucket = {
   m?: CSSBucketEntry[];
 };
 
+/** @internal */
 export type CSSBucketEntry = string | [string, Record<string, unknown>];
 
 export type StylesBySlots<Slots extends string | number> = Record<Slots, GriffelStyle>;

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.ts
@@ -5,4 +5,4 @@ export const useStyles = __css({
   },
 });
 
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fp00rh9%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets-multiple%2Fblank.jpg)%2Curl(..%2F__fixtures__%2Fwebpack%2Fassets-multiple%2Fempty.jpg)%3B%7D';
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fp00rh9%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets-multiple%2Fblank.jpg)%2Curl(..%2F__fixtures__%2Fwebpack%2Fassets-multiple%2Fempty.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
@@ -5,4 +5,4 @@ export const useStyles = __css({
   },
 });
 
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D';
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fnwsaxv%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Fassets%2Fblank.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -10,4 +10,4 @@ export const styles = __css({
   },
 });
 
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fycuoez%7Bpadding-left%3A4px%3B%7D%0A.f8wuabp%7Bpadding-right%3A4px%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D.fycuoez%7Bpadding-left%3A4px%3B%7D.f8wuabp%7Bpadding-right%3A4px%3B%7D.fcnqdeg%7Bbackground-color%3Agreen%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/fs.json
@@ -1,1 +1,1 @@
-["bundle.js", "griffel.e44646c584b8724e9528.css"]
+["bundle.js", "griffel.3f25ad2d330c015ca6fa.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
@@ -1,4 +1,4 @@
-/** griffel.e44646c584b8724e9528.css **/
+/** griffel.3f25ad2d330c015ca6fa.css **/
 .fe3e8s9 {
   color: red;
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.ts
@@ -6,4 +6,4 @@ export const useClasses = __css({
 });
 export const useClassName = __resetCSS('rjefjbm', 'r7z97ji');
 
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D%0A.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D';
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.css
@@ -1,7 +1,7 @@
 /** griffel.css **/
-.fe3e8s9 {
-  color: red;
-}
 .fcnqdeg {
   background-color: green;
+}
+.fe3e8s9 {
+  color: red;
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -10,4 +10,4 @@ export const stylesB = __css({
   },
 });
 
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.fe3e8s9%7Bcolor%3Ared%3B%7D%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D';
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.ts
@@ -1,4 +1,4 @@
 import { __resetStyles, __resetCSS } from '@griffel/react';
 export const useClassName = __resetCSS('ra9m047', null);
 
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.ra9m047%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Freset-assets%2Fblank.jpg)%3B%7D';
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.ra9m047%7Bbackground-image%3Aurl(..%2F__fixtures__%2Fwebpack%2Freset-assets%2Fblank.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.ts
@@ -1,4 +1,4 @@
 import { __resetStyles, __resetCSS } from '@griffel/react';
 export const useClassName = __resetCSS('rjefjbm', 'r7z97ji');
 
-import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D%0A.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D';
+import 'griffel.css!=!../../../virtual-loader/index.js!../../../virtual-loader/griffel.css?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A';

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -3,6 +3,7 @@ import { Compilation } from 'webpack';
 import type { Compiler, sources } from 'webpack';
 
 import { sortCSSRules } from './sortCSSRules';
+import { parseCSSRules } from './parseCSSRules';
 
 export type GriffelCSSExtractionPluginOptions = {
   compareMediaQueries?: GriffelRenderer['compareMediaQueries'];
@@ -62,10 +63,10 @@ export class GriffelCSSExtractionPlugin {
 
           const [assetName, assetSource] = griffelAsset;
 
-          const unsortedCSSRules = getAssetSourceContents(assetSource);
-          const sortedCSSRules = sortCSSRules(unsortedCSSRules, this.compareMediaQueries);
+          const { cssRulesByBucket } = parseCSSRules(getAssetSourceContents(assetSource));
+          const cssRules = sortCSSRules([cssRulesByBucket], this.compareMediaQueries);
 
-          compilation.updateAsset(assetName, new compiler.webpack.sources.RawSource(sortedCSSRules));
+          compilation.updateAsset(assetName, new compiler.webpack.sources.RawSource(cssRules));
         },
       );
     });

--- a/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
@@ -1,0 +1,91 @@
+import { parseCSSRules } from './parseCSSRules';
+import { CSSRulesByBucket } from '@griffel/core';
+
+function removeEmptyBuckets(cssRulesByBucket: CSSRulesByBucket) {
+  return Object.fromEntries(Object.entries(cssRulesByBucket).filter(([, bucketEntries]) => bucketEntries.length > 0));
+}
+
+describe('parseCSSRules', () => {
+  it('handles regular rules', () => {
+    const css = `
+    /** @griffel:css-start [d] **/
+    .fe3e8s9 { color: red; }
+    /** @griffel:css-end **/
+    /** @griffel:css-start [h] **/
+    .faf35ka:hover { color: red; }
+    /** @griffel:css-end **/
+  `;
+    const { cssRulesByBucket, remainingCSS } = parseCSSRules(css);
+
+    expect(removeEmptyBuckets(cssRulesByBucket)).toMatchInlineSnapshot(`
+      Object {
+        "d": Array [
+          ".fe3e8s9{color:red;}",
+        ],
+        "h": Array [
+          ".faf35ka:hover{color:red;}",
+        ],
+      }
+    `);
+    expect(remainingCSS).toBe('');
+  });
+
+  it('handles rules with meta', () => {
+    const css = `
+    /** @griffel:css-start [d] **/
+    .fe3e8s9 { color: red; }
+    /** @griffel:css-end **/
+    /** @griffel:css-start [m] [{"m":"screen and (max-width: 100px)"}] **/
+    @media screen and (max-width: 100px) { .fr5o61b{ color:red; } }
+    /** @griffel:css-end **/
+    /** @griffel:css-start [m] [{"m":"screen and (max-width: 100px)"}] **/
+    @media screen and (max-width: 100px) { .f1j0ers2 { display: grid; } }
+    /** @griffel:css-end **/
+  `;
+    const { cssRulesByBucket, remainingCSS } = parseCSSRules(css);
+
+    expect(removeEmptyBuckets(cssRulesByBucket)).toMatchInlineSnapshot(`
+      Object {
+        "d": Array [
+          ".fe3e8s9{color:red;}",
+        ],
+        "m": Array [
+          Array [
+            "@media screen and (max-width: 100px){.fr5o61b{color:red;}}",
+            Object {
+              "m": "screen and (max-width: 100px)",
+            },
+          ],
+          Array [
+            "@media screen and (max-width: 100px){.f1j0ers2{display:grid;}}",
+            Object {
+              "m": "screen and (max-width: 100px)",
+            },
+          ],
+        ],
+      }
+    `);
+    expect(remainingCSS).toBe('');
+  });
+
+  it('keeps third parties CSS', () => {
+    const css = `
+    /** @griffel:css-start [d] **/
+    .fe3e8s9 { color: red; }
+    /** @griffel:css-end **/
+    .foo { color: red }
+    /* some comment */
+    .bar { color: green }
+  `;
+    const { cssRulesByBucket, remainingCSS } = parseCSSRules(css);
+
+    expect(removeEmptyBuckets(cssRulesByBucket)).toMatchInlineSnapshot(`
+      Object {
+        "d": Array [
+          ".fe3e8s9{color:red;}",
+        ],
+      }
+    `);
+    expect(remainingCSS).toBe('.foo{color:red;}.bar{color:green;}');
+  });
+});

--- a/packages/webpack-extraction-plugin/src/parseCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/parseCSSRules.ts
@@ -15,7 +15,7 @@ export function parseCSSRules(css: string) {
   let cssBucketName: StyleBucketName | null = null;
   let cssMeta: Record<string, unknown> | null = null;
 
-  elements.forEach(element => {
+  for (const element of elements) {
     if (element.type === COMMENT) {
       if (element.value.indexOf('/** @griffel:css-start') === 0) {
         cssBucketName = element.value.charAt(24) as StyleBucketName;
@@ -24,14 +24,14 @@ export function parseCSSRules(css: string) {
           cssMeta = JSON.parse(element.value.slice(28, -5));
         }
 
-        return;
+        continue;
       }
 
       if (element.value.indexOf('/** @griffel:css-end') === 0) {
         cssBucketName = null;
         cssMeta = null;
 
-        return;
+        continue;
       }
     }
 
@@ -40,11 +40,11 @@ export function parseCSSRules(css: string) {
       const bucketEntry: CSSBucketEntry = element.type === MEDIA ? [cssRule, cssMeta!] : cssRule;
 
       cssRulesByBucket[cssBucketName].push(bucketEntry);
-      return;
+      continue;
     }
 
     unrelatedElements.push(element);
-  });
+  }
 
   return { cssRulesByBucket, remainingCSS: serialize(unrelatedElements, stringify) };
 }

--- a/packages/webpack-extraction-plugin/src/parseCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/parseCSSRules.ts
@@ -1,0 +1,50 @@
+import { styleBucketOrdering } from '@griffel/core';
+import { COMMENT, compile, MEDIA, serialize, stringify } from 'stylis';
+
+import type { CSSBucketEntry, CSSRulesByBucket, StyleBucketName } from '@griffel/core';
+
+export function parseCSSRules(css: string) {
+  const cssRulesByBucket = styleBucketOrdering.reduce<CSSRulesByBucket>((acc, styleBucketName) => {
+    acc[styleBucketName] = [];
+
+    return acc;
+  }, {}) as Required<CSSRulesByBucket>;
+  const elements = compile(css);
+  const unrelatedElements: ReturnType<typeof compile> = [];
+
+  let cssBucketName: StyleBucketName | null = null;
+  let cssMeta: Record<string, unknown> | null = null;
+
+  elements.forEach(element => {
+    if (element.type === COMMENT) {
+      if (element.value.indexOf('/** @griffel:css-start') === 0) {
+        cssBucketName = element.value.charAt(24) as StyleBucketName;
+
+        if (cssBucketName === 'm') {
+          cssMeta = JSON.parse(element.value.slice(28, -5));
+        }
+
+        return;
+      }
+
+      if (element.value.indexOf('/** @griffel:css-end') === 0) {
+        cssBucketName = null;
+        cssMeta = null;
+
+        return;
+      }
+    }
+
+    if (cssBucketName) {
+      const cssRule = serialize([element], stringify);
+      const bucketEntry: CSSBucketEntry = element.type === MEDIA ? [cssRule, cssMeta!] : cssRule;
+
+      cssRulesByBucket[cssBucketName].push(bucketEntry);
+      return;
+    }
+
+    unrelatedElements.push(element);
+  });
+
+  return { cssRulesByBucket, remainingCSS: serialize(unrelatedElements, stringify) };
+}

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -1,8 +1,7 @@
-import { GriffelRenderer } from '@griffel/core';
+import { CSSRulesByBucket, GriffelRenderer } from '@griffel/core';
 import * as prettier from 'prettier';
-import { compile } from 'stylis';
 
-import { getElementReference, getElementMetadata, sortCSSRules } from './sortCSSRules';
+import { sortCSSRules } from './sortCSSRules';
 
 export const cssSerializer: jest.SnapshotSerializerPlugin = {
   test(value) {
@@ -20,47 +19,18 @@ export const cssSerializer: jest.SnapshotSerializerPlugin = {
 
 expect.addSnapshotSerializer(cssSerializer);
 
-describe('getElementReference', () => {
-  it.each`
-    css                                                                                              | reference
-    ${'.foo { color: red; }'}                                                                        | ${'.foo'}
-    ${'.foo:hover { color: red; }'}                                                                  | ${'.foo:hover'}
-    ${'@media (max-width: 2px) { .foo { color: blue; } }'}                                           | ${'@media (max-width: 2px)[.foo]'}
-    ${'@keyframes foo { from { transform:rotate(0deg); } to { transform:rotate(360deg); } }'}        | ${'@keyframes foo'}
-    ${'@media screen and (max-width: 992px) { .a { text-align: left; } .b { text-align: right; } }'} | ${'@media screen and (max-width: 992px)[.a,.b]'}
-    ${'@media (max-width: 2px) { @supports (display: grid) { .a { color: blue; } } }'}               | ${'@media (max-width: 2px)[@supports (display: grid)[.a]]'}
-  `('returns "$reference" for "$css"', ({ css, reference }: { css: string; reference: string }) => {
-    const element = compile(css)[0];
-
-    expect(getElementReference(element)).toBe(reference);
-  });
-});
-
-describe('getElementMetadata', () => {
-  it.each`
-    css                                                    | metadata
-    ${'.foo { color: red; }'}                              | ${''}
-    ${'.foo:hover { color: red; }'}                        | ${''}
-    ${'@media (max-width: 2px) { .foo { color: blue; } }'} | ${'(max-width: 2px)'}
-  `('returns "$reference" for "$css"', ({ css, metadata }: { css: string; metadata: string }) => {
-    const element = compile(css)[0];
-
-    expect(getElementMetadata(element)).toBe(metadata);
-  });
-});
-
 describe('sortCSSRules', () => {
   it('removes duplicate rules', () => {
-    const css = `
-      .baz { color: orange; }
-      .foo { color: red; }
-      .baz { color: orange; }
+    const setA: CSSRulesByBucket = {
+      d: ['.baz { color: orange; }', '.foo { color: red; }'],
+      m: [['@media (max-width: 2px) { .foo { color: blue; } }', { m: '(max-width: 2px)' }]],
+    };
+    const setB: CSSRulesByBucket = {
+      d: ['.baz { color: orange; }'],
+      m: [['@media (max-width: 2px) { .yellow { color: blue; } }', { m: '(max-width: 2px)' }]],
+    };
 
-      @media (max-width: 2px) { .foo { color: blue; } }
-      @media (max-width: 2px) { .yellow { color: blue; } }
-    `;
-
-    expect(sortCSSRules(css, () => 0)).toMatchInlineSnapshot(`
+    expect(sortCSSRules([setA, setB], () => 0)).toMatchInlineSnapshot(`
       .baz {
         color: orange;
       }
@@ -81,14 +51,16 @@ describe('sortCSSRules', () => {
   });
 
   it('sorts rules by buckets order', () => {
-    const css = `
-      .foo:focus { color: pink; }
-      .baz { color: orange; }
-      .foo:hover { color: yellow; }
-      .foo { color: red; }
-    `;
+    const setA: CSSRulesByBucket = {
+      d: ['.baz { color: orange; }'],
+      f: ['.foo:focus { color: pink; }'],
+    };
+    const setB: CSSRulesByBucket = {
+      d: ['.foo { color: red; }'],
+      h: ['.foo:hover { color: yellow; }'],
+    };
 
-    expect(sortCSSRules(css, () => 0)).toMatchInlineSnapshot(`
+    expect(sortCSSRules([setA, setB], () => 0)).toMatchInlineSnapshot(`
       .baz {
         color: orange;
       }
@@ -105,18 +77,22 @@ describe('sortCSSRules', () => {
   });
 
   it('sorts media queries', () => {
-    const css = `
-      @media (max-width: 2px) { .foo { color: blue; } }
-      @media (max-width: 1px) { .foo { color: red; } }
-      @media (max-width: 3px) { .foo { color: red; } }
-      .foo { color: green; }
-    `;
+    const setA: CSSRulesByBucket = {
+      m: [
+        ['@media (max-width: 2px) { .foo { color: blue; } }', { m: '(max-width: 2px)' }],
+        ['@media (max-width: 3px) { .foo { color: red; } }', { m: '(max-width: 3px)' }],
+      ],
+    };
+    const setB: CSSRulesByBucket = {
+      d: ['.foo { color: green; }'],
+      m: [['@media (max-width: 1px) { .foo { color: red; } }', { m: '(max-width: 1px)' }]],
+    };
 
     const mediaQueryOrder = ['(max-width: 1px)', '(max-width: 2px)', '(max-width: 3px)', '(max-width: 4px)'];
     const compareMediaQueries: GriffelRenderer['compareMediaQueries'] = (a: string, b: string) =>
       mediaQueryOrder.indexOf(a) - mediaQueryOrder.indexOf(b);
 
-    expect(sortCSSRules(css, compareMediaQueries)).toMatchInlineSnapshot(`
+    expect(sortCSSRules([setA, setB], compareMediaQueries)).toMatchInlineSnapshot(`
       .foo {
         color: green;
       }
@@ -134,19 +110,6 @@ describe('sortCSSRules', () => {
         .foo {
           color: red;
         }
-      }
-    `);
-  });
-
-  it('removes comments from output', () => {
-    const css = `
-      /* This is a comment in CSS */
-      .baz { color: orange; }
-    `;
-
-    expect(sortCSSRules(css, () => 0)).toMatchInlineSnapshot(`
-      .baz {
-        color: orange;
       }
     `);
   });

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -17,20 +17,24 @@ export function sortCSSRules(
     .map(styleBucketName => {
       return {
         styleBucketName,
-        cssBucketEntries: Object.values(
-          Object.fromEntries(
-            setOfCSSRules.flatMap(cssRulesByBucket => {
-              if (Array.isArray(cssRulesByBucket[styleBucketName])) {
-                return cssRulesByBucket[styleBucketName]!.map(bucketEntry => [
-                  getCSSRuleFromBucketEntry(bucketEntry),
-                  bucketEntry,
-                ]);
-              }
+        cssBucketEntries:
+          // We deduplicate CSS rules there by using them as keys in an object:
+          // - create an array with pairs [key, value]
+          // - use Object.fromEntries() to create an object that contains unique values
+          Object.values(
+            Object.fromEntries(
+              setOfCSSRules.flatMap(cssRulesByBucket => {
+                if (Array.isArray(cssRulesByBucket[styleBucketName])) {
+                  return cssRulesByBucket[styleBucketName]!.map(bucketEntry => [
+                    getCSSRuleFromBucketEntry(bucketEntry),
+                    bucketEntry,
+                  ]);
+                }
 
-              return [];
-            }),
+                return [];
+              }),
+            ),
           ),
-        ),
       };
     })
     .reduce((acc, { styleBucketName, cssBucketEntries }) => {

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -1,99 +1,54 @@
-import {
-  RESET_HASH_PREFIX,
-  getStyleBucketName,
-  GriffelRenderer,
-  StyleBucketName,
-  styleBucketOrdering,
-} from '@griffel/core';
-import { COMMENT, compile, Element, KEYFRAMES, MEDIA, RULESET, serialize, stringify, SUPPORTS, tokenize } from 'stylis';
+import { styleBucketOrdering } from '@griffel/core';
+import type { GriffelRenderer, CSSBucketEntry, CSSRulesByBucket } from '@griffel/core';
 
-function isResetClassName(className: string) {
-  return className[0] === '.' && className[1] === RESET_HASH_PREFIX;
+function getCSSRuleFromBucketEntry(entry: CSSBucketEntry): string {
+  return Array.isArray(entry) ? entry[0] : entry;
 }
 
-export function getSelectorFromElement(element: Element) {
-  return tokenize(element.value).slice(1).join('');
+function getCSSMetaFromBucketEntry(entry: CSSBucketEntry): Record<string, unknown> {
+  return Array.isArray(entry) ? entry[1] : {};
 }
 
-export function getElementMetadata(element: Element): string {
-  if (element.type === MEDIA) {
-    return element.value.replace(/^@media/, '').trim();
-  }
+export function sortCSSRules(
+  setOfCSSRules: CSSRulesByBucket[],
+  compareMediaQueries: GriffelRenderer['compareMediaQueries'],
+) {
+  return styleBucketOrdering
+    .map(styleBucketName => {
+      return {
+        styleBucketName,
+        cssBucketEntries: Object.values(
+          Object.fromEntries(
+            setOfCSSRules.flatMap(cssRulesByBucket => {
+              if (Array.isArray(cssRulesByBucket[styleBucketName])) {
+                return cssRulesByBucket[styleBucketName]!.map(bucketEntry => [
+                  getCSSRuleFromBucketEntry(bucketEntry),
+                  bucketEntry,
+                ]);
+              }
 
-  return '';
-}
+              return [];
+            }),
+          ),
+        ),
+      };
+    })
+    .reduce((acc, { styleBucketName, cssBucketEntries }) => {
+      if (styleBucketName === 'm') {
+        return (
+          acc +
+          cssBucketEntries
+            .sort((entryA, entryB) => {
+              return compareMediaQueries(
+                getCSSMetaFromBucketEntry(entryA)['m'] as string,
+                getCSSMetaFromBucketEntry(entryB)['m'] as string,
+              );
+            })
+            .map(entry => entry[0])
+            .join('')
+        );
+      }
 
-export function getElementReference(element: Element, suffix = ''): string {
-  if (element.type === RULESET || element.type === KEYFRAMES) {
-    return element.value + suffix;
-  }
-
-  if (Array.isArray(element.children)) {
-    return element.value + '[' + element.children.map(child => getElementReference(child, suffix)).join(',') + ']';
-  }
-
-  function removeRootProperty(element: Element): unknown {
-    return {
-      ...element,
-      children: Array.isArray(element.children)
-        ? element.children.map(child => removeRootProperty(child))
-        : element.children,
-      root: undefined,
-      parent: undefined,
-    };
-  }
-
-  throw new Error(
-    [
-      'getElementReference(): An unhandled case, please report if it happens and provide debug information about an element:',
-      JSON.stringify(removeRootProperty(element), null, 2),
-    ].join('\n'),
-  );
-}
-
-export function getStyleBucketNameFromElement(element: Element): StyleBucketName {
-  if (element.type === KEYFRAMES) {
-    return 'k';
-  }
-
-  if (isResetClassName(element.value)) {
-    return 'r';
-  }
-
-  return getStyleBucketName(
-    [getSelectorFromElement(element)],
-    element.type === '@layer' ? element.value : '',
-    element.type === MEDIA ? element.value : '',
-    element.type === SUPPORTS ? element.value : '',
-  );
-}
-
-export function sortCSSRules(css: string, compareMediaQueries: GriffelRenderer['compareMediaQueries']): string {
-  const childElements = compile(css)
-    // Remove top level comments as it is unclear how to sort them
-    .filter(element => element.type !== COMMENT)
-    .map(element => ({
-      ...element,
-      bucketName: getStyleBucketNameFromElement(element),
-      metadata: getElementMetadata(element),
-      reference: getElementReference(element),
-    }));
-  const uniqueElements = childElements.reduce<Record<string, typeof childElements[0]>>((acc, element) => {
-    acc[element.reference] = element;
-
-    return acc;
-  }, {});
-  const sortedElements = Object.values(uniqueElements).sort((elementA, elementB) => {
-    if (elementA.bucketName === 'm' && elementB.bucketName === 'm') {
-      return compareMediaQueries(elementA.metadata, elementB.metadata);
-    }
-
-    if (elementA.bucketName === elementB.bucketName) {
-      return 0;
-    }
-
-    return styleBucketOrdering.indexOf(elementA.bucketName) - styleBucketOrdering.indexOf(elementB.bucketName);
-  });
-
-  return serialize(sortedElements, stringify);
+      return acc + cssBucketEntries.join('');
+    }, '');
 }

--- a/packages/webpack-extraction-plugin/src/transformSync.ts
+++ b/packages/webpack-extraction-plugin/src/transformSync.ts
@@ -1,4 +1,6 @@
 import * as Babel from '@babel/core';
+import type { CSSRulesByBucket } from '@griffel/core';
+
 import { babelPluginStripGriffelRuntime, StripRuntimeBabelPluginMetadata } from './babelPluginStripGriffelRuntime';
 
 export type TransformOptions = {
@@ -11,7 +13,7 @@ export type TransformOptions = {
 
 export type TransformResult = {
   code: string;
-  cssRules: string[] | undefined;
+  cssRulesByBucket: CSSRulesByBucket | undefined;
   sourceMap: NonNullable<Babel.BabelFileResult['map']> | undefined;
 };
 
@@ -52,7 +54,7 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
 
   return {
     code: babelFileResult.code as string,
-    cssRules: (babelFileResult.metadata as unknown as StripRuntimeBabelPluginMetadata).cssRules,
+    cssRulesByBucket: (babelFileResult.metadata as unknown as StripRuntimeBabelPluginMetadata).cssRulesByBucket,
     sourceMap: babelFileResult.map === null ? undefined : babelFileResult.map,
   };
 }

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -82,14 +82,12 @@ function webpackLoader(
             acc +
             cssBucketRules
               .map(entry => {
-                return (
-                  `/** @griffel:css-start [${cssBucketName}] [${JSON.stringify(entry[1])}] **/` +
-                  '\n' +
-                  normalizeCSSBucketEntry(entry)[0] +
-                  '\n' +
-                  `/** @griffel:css-end **/` +
-                  '\n'
-                );
+                return [
+                  `/** @griffel:css-start [${cssBucketName}] [${JSON.stringify(entry[1])}] **/`,
+                  normalizeCSSBucketEntry(entry)[0],
+                  `/** @griffel:css-end **/`,
+                  '',
+                ].join('\n');
               })
               .join('')
           );
@@ -97,12 +95,12 @@ function webpackLoader(
 
         return (
           acc +
-          `/** @griffel:css-start [${cssBucketName}] **/` +
-          '\n' +
-          cssBucketRules.flatMap(entry => normalizeCSSBucketEntry(entry)).join('') +
-          '\n' +
-          `/** @griffel:css-end **/` +
-          '\n'
+          [
+            `/** @griffel:css-start [${cssBucketName}] **/`,
+            cssBucketRules.flatMap(entry => normalizeCSSBucketEntry(entry)).join(''),
+            `/** @griffel:css-end **/`,
+            '',
+          ].join('\n')
         );
       }, '');
 


### PR DESCRIPTION
This PR changes the approach for sorting CSS rules in a produced CSS asset by `@griffel/webpack-extraction-plugin`.

### Before

We used `sortCSSRules` to parse CSS rules and sort them into buckets in the similar order as rules in `resolveStyleRules()`. However, it was not **the same way**.

### After

The loader used for CSS extraction now emits comments to CSS to identify chunks and meta information (media queries case).

```css
/** @griffel:css-start [d] **/
.fe3e8s9 {
  color: red;
}
/** @griffel:css-end **/
/** @griffel:css-start [m] [{"m":"screen and (max-width: 100px)"}] **/
@media screen and (max-width: 100px) {
  .fr5o61b {
    color: red;
  }
}
/** @griffel:css-end **/
/** @griffel:css-start [m] [{"m":"screen and (max-width: 100px)"}] **/
@media screen and (max-width: 100px) {
  .f1j0ers2 {
    display: grid;
  }
}
/** @griffel:css-end **/
```

This solves the sorting problem: now we can use the same approach. It also allows us clearly identify our CSS rules in output and unblocks other approaches for the extraction plugin.