### PR TITLE
chore: bump loader-utils, schema-utils and beachball

### DIFF
--- a/.yarn/patches/beachball-npm-2.31.5-0e84ec4233.patch
+++ b/.yarn/patches/beachball-npm-2.31.5-0e84ec4233.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/packageManager/packagePublish.js b/lib/packageManager/packagePublish.js
-index 6848f4d9fa070cd5262de8dc19a0a305b0dc4b6d..a016d229f92f567f43b2cc3d403c38725ceb1d70 100644
+index 6a211b2b472c8d16f776f79a89d5914cabd390b7..f0006dd42e1f8aae581e61c6c5b6dfe495500ed1 100644
 --- a/lib/packageManager/packagePublish.js
 +++ b/lib/packageManager/packagePublish.js
 @@ -9,6 +9,10 @@ const npm_1 = require("./npm");
@@ -19,9 +19,8 @@ index 6848f4d9fa070cd5262de8dc19a0a305b0dc4b6d..a016d229f92f567f43b2cc3d403c3872
      }
 +    console.log(`publish cwd: ${artifactsPath}`);
      console.log(`publish command: ${args.join(' ')}`);
--    return npm_1.npm(args, { cwd: packagePath, timeout });
-+    return npm_1.npm(args, { cwd: artifactsPath, timeout });
+-    return npm_1.npmAsync(args, { cwd: packagePath, timeout, all: true });
++    return npm_1.npmAsync(args, { cwd: artifactsPath, timeout, all: true });
  }
  exports.packagePublish = packagePublish;
  //# sourceMappingURL=packagePublish.js.map
-\ No newline at end of file

--- a/change/@griffel-webpack-extraction-plugin-4de53343-d0d0-448c-b7d5-edee0aa3facb.json
+++ b/change/@griffel-webpack-extraction-plugin-4de53343-d0d0-448c-b7d5-edee0aa3facb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove loader-utils & schema-utils from dependencies",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-loader-2410326a-c4ef-41e8-824d-f9d543e4ce90.json
+++ b/change/@griffel-webpack-loader-2410326a-c4ef-41e8-824d-f9d543e4ce90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove loader-utils & schema-utils from dependencies",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@types/d3-scale-chromatic": "^3.0.0",
     "@types/jest": "27.0.2",
     "@types/js-beautify": "^1.13.3",
-    "@types/loader-utils": "2.0.3",
     "@types/mini-css-extract-plugin": "2.5.1",
     "@types/node": "14.14.33",
     "@types/react": "17.0.30",
@@ -72,7 +71,7 @@
     "babel-loader": "8.1.0",
     "babel-plugin-annotate-pure-calls": "0.4.0",
     "babel-plugin-tester": "10.0.0",
-    "beachball": "^2.20.0",
+    "beachball": "2.31.5",
     "bestzip": "2.2.0",
     "d3-scale-chromatic": "^3.0.0",
     "doctoc": "2.2.1",
@@ -127,9 +126,7 @@
     "browserslist": "^4.19.1",
     "csstype": "^3.0.10",
     "enhanced-resolve": "^5.8.2",
-    "loader-utils": "^2.0.4",
     "rtl-css-js": "^1.16.0",
-    "schema-utils": "^3.1.1",
     "source-map-js": "1.0.2",
     "stylis": "^4.0.13",
     "swc-node": "1.0.0",
@@ -139,7 +136,7 @@
     "@docusaurus/theme-common@2.1.0": "patch:@docusaurus/theme-common@npm:2.1.0#.yarn/patches/@docusaurus-theme-common-npm-2.1.0-d5ae2a9539.patch",
     "@nrwl/web": "patch:@nrwl/web@npm:13.4.5#.yarn/patches/@nrwl-web-npm-13.4.5-d7e9ea40d2",
     "@nrwl/workspace": "patch:@nrwl/workspace@npm:13.4.5#.yarn/patches/@nrwl-workspace-npm-13.4.5-233a3ec85c",
-    "beachball": "patch:beachball@npm:2.21.0#.yarn/patches/beachball-npm-2.21.0-85c8ba3d6b",
+    "beachball@2.31.5": "patch:beachball@npm:2.31.5#.yarn/patches/beachball-npm-2.31.5-0e84ec4233.patch",
     "source-map-js@1.0.2": "patch:source-map-js@npm:1.0.2#.yarn/patches/source-map-js-npm-1.0.2-ee4f9f9b30.patch"
   }
 }

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -10,8 +10,6 @@
   "dependencies": {
     "@babel/core": "^7.12.13",
     "@babel/helper-plugin-utils": "^7.12.13",
-    "loader-utils": "^2.0.4",
-    "schema-utils": "^3.1.1",
     "stylis": "^4.0.13",
     "tslib": "^2.1.0"
   },

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -1,11 +1,8 @@
 import { normalizeCSSBucketEntry } from '@griffel/core';
-import { getOptions } from 'loader-utils';
 import * as path from 'path';
-import { validate } from 'schema-utils';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
-import { configSchema } from './schema';
 
 type WebpackLoaderOptions = never;
 
@@ -37,7 +34,7 @@ function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOption
 }
 
 function webpackLoader(
-  this: webpack.LoaderContext<never>,
+  this: webpack.LoaderContext<WebpackLoaderOptions>,
   sourceCode: WebpackLoaderParams[0],
   inputSourceMap: WebpackLoaderParams[1],
 ) {
@@ -45,13 +42,6 @@ function webpackLoader(
   // Loaders are cacheable by default, but in edge cases/bugs when caching does not work until it's specified:
   // https://github.com/webpack/webpack/issues/14946
   this.cacheable();
-
-  const options = getOptions(this) as WebpackLoaderOptions;
-
-  validate(configSchema, options, {
-    name: '@griffel/webpack-extraction-plugin/loader',
-    baseDataPath: 'options',
-  });
 
   // Early return to handle cases when __styles() calls are not present, allows skipping expensive invocation of Babel
   if (sourceCode.indexOf('__styles') === -1 && sourceCode.indexOf('__resetStyles') === -1) {

--- a/packages/webpack-loader/__fixtures__/error-config/error.ts
+++ b/packages/webpack-loader/__fixtures__/error-config/error.ts
@@ -1,1 +1,1 @@
-export default /webpack-loader has been initialized using an options object that does not match the API schema/;
+export default /Loader has been initialized using an options object that does not match the API schema/;

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -11,8 +11,6 @@
     "@babel/core": "^7.12.13",
     "@griffel/babel-preset": "^1.4.6",
     "enhanced-resolve": "^5.8.2",
-    "loader-utils": "^2.0.4",
-    "schema-utils": "^3.1.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -1,8 +1,6 @@
 import { configSchema, BabelPluginOptions, EvalCache, Module } from '@griffel/babel-preset';
 import * as enhancedResolve from 'enhanced-resolve';
-import { getOptions } from 'loader-utils';
 import * as path from 'path';
-import { validate } from 'schema-utils';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
@@ -40,20 +38,15 @@ function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOption
 }
 
 export function webpackLoader(
-  this: webpack.LoaderContext<never>,
+  this: webpack.LoaderContext<WebpackLoaderOptions>,
   sourceCode: WebpackLoaderParams[0],
   inputSourceMap: WebpackLoaderParams[1],
 ) {
-  // Loaders are cacheable by default, but in there edge cases/bugs when caching does not work until it's specified:
+  // Loaders are cacheable by default, but there are edge cases/bugs when caching does not work until it's specified:
   // https://github.com/webpack/webpack/issues/14946
   this.cacheable();
 
-  const options = getOptions(this) as WebpackLoaderOptions;
-
-  validate(configSchema, options, {
-    name: '@griffel/webpack-loader',
-    baseDataPath: 'options',
-  });
+  const options = this.getOptions(configSchema);
 
   // Early return to handle cases when makeStyles() calls are not present, allows to avoid expensive invocation of Babel
   if (!shouldTransformSourceCode(sourceCode, options.modules)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6587,16 +6587,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/loader-utils@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@types/loader-utils@npm:2.0.3"
-  dependencies:
-    "@types/node": "*"
-    "@types/webpack": ^4
-  checksum: f50cce4ddd91f80b3a41476079cf41bc81e66c50b82a4cd69912f648e4e9881bf323cfb03795c96d3b1379f4f5bd9ab21201cc06f2785919611ca05490b85440
-  languageName: node
-  linkType: hard
-
 "@types/mdast@npm:^3.0.0":
   version: 3.0.10
   resolution: "@types/mdast@npm:3.0.10"
@@ -6622,7 +6612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimatch@npm:*, @types/minimatch@npm:^3.0.3":
+"@types/minimatch@npm:*":
   version: 3.0.5
   resolution: "@types/minimatch@npm:3.0.5"
   checksum: c41d136f67231c3131cf1d4ca0b06687f4a322918a3a5adddc87ce90ed9dbd175a3610adee36b106ae68c0b92c637c35e02b58c8a56c424f71d30993ea220b92
@@ -6992,7 +6982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/webpack@npm:^4, @types/webpack@npm:^4.41.26, @types/webpack@npm:^4.41.8":
+"@types/webpack@npm:^4.41.26, @types/webpack@npm:^4.41.8":
   version: 4.41.32
   resolution: "@types/webpack@npm:4.41.32"
   dependencies:
@@ -8127,13 +8117,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-differ@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "array-differ@npm:3.0.0"
-  checksum: 117edd9df5c1530bd116c6e8eea891d4bd02850fd89b1b36e532b6540e47ca620a373b81feca1c62d1395d9ae601516ba538abe5e8172d41091da2c546b05fb7
-  languageName: node
-  linkType: hard
-
 "array-flatten@npm:1.1.1":
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
@@ -8799,53 +8782,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"beachball@npm:2.21.0":
-  version: 2.21.0
-  resolution: "beachball@npm:2.21.0"
+"beachball@npm:2.31.5":
+  version: 2.31.5
+  resolution: "beachball@npm:2.31.5"
   dependencies:
-    cosmiconfig: ^6.0.0
-    execa: ^4.0.3
-    fs-extra: ^8.0.1
-    git-url-parse: ^11.1.2
-    glob: ^7.1.4
-    human-id: ^2.0.1
+    cosmiconfig: ^7.0.0
+    execa: ^5.0.0
+    fs-extra: ^10.0.0
     lodash: ^4.17.15
     minimatch: ^3.0.4
     p-limit: ^3.0.2
-    prompts: ~2.1.0
-    semver: ^6.1.1
+    prompts: ^2.4.2
+    semver: ^7.0.0
     toposort: ^2.0.2
-    uuid: ^8.3.1
-    workspace-tools: ^0.16.2
-    yargs-parser: ^20.2.4
+    uuid: ^9.0.0
+    workspace-tools: ^0.29.0
+    yargs-parser: ^21.0.0
   bin:
     beachball: bin/beachball.js
-  checksum: 468f62b7aef67b03e2e3db8582e1a169851db2d8ebba6849a06720459a4d5d042a0741267760aec514c52b11cea5689d74cbfa062c050df8d398b3c18f641f47
+  checksum: 217627dd2c365b8cbc3695b96463250358a50853ac3b307b55cb1a58cc6760b3c6aaddb12021c7de006cd0b510f20093366adff8ce35fed776d4d9b969e40c81
   languageName: node
   linkType: hard
 
-"beachball@patch:beachball@npm:2.21.0#.yarn/patches/beachball-npm-2.21.0-85c8ba3d6b::locator=griffel-repository%40workspace%3A.":
-  version: 2.21.0
-  resolution: "beachball@patch:beachball@npm%3A2.21.0#.yarn/patches/beachball-npm-2.21.0-85c8ba3d6b::version=2.21.0&hash=a06160&locator=griffel-repository%40workspace%3A."
+"beachball@patch:beachball@npm:2.31.5#.yarn/patches/beachball-npm-2.31.5-0e84ec4233.patch::locator=griffel-repository%40workspace%3A.":
+  version: 2.31.5
+  resolution: "beachball@patch:beachball@npm%3A2.31.5#.yarn/patches/beachball-npm-2.31.5-0e84ec4233.patch::version=2.31.5&hash=e6e3ec&locator=griffel-repository%40workspace%3A."
   dependencies:
-    cosmiconfig: ^6.0.0
-    execa: ^4.0.3
-    fs-extra: ^8.0.1
-    git-url-parse: ^11.1.2
-    glob: ^7.1.4
-    human-id: ^2.0.1
+    cosmiconfig: ^7.0.0
+    execa: ^5.0.0
+    fs-extra: ^10.0.0
     lodash: ^4.17.15
     minimatch: ^3.0.4
     p-limit: ^3.0.2
-    prompts: ~2.1.0
-    semver: ^6.1.1
+    prompts: ^2.4.2
+    semver: ^7.0.0
     toposort: ^2.0.2
-    uuid: ^8.3.1
-    workspace-tools: ^0.16.2
-    yargs-parser: ^20.2.4
+    uuid: ^9.0.0
+    workspace-tools: ^0.29.0
+    yargs-parser: ^21.0.0
   bin:
     beachball: bin/beachball.js
-  checksum: 3a5077fb0f31d6270e4a51c10a86ad9e8e92a6f16052ddd48b8e30053cd619135feb2eb1689c219e83438a2f65d030d8f5aa247708faf542769d9ba7c39e082c
+  checksum: 204fd319f7f4ad9997fc25586ef66b88e929daa324f6a9a573a38c793ca39bb965233e161168337a3e8151b74d8df0a9048c59259581ebda65aa2a41fc312bf7
   languageName: node
   linkType: hard
 
@@ -13370,23 +13347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^4.0.3":
-  version: 4.1.0
-  resolution: "execa@npm:4.1.0"
-  dependencies:
-    cross-spawn: ^7.0.0
-    get-stream: ^5.0.0
-    human-signals: ^1.1.1
-    is-stream: ^2.0.0
-    merge-stream: ^2.0.0
-    npm-run-path: ^4.0.0
-    onetime: ^5.1.0
-    signal-exit: ^3.0.2
-    strip-final-newline: ^2.0.0
-  checksum: e30d298934d9c52f90f3847704fd8224e849a081ab2b517bbc02f5f7732c24e56a21f14cb96a08256deffeb2d12b2b7cb7e2b014a12fb36f8d3357e06417ed55
-  languageName: node
-  linkType: hard
-
 "execa@npm:^5.0.0":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -13780,13 +13740,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filter-obj@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "filter-obj@npm:1.1.0"
-  checksum: cf2104a7c45ff48e7f505b78a3991c8f7f30f28bd8106ef582721f321f1c6277f7751aacd5d83026cb079d9d5091082f588d14a72e7c5d720ece79118fa61e10
-  languageName: node
-  linkType: hard
-
 "finalhandler@npm:1.2.0":
   version: 1.2.0
   resolution: "finalhandler@npm:1.2.0"
@@ -13876,16 +13829,6 @@ __metadata:
     locate-path: ^7.1.0
     path-exists: ^5.0.0
   checksum: 9a21b7f9244a420e54c6df95b4f6fc3941efd3c3e5476f8274eb452f6a85706e7a6a90de71353ee4f091fcb4593271a6f92810a324ec542650398f928783c280
-  languageName: node
-  linkType: hard
-
-"find-yarn-workspace-root@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "find-yarn-workspace-root@npm:1.2.1"
-  dependencies:
-    fs-extra: ^4.0.3
-    micromatch: ^3.1.4
-  checksum: a8f4565fb1ead6122acc0d324fa3257c20f7b0c91b7b266dab9eee7251fb5558fcff5b35dbfd301bfd1cbb91c1cdd1799b28ffa5b9a92efd8c7ded3663652bbe
   languageName: node
   linkType: hard
 
@@ -14114,7 +14057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:8.1.0, fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
+"fs-extra@npm:8.1.0, fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
   dependencies:
@@ -14138,7 +14081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.1.0":
+"fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:
@@ -14146,17 +14089,6 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "fs-extra@npm:4.0.3"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
-  checksum: c5ae3c7043ad7187128e619c0371da01b58694c1ffa02c36fb3f5b459925d9c27c3cb1e095d9df0a34a85ca993d8b8ff6f6ecef868fd5ebb243548afa7fc0936
   languageName: node
   linkType: hard
 
@@ -14394,7 +14326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
+"get-stream@npm:^5.1.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -14427,16 +14359,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-up@npm:^4.0.0":
-  version: 4.0.5
-  resolution: "git-up@npm:4.0.5"
-  dependencies:
-    is-ssh: ^1.3.0
-    parse-url: ^6.0.0
-  checksum: dd8f39a115ec0523b7da369cd4c6dc94a9b11fcc652e6fc9d011a93c287e27cc34e1d1c89cff8864f9ab11a1b2bea49786951d8eb3f1e5babd351afcc63f6135
-  languageName: node
-  linkType: hard
-
 "git-up@npm:^7.0.0":
   version: 7.0.0
   resolution: "git-up@npm:7.0.0"
@@ -14444,15 +14366,6 @@ __metadata:
     is-ssh: ^1.4.0
     parse-url: ^8.1.0
   checksum: 2faadbab51e94d2ffb220e426e950087cc02c15d664e673bd5d1f734cfa8196fed8b19493f7bf28fe216d087d10e22a7fd9b63687e0ba7d24f0ddcfb0a266d6e
-  languageName: node
-  linkType: hard
-
-"git-url-parse@npm:^11.1.2":
-  version: 11.6.0
-  resolution: "git-url-parse@npm:11.6.0"
-  dependencies:
-    git-up: ^4.0.0
-  checksum: 18a7d0bbac76c55fe8a501d4bd4c6b5f5528883a4dadcfce1152b4902e3e5831df8e97f36ea3f564de633e9ab44d9ab09bb2f319e41af1b6e4f627af139d35d5
   languageName: node
   linkType: hard
 
@@ -14794,7 +14707,6 @@ __metadata:
     "@types/d3-scale-chromatic": ^3.0.0
     "@types/jest": 27.0.2
     "@types/js-beautify": ^1.13.3
-    "@types/loader-utils": 2.0.3
     "@types/mini-css-extract-plugin": 2.5.1
     "@types/node": 14.14.33
     "@types/react": 17.0.30
@@ -14811,7 +14723,7 @@ __metadata:
     babel-loader: 8.1.0
     babel-plugin-annotate-pure-calls: 0.4.0
     babel-plugin-tester: 10.0.0
-    beachball: ^2.20.0
+    beachball: 2.31.5
     bestzip: 2.2.0
     browserslist: ^4.19.1
     csstype: ^3.0.10
@@ -14833,7 +14745,6 @@ __metadata:
     jest: 27.2.3
     jest-chrome: ^0.7.2
     js-beautify: ^1.14.0
-    loader-utils: ^2.0.4
     log-symbols: 4.1.0
     mdx-mermaid: 1.3.2
     mermaid: 9.1.7
@@ -14848,7 +14759,6 @@ __metadata:
     react-dom: 17.0.2
     react-test-renderer: 17.0.2
     rtl-css-js: ^1.16.0
-    schema-utils: ^3.1.1
     simple-git-hooks: 2.7.0
     source-map-js: 1.0.2
     stylis: ^4.0.13
@@ -15489,20 +15399,6 @@ __metadata:
     agent-base: 6
     debug: 4
   checksum: 165bfb090bd26d47693597661298006841ab733d0c7383a8cb2f17373387a94c903a3ac687090aa739de05e379ab6f868bae84ab4eac288ad85c328cd1ec9e53
-  languageName: node
-  linkType: hard
-
-"human-id@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "human-id@npm:2.0.1"
-  checksum: 4e5b100dbea18dee65b33e62d5b9ac51d73644a5a5e74d09afeb935c57f267292d64c2dd980a1400f6dc431d3e1c9cea4b3c7617e2d666cb88ab4c606dab38c1
-  languageName: node
-  linkType: hard
-
-"human-signals@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "human-signals@npm:1.1.1"
-  checksum: d587647c9e8ec24e02821b6be7de5a0fc37f591f6c4e319b3054b43fd4c35a70a94c46fc74d8c1a43c47fde157d23acd7421f375e1c1365b09a16835b8300205
   languageName: node
   linkType: hard
 
@@ -16367,7 +16263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-ssh@npm:^1.3.0, is-ssh@npm:^1.4.0":
+"is-ssh@npm:^1.4.0":
   version: 1.4.0
   resolution: "is-ssh@npm:1.4.0"
   dependencies:
@@ -17606,7 +17502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kleur@npm:^3.0.2, kleur@npm:^3.0.3":
+"kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: df82cd1e172f957bae9c536286265a5cdbd5eeca487cb0a3b2a7b41ef959fc61f8e7c0e9aeea9c114ccf2c166b6a8dd45a46fd619c1c569d210ecd2765ad5169
@@ -17800,17 +17696,17 @@ __metadata:
   linkType: hard
 
 "loader-utils@npm:^1.1.0, loader-utils@npm:^1.2.3, loader-utils@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "loader-utils@npm:1.4.0"
+  version: 1.4.2
+  resolution: "loader-utils@npm:1.4.2"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^1.0.1
-  checksum: d150b15e7a42ac47d935c8b484b79e44ff6ab4c75df7cc4cb9093350cf014ec0b17bdb60c5d6f91a37b8b218bd63b973e263c65944f58ca2573e402b9a27e717
+  checksum: eb6fb622efc0ffd1abdf68a2022f9eac62bef8ec599cf8adb75e94d1d338381780be6278534170e99edc03380a6d29bc7eb1563c89ce17c5fed3a0b17f1ad804
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^2.0.0, loader-utils@npm:^2.0.4":
+"loader-utils@npm:^2.0.0":
   version: 2.0.4
   resolution: "loader-utils@npm:2.0.4"
   dependencies:
@@ -17822,9 +17718,9 @@ __metadata:
   linkType: hard
 
 "loader-utils@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "loader-utils@npm:3.2.0"
-  checksum: c7b9a8dc4b3bc19e9ef563c48e3a18ea9f8bb2da1ad38a12e4b88358cfba5f148a7baf12d78fe78ffcb718ce1e062ab31fcf5c148459f1247a672a4213471e80
+  version: 3.2.1
+  resolution: "loader-utils@npm:3.2.1"
+  checksum: 4e3ea054cdc8be1ab1f1238f49f42fdf0483039eff920fb1d442039f3f0ad4ebd11fb8e584ccdf2cb7e3c56b3d40c1832416e6408a55651b843da288960cc792
   languageName: node
   linkType: hard
 
@@ -19067,19 +18963,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multimatch@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "multimatch@npm:4.0.0"
-  dependencies:
-    "@types/minimatch": ^3.0.3
-    array-differ: ^3.0.0
-    array-union: ^2.1.0
-    arrify: ^2.0.1
-    minimatch: ^3.0.4
-  checksum: bdb6a98dad4e919d9a1a2a0db872f44fa2337315f2fd5827d91ae005cf22f4425782bdfa97c10b80d567f0cb3c226c31f4e85f8f6a4a4be4facf9af0de1bb0c2
-  languageName: node
-  linkType: hard
-
 "nan@npm:^2.12.1":
   version: 2.15.0
   resolution: "nan@npm:2.15.0"
@@ -19433,7 +19316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^6.0.1, normalize-url@npm:^6.1.0":
+"normalize-url@npm:^6.0.1":
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 4a4944631173e7d521d6b80e4c85ccaeceb2870f315584fa30121f505a6dfd86439c5e3fdd8cd9e0e291290c41d0c3599f0cb12ab356722ed242584c30348e50
@@ -19449,7 +19332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
+"npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
   dependencies:
@@ -19706,7 +19589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
+"onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
@@ -20098,36 +19981,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-path@npm:^4.0.0":
-  version: 4.0.3
-  resolution: "parse-path@npm:4.0.3"
-  dependencies:
-    is-ssh: ^1.3.0
-    protocols: ^1.4.0
-    qs: ^6.9.4
-    query-string: ^6.13.8
-  checksum: d1704c0027489b64838c608c3f075fe3599c18a7413fa92e7074a0157e5bcc1a4ef73e7ae9bd9dbf5fad1809137437310cc69a57e5f5130ea17226165f3e942a
-  languageName: node
-  linkType: hard
-
 "parse-path@npm:^7.0.0":
   version: 7.0.0
   resolution: "parse-path@npm:7.0.0"
   dependencies:
     protocols: ^2.0.0
   checksum: 244b46523a58181d251dda9b888efde35d8afb957436598d948852f416d8c76ddb4f2010f9fc94218b4be3e5c0f716aa0d2026194a781e3b8981924142009302
-  languageName: node
-  linkType: hard
-
-"parse-url@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "parse-url@npm:6.0.0"
-  dependencies:
-    is-ssh: ^1.3.0
-    normalize-url: ^6.1.0
-    parse-path: ^4.0.0
-    protocols: ^1.4.0
-  checksum: 6b680d1fdfba15fc54106c1130540bf61a415bc3085351b8609a213b2fdf551c53ec8d32703d8ea9b6c5fbf2da92ee1593c99f682032512b15ce87f9013d2a39
   languageName: node
   linkType: hard
 
@@ -21304,16 +21163,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "prompts@npm:2.1.0"
-  dependencies:
-    kleur: ^3.0.2
-    sisteransi: ^1.0.0
-  checksum: f84fdae70dd332b7293e26659ae71c0db4a5fe87d9e40f07b4863996feeed1c88ad5c99d4eeb5362d3aec6ffee97c6ba5a9e2870f885a6a43952f4e079fb2226
-  languageName: node
-  linkType: hard
-
 "prop-types@npm:^15.0.0, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
@@ -21338,13 +21187,6 @@ __metadata:
   version: 1.2.4
   resolution: "proto-list@npm:1.2.4"
   checksum: 4d4826e1713cbfa0f15124ab0ae494c91b597a3c458670c9714c36e8baddf5a6aad22842776f2f5b137f259c8533e741771445eb8df82e861eea37a6eaba03f7
-  languageName: node
-  linkType: hard
-
-"protocols@npm:^1.4.0":
-  version: 1.4.8
-  resolution: "protocols@npm:1.4.8"
-  checksum: 2d555c013df0b05402970f67f7207c9955a92b1d13ffa503c814b5fe2f6dde7ac6a03320e0975c1f5832b0113327865e0b3b28bfcad023c25ddb54b53fab8684
   languageName: node
   linkType: hard
 
@@ -21475,24 +21317,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.10.3, qs@npm:^6.10.0, qs@npm:^6.4.0, qs@npm:^6.9.4":
+"qs@npm:6.10.3, qs@npm:^6.10.0, qs@npm:^6.4.0":
   version: 6.10.3
   resolution: "qs@npm:6.10.3"
   dependencies:
     side-channel: ^1.0.4
   checksum: 0fac5e6c7191d0295a96d0e83c851aeb015df7e990e4d3b093897d3ac6c94e555dbd0a599739c84d7fa46d7fee282d94ba76943983935cf33bba6769539b8019
-  languageName: node
-  linkType: hard
-
-"query-string@npm:^6.13.8":
-  version: 6.14.1
-  resolution: "query-string@npm:6.14.1"
-  dependencies:
-    decode-uri-component: ^0.2.0
-    filter-obj: ^1.1.0
-    split-on-first: ^1.0.0
-    strict-uri-encode: ^2.0.0
-  checksum: f2c7347578fa0f3fd4eaace506470cb4e9dc52d409a7ddbd613f614b9a594d750877e193b5d5e843c7477b3b295b857ec328903c943957adc41a3efb6c929449
   languageName: node
   linkType: hard
 
@@ -22067,7 +21897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-yaml-file@npm:2.1.0, read-yaml-file@npm:^2.0.0":
+"read-yaml-file@npm:2.1.0":
   version: 2.1.0
   resolution: "read-yaml-file@npm:2.1.0"
   dependencies:
@@ -23135,14 +22965,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "semver@npm:7.3.7"
+"semver@npm:7.x, semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
+  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
   languageName: node
   linkType: hard
 
@@ -23424,7 +23254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sisteransi@npm:^1.0.0, sisteransi@npm:^1.0.5":
+"sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
   checksum: aba6438f46d2bfcef94cf112c835ab395172c75f67453fe05c340c770d3c402363018ae1ab4172a1026a90c47eaccf3af7b6ff6fa749a680c2929bd7fa2b37a4
@@ -23735,13 +23565,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split-on-first@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "split-on-first@npm:1.1.0"
-  checksum: 16ff85b54ddcf17f9147210a4022529b343edbcbea4ce977c8f30e38408b8d6e0f25f92cd35b86a524d4797f455e29ab89eb8db787f3c10708e0b47ebf528d30
-  languageName: node
-  linkType: hard
-
 "split-string@npm:^3.0.1, split-string@npm:^3.0.2":
   version: 3.1.0
   resolution: "split-string@npm:3.1.0"
@@ -23881,13 +23704,6 @@ __metadata:
   version: 1.0.1
   resolution: "stream-shift@npm:1.0.1"
   checksum: 59b82b44b29ec3699b5519a49b3cedcc6db58c72fb40c04e005525dfdcab1c75c4e0c180b923c380f204bed78211b9bad8faecc7b93dece4d004c3f6ec75737b
-  languageName: node
-  linkType: hard
-
-"strict-uri-encode@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "strict-uri-encode@npm:2.0.0"
-  checksum: eaac4cf978b6fbd480f1092cab8b233c9b949bcabfc9b598dd79a758f7243c28765ef7639c876fa72940dac687181b35486ea01ff7df3e65ce3848c64822c581
   languageName: node
   linkType: hard
 
@@ -25662,12 +25478,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.1, uuid@npm:^8.3.2":
+"uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 
@@ -26364,24 +26189,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workspace-tools@npm:^0.16.2":
-  version: 0.16.2
-  resolution: "workspace-tools@npm:0.16.2"
-  dependencies:
-    "@yarnpkg/lockfile": ^1.1.0
-    find-up: ^4.1.0
-    find-yarn-workspace-root: ^1.2.1
-    fs-extra: ^9.0.0
-    git-url-parse: ^11.1.2
-    globby: ^11.0.0
-    jju: ^1.4.0
-    multimatch: ^4.0.0
-    read-yaml-file: ^2.0.0
-  checksum: 5af6bc293559ca1ad42cf8521f8d11682a78f90c8729f5cdb66f849c3c190b38ba81a5ec2bc951ef533b1a368e12b3484e32cbded3fd6a8f05ab15cf818c4e72
-  languageName: node
-  linkType: hard
-
-"workspace-tools@npm:^0.29.1":
+"workspace-tools@npm:^0.29.0, workspace-tools@npm:^0.29.1":
   version: 0.29.1
   resolution: "workspace-tools@npm:0.29.1"
   dependencies:
@@ -26565,7 +26373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:20.x, yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.4, yargs-parser@npm:^20.2.7":
+"yargs-parser@npm:20.x, yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.7":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
@@ -26582,7 +26390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:^21.0.0, yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c


### PR DESCRIPTION
- Removes `loader-utils` & `schema-utils` from dependencies
- Bumps loader-utils in `yarn.lock` resolve security alerts
- Bumps beachball to resolve security alerts