### PR TITLE
chore: adjust error messaging for rules which don't include ampersands

### DIFF
--- a/change/@griffel-core-d096f264-8c73-426c-b236-bcbf30ad8f49.json
+++ b/change/@griffel-core-d096f264-8c73-426c-b236-bcbf30ad8f49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adjusting console logging to emit a more descriptive error message.",
+  "packageName": "@griffel/core",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-core-d096f264-8c73-426c-b236-bcbf30ad8f49.json
+++ b/change/@griffel-core-d096f264-8c73-426c-b236-bcbf30ad8f49.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Adjusting console logging to emit a more descriptive error message.",
+  "comment": "chore: adjust console logging to emit a more descriptive error message",
   "packageName": "@griffel/core",
   "email": "dzearing@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/core/src/runtime/resolveResetStyleRules.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.ts
@@ -119,8 +119,19 @@ function createStringFromStyles(styles: GriffelResetStyle) {
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
-      console.error(`Please fix the unresolved style rule: \n ${property} \n ${JSON.stringify(value, null, 2)}"`);
+      if (property.indexOf('&') === -1) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `Please fix the unresolved style rule (it may be missing an ampersand placeholder where the generated class name should be injected): \n ${property} \n ${JSON.stringify(
+            value,
+            null,
+            2,
+          )}"`,
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(`Please fix the unresolved style rule: \n ${property} \n ${JSON.stringify(value, null, 2)}"`);
+      }
     }
   }
 

--- a/packages/core/src/runtime/resolveResetStyleRules.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.ts
@@ -11,6 +11,7 @@ import { isObject } from './utils/isObject';
 import { hyphenateProperty } from './utils/hyphenateProperty';
 import { compileCSSRules, normalizePseudoSelector } from './compileCSS';
 import { compileKeyframeRule, compileKeyframesCSS } from './compileKeyframeCSS';
+import { warnAboutUnresolvedRule } from './warnAboutUnresolvedRule';
 
 /**
  * @internal
@@ -119,17 +120,7 @@ function createStringFromStyles(styles: GriffelResetStyle) {
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      const ruleText = JSON.stringify(value, null, 2);
-
-      if (property.indexOf('&') === -1) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `Please fix the unresolved style rule (it is missing an ampersand placeholder where the generated class name should be injected): \n ${property} \n ${ruleText}`,
-        );
-      } else {
-        // eslint-disable-next-line no-console
-        console.error(`Please fix the unresolved style rule: \n ${property} \n ${ruleText}`);
-      }
+      warnAboutUnresolvedRule(property, value);
     }
   }
 

--- a/packages/core/src/runtime/resolveResetStyleRules.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.ts
@@ -119,18 +119,16 @@ function createStringFromStyles(styles: GriffelResetStyle) {
     }
 
     if (process.env.NODE_ENV !== 'production') {
+      const ruleText = JSON.stringify(value, null, 2);
+
       if (property.indexOf('&') === -1) {
         // eslint-disable-next-line no-console
         console.error(
-          `Please fix the unresolved style rule (it is missing an ampersand placeholder where the generated class name should be injected): \n ${property} \n ${JSON.stringify(
-            value,
-            null,
-            2,
-          )}"`,
+          `Please fix the unresolved style rule (it is missing an ampersand placeholder where the generated class name should be injected): \n ${property} \n ${ruleText}`,
         );
       } else {
         // eslint-disable-next-line no-console
-        console.error(`Please fix the unresolved style rule: \n ${property} \n ${JSON.stringify(value, null, 2)}"`);
+        console.error(`Please fix the unresolved style rule: \n ${property} \n ${ruleText}`);
       }
     }
   }

--- a/packages/core/src/runtime/resolveResetStyleRules.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.ts
@@ -122,7 +122,7 @@ function createStringFromStyles(styles: GriffelResetStyle) {
       if (property.indexOf('&') === -1) {
         // eslint-disable-next-line no-console
         console.error(
-          `Please fix the unresolved style rule (it may be missing an ampersand placeholder where the generated class name should be injected): \n ${property} \n ${JSON.stringify(
+          `Please fix the unresolved style rule (it is missing an ampersand placeholder where the generated class name should be injected): \n ${property} \n ${JSON.stringify(
             value,
             null,
             2,

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -1,7 +1,7 @@
 import hashString from '@emotion/hash';
 import { convert, convertProperty } from 'rtl-css-js/core';
 
-import { HASH_PREFIX } from '../constants';
+import { HASH_PREFIX, UNSUPPORTED_CSS_PROPERTIES } from '../constants';
 import {
   GriffelStyle,
   CSSClassesMap,
@@ -22,7 +22,7 @@ import { isObject } from './utils/isObject';
 import { getStyleBucketName } from './getStyleBucketName';
 import { hashClassName } from './utils/hashClassName';
 import { hashPropertyKey } from './utils/hashPropertyKey';
-import { UNSUPPORTED_CSS_PROPERTIES } from '..';
+import { warnAboutUnresolvedRule } from './warnAboutUnresolvedRule';
 
 function pushToClassesMap(
   classesMap: CSSClassesMap,
@@ -320,8 +320,7 @@ export function resolveStyleRules(
         );
       } else {
         if (process.env.NODE_ENV !== 'production') {
-          // eslint-disable-next-line no-console
-          console.error(`Please fix the unresolved style rule: \n ${property} \n ${JSON.stringify(value, null, 2)}"`);
+          warnAboutUnresolvedRule(property, value);
         }
       }
     }

--- a/packages/core/src/runtime/warnAboutUnresolvedRule.test.ts
+++ b/packages/core/src/runtime/warnAboutUnresolvedRule.test.ts
@@ -1,0 +1,29 @@
+import { warnAboutUnresolvedRule } from './warnAboutUnresolvedRule';
+
+describe('warnAboutUnresolvedRule', () => {
+  it('warns on a missing "&"', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    warnAboutUnresolvedRule('div', {
+      color: 'red',
+      ':hover': { color: 'blue' },
+    });
+
+    expect(spy.mock.calls[0][0]).toMatchInlineSnapshot(`
+      "@griffel/react: A rule was not resolved to CSS properly. Please check your \`makeStyles\` or \`makeResetStyles\` calls for following:
+        makeStyles({
+          [slot]: {
+            \\"div\\": {
+              \\"color\\": \\"red\\",
+              \\":hover\\": {
+                \\"color\\": \\"blue\\"
+              }
+            }
+          }
+        })
+
+      It looks that you're are using a nested selector, but it is missing an ampersand placeholder where the generated class name should be injected.
+      Try to update a property to include it i.e \\"div\\" => \\"&div\\"."
+    `);
+  });
+});

--- a/packages/core/src/runtime/warnAboutUnresolvedRule.ts
+++ b/packages/core/src/runtime/warnAboutUnresolvedRule.ts
@@ -1,4 +1,4 @@
-import type { GriffelResetStyle, GriffelStyle } from '@griffel/core';
+import type { GriffelResetStyle, GriffelStyle } from '../types';
 
 export function warnAboutUnresolvedRule(property: string, value: GriffelStyle | GriffelResetStyle) {
   const ruleText = JSON.stringify(value, null, 2);

--- a/packages/core/src/runtime/warnAboutUnresolvedRule.ts
+++ b/packages/core/src/runtime/warnAboutUnresolvedRule.ts
@@ -1,0 +1,34 @@
+import type { GriffelResetStyle, GriffelStyle } from '@griffel/core';
+
+export function warnAboutUnresolvedRule(property: string, value: GriffelStyle | GriffelResetStyle) {
+  const ruleText = JSON.stringify(value, null, 2);
+  const message: string[] = [
+    '@griffel/react: A rule was not resolved to CSS properly. ' +
+      'Please check your `makeStyles` or `makeResetStyles` calls for following:',
+    ' '.repeat(2) + 'makeStyles({',
+    ' '.repeat(4) + `[slot]: {`,
+    ' '.repeat(6) +
+      `"${property}": ${ruleText
+        .split('\n')
+        .map((l, n) => ' '.repeat(n === 0 ? 0 : 6) + l)
+        .join('\n')}`,
+    ' '.repeat(4) + '}',
+    ' '.repeat(2) + `})`,
+    '',
+  ];
+
+  if (property.indexOf('&') === -1) {
+    message.push(
+      `It looks that you're are using a nested selector, but it is missing an ampersand placeholder where the generated class name should be injected.`,
+    );
+    message.push(`Try to update a property to include it i.e "${property}" => "&${property}".`);
+  } else {
+    message.push('');
+    message.push(
+      "If it's not obvious what triggers a problem, please report an issue at https://github.com/microsoft/griffel/issues",
+    );
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(message.join('\n'));
+}


### PR DESCRIPTION
With this rule:

```
rule: {
  '.my-class': {
    ...
  }
}
```

Before:

Would fail to register and emit a `console.error` message indicating something was wrong.

After

Same behavior, but the message indicates an ampersand is missing in '.my-class'.
