### PR TITLE
feat: expose "styleElementAttributes" on GriffelRenderer

### DIFF
--- a/change/@griffel-core-a8eb3726-f851-4e4b-835a-a1b792aec1db.json
+++ b/change/@griffel-core-a8eb3726-f851-4e4b-835a-a1b792aec1db.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: expose \"styleElementAttributes\" on GriffelRenderer",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/renderer/createDOMRenderer.ts
+++ b/packages/core/src/renderer/createDOMRenderer.ts
@@ -43,10 +43,11 @@ export function createDOMRenderer(
   target: Document | undefined = typeof document === 'undefined' ? undefined : document,
   options: CreateDOMRendererOptions = {},
 ): GriffelRenderer {
-  const { unstable_filterCSSRule, compareMediaQueries = defaultCompareMediaQueries } = options;
+  const { unstable_filterCSSRule, styleElementAttributes, compareMediaQueries = defaultCompareMediaQueries } = options;
   const renderer: GriffelRenderer = {
     insertionCache: {},
     stylesheets: {},
+    styleElementAttributes: Object.freeze(styleElementAttributes),
     compareMediaQueries,
 
     id: `d${lastIndex++}`,
@@ -59,13 +60,7 @@ export function createDOMRenderer(
         // This is a hot path in rendering styles: ".length" is cached in "l" var to avoid accesses the property
         for (let i = 0, l = cssRulesForBucket.length; i < l; i++) {
           const [ruleCSS, metadata] = normalizeCSSBucketEntry(cssRulesForBucket[i]);
-          const sheet = getStyleSheetForBucket(
-            styleBucketName as StyleBucketName,
-            target,
-            renderer,
-            options.styleElementAttributes,
-            metadata,
-          );
+          const sheet = getStyleSheetForBucket(styleBucketName as StyleBucketName, target, renderer, metadata);
 
           if (renderer.insertionCache[ruleCSS]) {
             continue;

--- a/packages/core/src/renderer/getStyleSheetForBucket.test.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.test.ts
@@ -47,23 +47,23 @@ describe('getStyleSheetForBucket', () => {
     getStyleSheetForBucket('d', target, renderer);
     getStyleSheetForBucket('v', target, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, {}, { m: '(max-width: 3px)' });
+    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 3px)' });
 
     getStyleSheetForBucket('a', target, renderer);
     getStyleSheetForBucket('i', target, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, {}, { m: '(max-width: 1px)' });
+    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 1px)' });
 
     getStyleSheetForBucket('h', target, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, {}, { m: '(max-width: 4px)' });
+    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 4px)' });
 
     getStyleSheetForBucket('w', target, renderer);
     getStyleSheetForBucket('t', target, renderer);
     getStyleSheetForBucket('k', target, renderer);
     getStyleSheetForBucket('f', target, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, {}, { m: '(max-width: 2px)' });
+    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 2px)' });
 
     const styleElements = target.head.querySelectorAll(`[${DATA_BUCKET_ATTR}]`);
     const styleElementOrder = Array.from(styleElements).map(styleElement =>

--- a/packages/core/src/renderer/getStyleSheetForBucket.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.ts
@@ -47,7 +47,6 @@ export function getStyleSheetForBucket(
   bucketName: StyleBucketName,
   target: Document | undefined,
   renderer: GriffelRenderer,
-  elementAttributes: Record<string, string> = {},
   metadata: Record<string, unknown> = {},
 ): IsomorphicStyleSheet {
   const isMediaBucket = bucketName === 'm';
@@ -56,7 +55,7 @@ export function getStyleSheetForBucket(
   if (!renderer.stylesheets[stylesheetKey]) {
     const tag: HTMLStyleElement | undefined = target && target.createElement('style');
     const stylesheet = createIsomorphicStyleSheet(tag, bucketName, {
-      ...elementAttributes,
+      ...renderer.styleElementAttributes,
       ...(isMediaBucket && { media: metadata['m'] as string }),
     });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -269,6 +269,11 @@ export interface GriffelRenderer {
   /**
    * @private
    */
+  styleElementAttributes?: Readonly<Record<string, string>>;
+
+  /**
+   * @private
+   */
   insertCSSRules(cssRules: CSSRulesByBucket): void;
 
   /**


### PR DESCRIPTION
Exposes `styleElementAttributes` on `GriffelRenderer` so attributes could be accessed and applied to other elements.

Is done to unblock https://github.com/microsoft/fluentui/issues/25421.