### PR TITLE
fix: Babel plugin no longer errors on array values being passed to animationName

### DIFF
--- a/change/@griffel-babel-preset-3f5d5c23-15e4-450a-b8d7-eafa30001b48.json
+++ b/change/@griffel-babel-preset-3f5d5c23-15e4-450a-b8d7-eafa30001b48.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Babel plugin no longer errors on array values being passed to animationName.",
+  "packageName": "@griffel/babel-preset",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-babel-preset-3f5d5c23-15e4-450a-b8d7-eafa30001b48.json
+++ b/change/@griffel-babel-preset-3f5d5c23-15e4-450a-b8d7-eafa30001b48.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Babel plugin no longer errors on array values being passed to animationName.",
+  "comment": "fix: Handle arrays in `animationName` definitions.",
   "packageName": "@griffel/babel-preset",
   "email": "humberto_makoto@hotmail.com",
   "dependentChangeType": "patch"

--- a/packages/babel-preset/__fixtures__/keyframes/code.ts
+++ b/packages/babel-preset/__fixtures__/keyframes/code.ts
@@ -1,0 +1,22 @@
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  single: {
+    animationName: {
+      from: { transform: 'rotate(0deg)' },
+      to: { transform: 'rotate(360deg)' },
+    },
+  },
+  multiple: {
+    animationName: [
+      {
+        from: { transform: 'rotate(0deg)' },
+        to: { transform: 'rotate(360deg)' },
+      },
+      {
+        from: { height: '100px' },
+        to: { height: '200px' },
+      },
+    ],
+  },
+});

--- a/packages/babel-preset/__fixtures__/keyframes/output.ts
+++ b/packages/babel-preset/__fixtures__/keyframes/output.ts
@@ -1,0 +1,27 @@
+import { __styles } from '@griffel/react';
+export const useStyles = __styles(
+  {
+    single: {
+      Bv12yb3: ['f1g6ul6r', 'f1fp4ujf'],
+    },
+    multiple: {
+      Bv12yb3: ['f1e467oh', 'f1w9bd63'],
+    },
+  },
+  {
+    k: [
+      '@-webkit-keyframes f1q8eu9e{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-moz-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}',
+      '@-webkit-keyframes f55c0se{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(-360deg);-moz-transform:rotate(-360deg);-ms-transform:rotate(-360deg);transform:rotate(-360deg);}}',
+      '@keyframes f1q8eu9e{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-moz-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}',
+      '@keyframes f55c0se{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(-360deg);-moz-transform:rotate(-360deg);-ms-transform:rotate(-360deg);transform:rotate(-360deg);}}',
+      '@-webkit-keyframes f19fnzg9{from{height:100px;}to{height:200px;}}',
+      '@keyframes f19fnzg9{from{height:100px;}to{height:200px;}}',
+    ],
+    d: [
+      '.f1g6ul6r{-webkit-animation-name:f1q8eu9e;animation-name:f1q8eu9e;}',
+      '.f1fp4ujf{-webkit-animation-name:f55c0se;animation-name:f55c0se;}',
+      '.f1e467oh{-webkit-animation-name:f1q8eu9e,f19fnzg9;animation-name:f1q8eu9e,f19fnzg9;}',
+      '.f1w9bd63{-webkit-animation-name:f55c0se,f19fnzg9;animation-name:f55c0se,f19fnzg9;}',
+    ],
+  },
+);

--- a/packages/babel-preset/src/assets/normalizeStyleRules.test.ts
+++ b/packages/babel-preset/src/assets/normalizeStyleRules.test.ts
@@ -128,4 +128,24 @@ describe('normalizeStyleRules', () => {
       },
     });
   });
+
+  it('handles keyframe arrays', () => {
+    expect(
+      normalizeStyleRules(
+        path.posix,
+        '/home/projects/foo',
+        '/home/projects/foo/src/styles/Component.styles.ts',
+
+        {
+          root: {
+            animationName: [{ from: { height: '20px' }, to: { height: '10px' } }],
+          },
+        },
+      ).toEqual({
+        root: {
+          animationName: [{ from: { eight: '20px' }, to: { height: '10px' } }],
+        },
+      }),
+    );
+  });
 });

--- a/packages/babel-preset/src/assets/normalizeStyleRules.test.ts
+++ b/packages/babel-preset/src/assets/normalizeStyleRules.test.ts
@@ -141,11 +141,11 @@ describe('normalizeStyleRules', () => {
             animationName: [{ from: { height: '20px' }, to: { height: '10px' } }],
           },
         },
-      ).toEqual({
-        root: {
-          animationName: [{ from: { eight: '20px' }, to: { height: '10px' } }],
-        },
-      }),
-    );
+      ),
+    ).toEqual({
+      root: {
+        animationName: [{ from: { eight: '20px' }, to: { height: '10px' } }],
+      },
+    });
   });
 });

--- a/packages/babel-preset/src/assets/normalizeStyleRules.test.ts
+++ b/packages/babel-preset/src/assets/normalizeStyleRules.test.ts
@@ -144,7 +144,7 @@ describe('normalizeStyleRules', () => {
       ),
     ).toEqual({
       root: {
-        animationName: [{ from: { eight: '20px' }, to: { height: '10px' } }],
+        animationName: [{ from: { height: '20px' }, to: { height: '10px' } }],
       },
     });
   });

--- a/packages/babel-preset/src/assets/normalizeStyleRules.ts
+++ b/packages/babel-preset/src/assets/normalizeStyleRules.ts
@@ -1,4 +1,4 @@
-import { GriffelStyle } from '@griffel/core';
+import { GriffelAnimation, GriffelStyle } from '@griffel/core';
 import { tokenize } from 'stylis';
 
 import { isAssetUrl } from './isAssetUrl';
@@ -54,9 +54,18 @@ export function normalizeStyleRules(
         return [key, value];
       }
 
-      // Fallback value
+      // Fallback values or keyframes
       if (Array.isArray(value)) {
-        return [key, value.map(rule => normalizeStyleRule(path, projectRoot, filename, rule as string))];
+        return [
+          key,
+          value.map(rule => {
+            if (typeof rule === 'object') {
+              return normalizeStyleRules(path, projectRoot, filename, rule as GriffelAnimation);
+            }
+
+            return normalizeStyleRule(path, projectRoot, filename, rule);
+          }),
+        ];
       }
 
       // Nested objects

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -53,6 +53,11 @@ pluginTester({
       fixture: path.resolve(fixturesDir, 'non-existing-module-call', 'code.ts'),
       outputFixture: path.resolve(fixturesDir, 'non-existing-module-call', 'output.ts'),
     },
+    {
+      title: 'syntax: animationName',
+      fixture: path.resolve(fixturesDir, 'keyframes', 'code.ts'),
+      outputFixture: path.resolve(fixturesDir, 'keyframes', 'output.ts'),
+    },
 
     // Assets
     //


### PR DESCRIPTION
## PR Description

This PR fixes an issue with the babel plugin that errored when an array of animations was being passed to `animationName`. This happened because the plugin tried to parse each animation as an individual rule instead of as an object with rules inside of it.

## Related issue(s)

- Fixes #275