### PR TITLE
fix: do not always normalize quotes in url()

### DIFF
--- a/change/@griffel-babel-preset-005f6c96-ccea-4fc1-b641-b97b741f7b2a.json
+++ b/change/@griffel-babel-preset-005f6c96-ccea-4fc1-b641-b97b741f7b2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: do not always normalize quotes in url()",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/__fixtures__/assets-urls/code.ts
+++ b/packages/babel-preset/__fixtures__/assets-urls/code.ts
@@ -5,5 +5,9 @@ export const useStyles = makeStyles({
   httpsUrl: { backgroundImage: 'url(https://www.example.com)' },
   httpsUrlWithQuotes: { backgroundImage: 'url("https://www.example.com")' },
   dataUrl: { backgroundImage: 'url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)' },
+  dataUrlQuotes: {
+    backgroundImage:
+      'url(\'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" height="32" aria-hidden="true" viewBox="0 0 16 16" width="32" data-view-component="true" class="octicon octicon-mark-github v-align-middle"%3E%3Cpath fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"%3E%3C/path%3E%3C/svg%3E\')',
+  },
   hashOnly: { filter: 'url(#a)' },
 });

--- a/packages/babel-preset/__fixtures__/assets-urls/output.ts
+++ b/packages/babel-preset/__fixtures__/assets-urls/output.ts
@@ -8,10 +8,13 @@ export const useStyles = __styles(
       Bcmaq0h: 'fvpuk3z',
     },
     httpsUrlWithQuotes: {
-      Bcmaq0h: 'fvpuk3z',
+      Bcmaq0h: 'fcrzfig',
     },
     dataUrl: {
       Bcmaq0h: 'f1b0d1k8',
+    },
+    dataUrlQuotes: {
+      Bcmaq0h: 'f15gfcnl',
     },
     hashOnly: {
       Bhu2qc9: 'f1bk4c0y',
@@ -21,7 +24,9 @@ export const useStyles = __styles(
     d: [
       `.f405sdg{background-image:url(http://www.example.com);}`,
       `.fvpuk3z{background-image:url(https://www.example.com);}`,
+      `.fcrzfig{background-image:url("https://www.example.com");}`,
       `.f1b0d1k8{background-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);}`,
+      `.f15gfcnl{background-image:url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" height="32" aria-hidden="true" viewBox="0 0 16 16" width="32" data-view-component="true" class="octicon octicon-mark-github v-align-middle"%3E%3Cpath fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"%3E%3C/path%3E%3C/svg%3E');}`,
       `.f1bk4c0y{-webkit-filter:url(#a);filter:url(#a);}`,
     ],
   },

--- a/packages/babel-preset/src/assets/isAssetUrl.test.ts
+++ b/packages/babel-preset/src/assets/isAssetUrl.test.ts
@@ -1,0 +1,24 @@
+import { isAssetUrl } from './isAssetUrl';
+
+describe('isAssetUrl', () => {
+  it('handles remote URLs', () => {
+    expect(isAssetUrl('data://example.com')).toBe(false);
+    expect(isAssetUrl('http://example.com')).toBe(false);
+    expect(isAssetUrl('https://example.com')).toBe(false);
+    expect(isAssetUrl('//example.com')).toBe(false);
+    expect(isAssetUrl('#svg-part')).toBe(false);
+  });
+
+  it('handles assets URLs', () => {
+    expect(isAssetUrl('../file.jpg')).toBe(true);
+    expect(isAssetUrl('./file.jpg')).toBe(true);
+  });
+
+  it('handles quotes around URLs', () => {
+    expect(isAssetUrl('"//example.com"')).toBe(false);
+    expect(isAssetUrl("'//example.com'")).toBe(false);
+
+    expect(isAssetUrl('"./file.jpg"')).toBe(true);
+    expect(isAssetUrl("'./file.jpg'")).toBe(true);
+  });
+});

--- a/packages/babel-preset/src/assets/isAssetUrl.ts
+++ b/packages/babel-preset/src/assets/isAssetUrl.ts
@@ -1,9 +1,11 @@
 export function isAssetUrl(value: string): boolean {
-  return (
-    !value.startsWith('data:') &&
-    !value.startsWith('http:') &&
-    !value.startsWith('https:') &&
-    !value.startsWith('//') /* Urls without protocol (use the same protocol as current page) */ &&
-    !value.startsWith('#') /* Hash only urls like `filter: url(#id)` */
-  );
+  const url = value.replace(/^['|"]/, '');
+  const isRemoteUrl =
+    url.startsWith('data:') ||
+    url.startsWith('http:') ||
+    url.startsWith('https:') ||
+    url.startsWith('//') /* Urls without protocol (use the same protocol as current page) */ ||
+    url.startsWith('#');
+
+  return !isRemoteUrl;
 }

--- a/packages/babel-preset/src/assets/normalizeStyleRules.ts
+++ b/packages/babel-preset/src/assets/normalizeStyleRules.ts
@@ -26,12 +26,17 @@ export function normalizeStyleRule(
 
   return tokenize(ruleValue).reduce((result, token, index, array) => {
     if (token === 'url') {
-      // Quotes in URL are optional, so we can also normalize them
-      // https://www.w3.org/TR/CSS2/syndata.html#value-def-uri
-      const url = array[index + 1].replace(/['|"](.+)['|"]/, '$1').slice(1, -1);
+      const url = array[index + 1].slice(1, -1);
 
       if (isAssetUrl(url)) {
-        array[index + 1] = `(${normalizeAssetPath(path, projectRoot, filename, url)})`;
+        array[index + 1] = `(${normalizeAssetPath(
+          path,
+          projectRoot,
+          filename,
+          // Quotes in URL are optional, so we can also normalize them as we know that it's a file path
+          // https://www.w3.org/TR/CSS2/syndata.html#value-def-uri
+          url.replace(/^['|"](.+)['|"]$/, '$1'),
+        )})`;
       } else {
         // Always replace with normalized value, so @griffel/core can de-duplicate them.
         array[index + 1] = `(${url})`;


### PR DESCRIPTION
Fixes #256.

_I still would like to normalize URLs, but didn't find about a good way to do that._

This PR removes quotes normalization for URLs that are not pointing to assets. For assets we can keep it as it just URL will be just a file path.