### PR TITLE
chore: rework CSS extraction

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-d7a0320b-5a5b-44b3-8532-bfb6de7648f9.json
+++ b/change/@griffel-webpack-extraction-plugin-d7a0320b-5a5b-44b3-8532-bfb6de7648f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: rework plugin to avoid dependency on splitChunks.cacheGroups",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/e2e/nextjs/project.json
+++ b/e2e/nextjs/project.json
@@ -2,12 +2,13 @@
   "root": "e2e/nextjs",
   "sourceRoot": "e2e/nextjs/src",
   "projectType": "library",
+  "implicitDependencies": ["@griffel/webpack-loader"],
   "targets": {
     "test": {
       "executor": "@nrwl/workspace:run-commands",
+      "dependsOn": [{ "target": "build", "projects": "dependencies" }],
       "options": {
         "cwd": "e2e/nextjs",
-        "dependsOn": [{ "target": "build", "projects": "dependencies" }],
         "commands": [{ "command": "swc-node src/test.ts" }],
         "outputPath": []
       }

--- a/e2e/typescript/project.json
+++ b/e2e/typescript/project.json
@@ -5,9 +5,9 @@
   "targets": {
     "test": {
       "executor": "@nrwl/workspace:run-commands",
+      "dependsOn": [{ "target": "build", "projects": "dependencies" }],
       "options": {
         "cwd": "e2e/typescript",
-        "dependsOn": [{ "target": "build", "projects": "dependencies" }],
         "commands": [{ "command": "swc-node src/test.ts" }],
         "outputPath": []
       }

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -63,7 +63,7 @@ function ensureModuleHasPostOrderIndex(griffelChunk: Chunk, cssModule: Module) {
       continue;
     }
 
-    // "mini-css-extract" requires to an index on modules, modules without indexes will be filtered out and throw
+    // "mini-css-extract" requires an index to exist on modules. A module with an index will be filtered out and the plugin will throw
     // https://github.com/webpack-contrib/mini-css-extract-plugin/blob/26334462e419026086856787d672b052cd916c62/src/index.js#L1133-L1140
     group.setModulePostOrderIndex(
       cssModule,

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -67,7 +67,7 @@ function ensureModuleHasPostOrderIndex(griffelChunk: Chunk, cssModule: Module) {
     // https://github.com/webpack-contrib/mini-css-extract-plugin/blob/26334462e419026086856787d672b052cd916c62/src/index.js#L1133-L1140
     group.setModulePostOrderIndex(
       cssModule,
-      // It's bad to use private APIs, but it's more reliable than just random indexes
+      // It's bad to use private APIs, but it's more reliable than random indexes
       // The same approach is used in Gatsby
       // https://github.com/gatsbyjs/gatsby/blob/0b3c34c2bf932e5486ad2d0c3589bde6dc818661/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts#L455-L463
       // https://github.com/webpack/webpack/blob/e184a03f2504f03b2e30091662df6630a99a5f72/lib/ChunkGroup.js#L98-L99

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -127,7 +127,7 @@ export class GriffelCSSExtractionPlugin {
           const cssAssetDetails = Object.entries(assets).find(([assetName]) => griffelChunk.files.has(assetName));
 
           if (typeof cssAssetDetails === 'undefined') {
-            throw new Error('Failed to an asset that contains Griffel CSS output');
+            throw new Error('Failed to find an asset that contains Griffel CSS output');
           }
 
           const [cssAssetName, cssAssetSource] = cssAssetDetails;


### PR DESCRIPTION
This PR refactors Webpack plugin for CSS extraction.

## Before

We use the same approach as [CompiledCSS](https://github.com/atlassian-labs/compiled/blob/40211567504538272f726085e7b5f8c7c4eb2255/packages/webpack-loader/src/extract-plugin.ts#L38-L69): we create a new `cacheGroup` in `optimization.splitChunks` and force all generated CSS files by us to go there.

As a result we will get a single asset (CSS file) that we can process and sort rules. This works, but this approach requires `optimization.splitChunks` to be **enabled**. One of our key partners has this setting **disabled** in dev environment: all try outs to enable it were not successful.

This approach also prevents all attempts to implement chunks splitting support and avoid a single CSS file.

## After

TL;DR Does the same, works differently ¯\_(ツ)_/¯

The key difference is that we don't use `optimization.splitChunks` and moving CSS files to a target chunk.

### Initial attempt

Inspired by https://github.com/atlassian-labs/compiled/pull/724. All processing was done during [`.processAssets` stage](https://webpack.js.org/api/compilation-hooks/#processassets) and it worked: we got a CSS file per a chunk (if it contained `makeStyles` calls) and I was able to extract rules from it to a dedicated chunk.

**But:**
- If a chunk contained **only** Griffel's CSS after processing we got an empty file, for example:
   ```
   - griffel.css (contains all CSS)
   - chunk.css (became empty file)
   - async-chunk.css (became empty file)
   ```
- These empty files **could not be removed** (via [`compilation.deleteAsset()`](https://webpack.js.org/api/compilation-object/#deleteasset)) as `mini-css-extract-plugin` [will register](https://github.com/webpack-contrib/mini-css-extract-plugin/blob/26334462e419026086856787d672b052cd916c62/src/index.js#L943-L945) async chunks in JS runtime and these assets will fail to load.
- Whatever modifications to assets we will do - we should do them before [`.runtimeRequirementInTree`](https://github.com/webpack-contrib/mini-css-extract-plugin/blob/26334462e419026086856787d672b052cd916c62/src/index.js#L1071-L1076) (undocumented Webpack hook) otherwise chunks that have empty CSS could be registered in JS runtime 💣 

### Implementation in this PR

After multiple attempts to do something with assets I realized that [`.processAssets`](https://webpack.js.org/api/compilation-hooks/#processassets) is **too late** to transfer CSS between chunks. The problem that at any stage before `.runtimeRequirementInTree` we don't have assets - we operate with modules ([not really well documented](https://webpack.js.org/concepts/under-the-hood/)). _Simple explanation: an asset is a concatenated set of modules._

On `.afterChunks` (again undocumented, happens after a chunk graph gets **generated** and modules **were collected**):
- we attach a custom chunk to main entrypoint
- we move all modules produced by `mini-css-extract-plugin` to that chunk (if they contain CSS produced by Griffel)

On `.processAssets` we are in the same condition actually as currently: all CSS modules produced by Griffel were moved to a dedicated chunk -> this chunk has a single CSS file -> we sort rules in it ✅ 