### PR TITLE
fix: avoid empty CSS imports

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-46602e0c-3b1b-4553-a919-32df4dda9fd9.json
+++ b/change/@griffel-webpack-extraction-plugin-46602e0c-3b1b-4553-a919-32df4dda9fd9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid empty CSS imports",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/missing-calls/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/missing-calls/code.ts
@@ -1,0 +1,1 @@
+export const foo = '__styles';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/missing-calls/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/missing-calls/output.ts
@@ -1,0 +1,1 @@
+export const foo = '__styles';

--- a/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
@@ -190,4 +190,7 @@ describe('webpackLoader', () => {
   testFixture('assets');
   testFixture('assets-multiple');
   testFixture('reset-assets');
+
+  // Ensures that a file without __styles calls remains unprocessed
+  testFixture('missing-calls');
 });


### PR DESCRIPTION
Fixes #266. More details in https://github.com/microsoft/griffel/issues/266#issuecomment-1340962907.

Our Babel plugin that strips runtime also returns a set of CSS rules in its metadata. Before this PR it always returned at least an empty object. Because of this the check below didn't work:

https://github.com/microsoft/griffel/blob/1289343d950319f48888cfe70c1c84af066f08db/packages/webpack-extraction-plugin/src/webpackLoader.ts#L68

As the check was passing always we were creating invalid imports for files that contain `__styles` as a string. [Files like that](https://github.com/microsoft/fluentui/blob/f3e6e65b7f6435dc6b09bfd626e99921a10983d8/packages/merge-styles/src/Stylesheet.ts#L90) were processed => got empty set of CSS rules => created an invalid import => crashed build.