### PR TITLE
Hook naming lint rule

### DIFF
--- a/change/@griffel-eslint-plugin-e8795784-65dd-47ae-af56-2cd19703c5ae.json
+++ b/change/@griffel-eslint-plugin-e8795784-65dd-47ae-af56-2cd19703c5ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add linter rule to enforce hook naming pattern",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "tigeroakes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,6 +1,7 @@
 export const recommendedConfig = {
   plugins: ['@griffel'],
   rules: {
+    '@griffel/hook-naming': 'error',
     '@griffel/no-shorthands': 'error',
   },
 };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,4 +1,5 @@
 import { recommendedConfig } from './configs/recommended';
+import { hookNamingRule } from './rules/hook-naming';
 import { noShorthandsRule } from './rules/no-shorthands';
 
 export = {
@@ -6,6 +7,7 @@ export = {
     recommended: recommendedConfig,
   },
   rules: {
+    'hook-naming': hookNamingRule,
     'no-shorthands': noShorthandsRule,
   },
 };

--- a/packages/eslint-plugin/src/rules/hook-naming.md
+++ b/packages/eslint-plugin/src/rules/hook-naming.md
@@ -1,0 +1,31 @@
+# Enforce that hooks from `makeStyles()` are named with a "use" prefix (`@griffel/hook-naming`)
+
+Ensure that hooks returned by the `makeStyles()` function start with "use", so they follow [React convention](https://reactjs.org/docs/hooks-custom.html#using-a-custom-hook) and can be checked for [rules of Hooks](https://reactjs.org/docs/hooks-rules.html).
+
+## Rule Details
+
+`makeStyles()` is a factory that returns React hooks. Hooks should have names beginning with "use" (such as `useStyles`, not `getStyles`) to follow React convention. This also allows React lint rules to ensure hooks are called properly.
+
+Examples of **incorrect** code for this rule:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+export const getStyles = makeStyles({
+  root: {
+    backgroundColor: 'red',
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    backgroundColor: 'red',
+  },
+});
+```

--- a/packages/eslint-plugin/src/rules/hook-naming.test.ts
+++ b/packages/eslint-plugin/src/rules/hook-naming.test.ts
@@ -1,0 +1,65 @@
+import { TSESLint } from '@typescript-eslint/utils';
+import * as path from 'path';
+
+import { noShorthandsRule, RULE_NAME } from './no-shorthands';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: path.resolve('./node_modules/@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run(RULE_NAME, noShorthandsRule, {
+  valid: [
+    {
+      name: 'named useStyles',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { backgroundColor: 'red' },
+});
+`,
+    },
+    {
+      name: 'can be imported from react-components',
+      code: `
+import { makeStyles } from '@fluentui/react-components';
+
+export const useStyles = makeStyles({
+  root: { color: 'red' },
+  background: { backgroundColor: 'red' },
+});
+`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'Named with get',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const getStyles = makeStyles({
+  root: { backgroundColor: 'red' },
+});
+`,
+      errors: [{ messageId: 'invalidMakeStylesHookNameFound' }],
+    },
+    {
+      name: 'Name is only styles',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const styles = makeStyles({
+  root: {
+    ':hover': { backgroundColor: 'red' }
+  },
+});
+`,
+      errors: [{ messageId: 'invalidMakeStylesHookNameFound' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/hook-naming.test.ts
+++ b/packages/eslint-plugin/src/rules/hook-naming.test.ts
@@ -1,7 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
 
-import { noShorthandsRule, RULE_NAME } from './no-shorthands';
+import { hookNamingRule, RULE_NAME } from './hook-naming';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: path.resolve('./node_modules/@typescript-eslint/parser'),
@@ -11,7 +11,7 @@ const ruleTester = new TSESLint.RuleTester({
   },
 });
 
-ruleTester.run(RULE_NAME, noShorthandsRule, {
+ruleTester.run(RULE_NAME, hookNamingRule, {
   valid: [
     {
       name: 'named useStyles',

--- a/packages/eslint-plugin/src/rules/hook-naming.ts
+++ b/packages/eslint-plugin/src/rules/hook-naming.ts
@@ -1,0 +1,42 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+import { createRule } from '../utils/createRule';
+import { isIdentifier, isMakeStylesIdentifier } from '../utils/helpers';
+
+export const RULE_NAME = 'hook-naming';
+
+export const hookNamingRule: ReturnType<ReturnType<typeof ESLintUtils.RuleCreator>> = createRule({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce that hooks returned from makeStyles() calls are named with a "use" prefix',
+      recommended: 'error',
+    },
+    messages: {
+      invalidMakeStylesHookNameFound: 'Hooks must start with the prefix "use"',
+    },
+    schema: [
+      {
+        type: 'string',
+      },
+    ],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      VariableDeclarator(node) {
+        if (node.init !== null && node.init.type === 'CallExpression' && isMakeStylesIdentifier(node.init.callee)) {
+          const { id } = node;
+          if (isIdentifier(id) && !id.name.startsWith('use')) {
+            context.report({
+              node: id,
+              messageId: 'invalidMakeStylesHookNameFound',
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/hook-naming.ts
+++ b/packages/eslint-plugin/src/rules/hook-naming.ts
@@ -14,7 +14,7 @@ export const hookNamingRule: ReturnType<ReturnType<typeof ESLintUtils.RuleCreato
       recommended: 'error',
     },
     messages: {
-      invalidMakeStylesHookNameFound: 'Hooks must start with the prefix "use"',
+      invalidMakeStylesHookNameFound: '`makeStyles` returns a hook. Hooks must start with the prefix `use`',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/no-shorthands.ts
+++ b/packages/eslint-plugin/src/rules/no-shorthands.ts
@@ -2,7 +2,7 @@ import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
 import * as CSS from 'csstype';
 
 import { createRule } from '../utils/createRule';
-import { isIdentifier, isObjectExpression, isProperty } from '../utils/helpers';
+import { isIdentifier, isMakeStylesIdentifier, isObjectExpression, isProperty } from '../utils/helpers';
 
 export const RULE_NAME = 'no-shorthands';
 
@@ -102,7 +102,7 @@ export const noShorthandsRule: ReturnType<ReturnType<typeof ESLintUtils.RuleCrea
   create(context) {
     return {
       CallExpression(node) {
-        if (isIdentifier(node.callee) && node.callee.name === 'makeStyles') {
+        if (isMakeStylesIdentifier(node.callee)) {
           const argument = node.arguments[0];
 
           if (isObjectExpression(argument)) {

--- a/packages/eslint-plugin/src/utils/helpers.ts
+++ b/packages/eslint-plugin/src/utils/helpers.ts
@@ -9,3 +9,7 @@ export const isObjectExpression: IsHelper<AST_NODE_TYPES.ObjectExpression> = AST
   AST_NODE_TYPES.ObjectExpression,
 );
 export const isProperty: IsHelper<AST_NODE_TYPES.Property> = ASTUtils.isNodeOfType(AST_NODE_TYPES.Property);
+
+export function isMakeStylesIdentifier(node: TSESTree.Node | null | undefined): node is TSESTree.Identifier {
+  return isIdentifier(node) && node.name === 'makeStyles';
+}


### PR DESCRIPTION
Fixes #213

Introduce a new linter rule to enforce the React hook naming pattern