### PR TITLE
fix: update path normalization in absolutePathToRelative

### DIFF
--- a/change/@griffel-babel-preset-63dd66d3-170c-447a-a1dd-4022b83ea67a.json
+++ b/change/@griffel-babel-preset-63dd66d3-170c-447a-a1dd-4022b83ea67a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update path normalization in absolutePathToRelative",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/src/assets/absolutePathToRelative.test.ts
+++ b/packages/babel-preset/src/assets/absolutePathToRelative.test.ts
@@ -20,6 +20,15 @@ describe('absolutePathToRelative', () => {
         'src/styles/Component.png',
       ),
     ).toBe('./Component.png');
+
+    expect(
+      absolutePathToRelative(
+        path.posix,
+        '/home/projects/foo',
+        '/home/projects/foo/packages/components/src/index.styles.ts',
+        'packages/components/src/images/Component.png',
+      ),
+    ).toBe('./images/Component.png');
   });
 
   it('handles Windows paths', () => {
@@ -40,5 +49,14 @@ describe('absolutePathToRelative', () => {
         'src/styles/Component.png',
       ),
     ).toBe('./Component.png');
+
+    expect(
+      absolutePathToRelative(
+        path.win32,
+        'C:\\Users\\Foo\\projects',
+        'C:\\Users\\Foo\\projects\\packages\\components\\src\\index.styles.ts',
+        'packages/components/src/images/Component.png',
+      ),
+    ).toBe('./images/Component.png');
   });
 });

--- a/packages/babel-preset/src/assets/absolutePathToRelative.ts
+++ b/packages/babel-preset/src/assets/absolutePathToRelative.ts
@@ -5,15 +5,13 @@ export function absolutePathToRelative(
   assetPath: string,
 ) {
   const fileDirectory = path.dirname(filename);
-
   const absoluteAssetPath = path.resolve(projectRoot, assetPath);
-  const assetDirectory = path.dirname(absoluteAssetPath);
 
-  if (fileDirectory === assetDirectory) {
-    return './' + path.basename(assetPath);
+  let relativeAssetPath = path.relative(fileDirectory, absoluteAssetPath);
+
+  if (!relativeAssetPath.startsWith('..' + path.sep)) {
+    relativeAssetPath = './' + relativeAssetPath;
   }
-
-  const relativeAssetPath = path.relative(fileDirectory, absoluteAssetPath);
 
   // Normalize paths to be POSIX-like as bundlers don't handle Windows paths
   // "path.posix" does not make sense there as there is no "windows-to-posix-path" function


### PR DESCRIPTION
`absolutePathToRelative()` was producing wrong paths before and caused build failures as Webpack failed to resolve paths:

```
[packages/experiences/*] > Requests that start with a name are treated as module requests and resolve within module directories (node_modules).
[packages/experiences/*] > If changing the source code is not an option there is also a resolve options called 'preferRelative' which tries to resolve these kind of requests in the current directory too.,Module not found: Error: Can't resolve 'images/Image.png' in '/Users/*/packages/components/src'
[packages/experiences/*] > Did you mean './images/Image.png'?
[packages/experiences/*] > Requests that should resolve in the current directory need to start with './'.
```

### Change

```
// Before
absolutePathToRelative(...args) // "images/Component.png"

// After
absolutePathToRelative(...args) // "./images/Component.png"
```