### PR TITLE
make webpack-extraction-plugin and webpack-loader support webpack v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "schema-utils": "^3.1.1",
     "source-map-js": "1.0.2",
     "stylis": "^4.0.13",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "webpack-sources": "3.2.3"
   },
   "resolutions": {
     "@nrwl/web": "patch:@nrwl/web@npm:13.4.5#.yarn/patches/@nrwl-web-npm-13.4.5-d7e9ea40d2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/stylis": "4.0.2",
     "@types/tmp": "0.2.3",
     "@types/webpack-env": "^1.17.0",
+    "@types/webpack-sources": "3.2.0",
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "~5.3.0",
     "@typescript-eslint/parser": "~5.3.0",

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -17,6 +17,7 @@
   },
   "peerDependencies": {
     "@griffel/core": "^1.8.1",
-    "webpack": "^4.44.2 || ^5"
+    "webpack": "^4.44.2 || ^5",
+    "webpack-sources": "3.2.3"
   }
 }

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -17,6 +17,6 @@
   },
   "peerDependencies": {
     "@griffel/core": "^1.8.1",
-    "webpack": "^5"
+    "webpack": "^4.44.2 || ^5"
   }
 }

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -13,11 +13,11 @@
     "loader-utils": "^2.0.0",
     "schema-utils": "^3.1.1",
     "stylis": "^4.0.13",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "webpack-sources": "3.2.3"
   },
   "peerDependencies": {
     "@griffel/core": "^1.8.1",
-    "webpack": "^4.44.2 || ^5",
-    "webpack-sources": "3.2.3"
+    "webpack": "^4.44.2 || ^5"
   }
 }

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -1,7 +1,6 @@
 import { defaultCompareMediaQueries, GriffelRenderer } from '@griffel/core';
 import { Compilation } from 'webpack';
 import type { Compiler, sources } from 'webpack';
-import { RawSource } from 'webpack-sources';
 
 import { sortCSSRules } from './sortCSSRules';
 

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -1,4 +1,4 @@
-import { getOptions } from 'loader-utils';
+import { getOptions, stringifyRequest } from 'loader-utils';
 import * as path from 'path';
 import { validate } from 'schema-utils';
 import * as webpack from 'webpack';
@@ -79,12 +79,20 @@ function webpackLoader(
 
   if (result) {
     if (result.cssRules) {
-      const request = `import ${JSON.stringify(
-        this.utils.contextify(
-          this.context || this.rootContext,
-          `griffel.css!=!${virtualLoaderPath}!${resourcePath}?style=${toURIComponent(result.cssRules.join('\n'))}`,
-        ),
-      )};`;
+      const request = this.utils
+        ? // webpack 5
+          `import ${JSON.stringify(
+            this.utils.contextify(
+              this.context || this.rootContext,
+              `griffel.css!=!${virtualLoaderPath}!${resourcePath}?style=${toURIComponent(result.cssRules.join('\n'))}`,
+            ),
+          )};`
+        : `import ${JSON.stringify(
+            stringifyRequest(
+              this.context || this.rootContext,
+              `griffel.css!=!${virtualLoaderPath}!${resourcePath}?style=${toURIComponent(result.cssRules.join('\n'))}`,
+            ),
+          )};`.replace(/\\"/gi, '');
 
       this.callback(null, `${result.code}\n\n${request};`, result.sourceMap);
       return;

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -17,6 +17,6 @@
   },
   "peerDependencies": {
     "@griffel/react": "^1.4.2",
-    "webpack": "^5"
+    "webpack": "^4.44.2 || ^5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6805,7 +6805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/webpack-sources@npm:*":
+"@types/webpack-sources@npm:*, @types/webpack-sources@npm:3.2.0":
   version: 3.2.0
   resolution: "@types/webpack-sources@npm:3.2.0"
   dependencies:
@@ -14564,6 +14564,7 @@ __metadata:
     "@types/stylis": 4.0.2
     "@types/tmp": 0.2.3
     "@types/webpack-env": ^1.17.0
+    "@types/webpack-sources": 3.2.0
     "@types/yargs": ^17.0.10
     "@typescript-eslint/eslint-plugin": ~5.3.0
     "@typescript-eslint/parser": ~5.3.0
@@ -14620,6 +14621,7 @@ __metadata:
     tslib: ^2.1.0
     typescript: ~4.5.2
     url-loader: ^3.0.0
+    webpack-sources: 3.2.3
     yargs: ^17.5.1
   languageName: unknown
   linkType: soft
@@ -25720,6 +25722,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-sources@npm:3.2.3, webpack-sources@npm:^3.0.2, webpack-sources@npm:^3.2.2, webpack-sources@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "webpack-sources@npm:3.2.3"
+  checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
+  languageName: node
+  linkType: hard
+
 "webpack-sources@npm:^1.2.0, webpack-sources@npm:^1.3.0, webpack-sources@npm:^1.4.0, webpack-sources@npm:^1.4.1, webpack-sources@npm:^1.4.3":
   version: 1.4.3
   resolution: "webpack-sources@npm:1.4.3"
@@ -25727,13 +25736,6 @@ __metadata:
     source-list-map: ^2.0.0
     source-map: ~0.6.1
   checksum: 37463dad8d08114930f4bc4882a9602941f07c9f0efa9b6bc78738cd936275b990a596d801ef450d022bb005b109b9f451dd087db2f3c9baf53e8e22cf388f79
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^3.0.2, webpack-sources@npm:^3.2.2, webpack-sources@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "webpack-sources@npm:3.2.3"
-  checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Hi experts, I'm an engineer from Microsoft SharePoint_STCA SZ. Currently our team are doing  some fluent v9 upgrade tasks. We find that fluent v9 uses griffel to support CSS-in-JS and provide some useful webpack loader or plugins to improve the performance. Unfortunately, these tools are designed for webpack 5, but our project uses webpack 4 and need large efforts to upgrade it to v5. So I tried to make it work on wbepack 4. This is a draft PR. Would you like to review and give us some comments?
@layershifter @ling1726