### PR TITLE
chore(webpack-extraction-plugin): refactor to support aliased imports

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-f9a0e45f-28d4-4e43-99e9-7783f2eace29.json
+++ b/change/@griffel-webpack-extraction-plugin-f9a0e45f-28d4-4e43-99e9-7783f2eace29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: support aliased imports",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
   "dependencies": {
     "@babel/core": "^7.12.13",
     "@babel/generator": "^7.12.13",
+    "@babel/helper-module-imports": "^7.12.13",
     "@babel/helper-plugin-utils": "^7.12.13",
     "@babel/template": "^7.12.13",
     "@babel/traverse": "^7.12.13",

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/alias/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/alias/code.ts
@@ -1,0 +1,11 @@
+import { __styles as _styles } from '@griffel/react';
+export const useStyles = /*#__PURE__*/ _styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/alias/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/alias/output.ts
@@ -1,0 +1,7 @@
+import { __css as _css } from '@griffel/react';
+import { __styles as _styles } from '@griffel/react';
+export const useStyles = /*#__PURE__*/ _css({
+  root: {
+    sj55zd: 'fe3e8s9',
+  },
+});

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/basic/output.ts
@@ -1,5 +1,6 @@
-import { __styles, __css } from '@griffel/react';
-export const styles = __css({
+import { __css as _css } from '@griffel/react';
+import { __styles } from '@griffel/react';
+export const styles = _css({
   root: {
     sj55zd: 'fe3e8s9',
     uwmqm3: ['fycuoez', 'f8wuabp'],

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/mixed/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/mixed/output.ts
@@ -1,7 +1,9 @@
-import { __resetStyles, __styles, __resetCSS, __css } from '@griffel/react';
-export const useClasses = __css({
+import { __css as _css } from '@griffel/react';
+import { __resetCSS as _resetCSS } from '@griffel/react';
+import { __resetStyles, __styles } from '@griffel/react';
+export const useClasses = _css({
   root: {
     sj55zd: 'fe3e8s9',
   },
 });
-export const useClassName = __resetCSS('rjefjbm', 'r7z97ji');
+export const useClassName = _resetCSS('rjefjbm', 'r7z97ji');

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
@@ -1,4 +1,3 @@
-import { __css as _css2 } from '@griffel/react';
 import { __css as _css } from '@griffel/react';
 import { __styles } from '@griffel/react';
 export const stylesA = _css({
@@ -6,7 +5,7 @@ export const stylesA = _css({
     sj55zd: 'fe3e8s9',
   },
 });
-export const stylesB = _css2({
+export const stylesB = _css({
   root: {
     De3pzq: 'fcnqdeg',
   },

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/multiple/output.ts
@@ -1,10 +1,12 @@
-import { __styles, __css } from '@griffel/react';
-export const stylesA = __css({
+import { __css as _css2 } from '@griffel/react';
+import { __css as _css } from '@griffel/react';
+import { __styles } from '@griffel/react';
+export const stylesA = _css({
   root: {
     sj55zd: 'fe3e8s9',
   },
 });
-export const stylesB = __css({
+export const stylesB = _css2({
   root: {
     De3pzq: 'fcnqdeg',
   },

--- a/packages/webpack-extraction-plugin/__fixtures__/babel/reset/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/babel/reset/output.ts
@@ -1,2 +1,3 @@
-import { __resetStyles, __resetCSS } from '@griffel/react';
-export const useClassName = __resetCSS('rjefjbm', 'r7z97ji');
+import { __resetCSS as _resetCSS } from '@griffel/react';
+import { __resetStyles } from '@griffel/react';
+export const useClassName = _resetCSS('rjefjbm', 'r7z97ji');

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.ts
@@ -1,5 +1,6 @@
-import { __styles, __css } from '@griffel/react';
-export const useStyles = __css({
+import { __css as _css } from '@griffel/react';
+import { __styles } from '@griffel/react';
+export const useStyles = _css({
   root: {
     Bcmaq0h: 'fp00rh9',
   },

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
@@ -1,5 +1,6 @@
-import { __styles, __css } from '@griffel/react';
-export const useStyles = __css({
+import { __css as _css } from '@griffel/react';
+import { __styles } from '@griffel/react';
+export const useStyles = _css({
   root: {
     Bcmaq0h: 'fnwsaxv',
   },

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -1,5 +1,6 @@
-import { __styles, __css } from '@griffel/react';
-export const styles = __css({
+import { __css as _css } from '@griffel/react';
+import { __styles } from '@griffel/react';
+export const styles = _css({
   root: {
     sj55zd: 'fe3e8s9',
     uwmqm3: ['fycuoez', 'f8wuabp'],

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.ts
@@ -1,9 +1,11 @@
-import { __resetStyles, __styles, __resetCSS, __css } from '@griffel/react';
-export const useClasses = __css({
+import { __css as _css } from '@griffel/react';
+import { __resetCSS as _resetCSS } from '@griffel/react';
+import { __resetStyles, __styles } from '@griffel/react';
+export const useClasses = _css({
   root: {
     sj55zd: 'fe3e8s9',
   },
 });
-export const useClassName = __resetCSS('rjefjbm', 'r7z97ji');
+export const useClassName = _resetCSS('rjefjbm', 'r7z97ji');
 
-require('./code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts');
+require('./code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts');

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -1,4 +1,3 @@
-import { __css as _css2 } from '@griffel/react';
 import { __css as _css } from '@griffel/react';
 import { __styles } from '@griffel/react';
 export const stylesA = _css({
@@ -6,7 +5,7 @@ export const stylesA = _css({
     sj55zd: 'fe3e8s9',
   },
 });
-export const stylesB = _css2({
+export const stylesB = _css({
   root: {
     De3pzq: 'fcnqdeg',
   },

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -1,10 +1,12 @@
-import { __styles, __css } from '@griffel/react';
-export const stylesA = __css({
+import { __css as _css2 } from '@griffel/react';
+import { __css as _css } from '@griffel/react';
+import { __styles } from '@griffel/react';
+export const stylesA = _css({
   root: {
     sj55zd: 'fe3e8s9',
   },
 });
-export const stylesB = __css({
+export const stylesB = _css2({
   root: {
     De3pzq: 'fcnqdeg',
   },

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.ts
@@ -1,4 +1,5 @@
-import { __resetStyles, __resetCSS } from '@griffel/react';
-export const useClassName = __resetCSS('ra9m047', null);
+import { __resetCSS as _resetCSS } from '@griffel/react';
+import { __resetStyles } from '@griffel/react';
+export const useClassName = _resetCSS('ra9m047', null);
 
 require('./code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.ra9m047%7Bbackground-image%3Aurl(.%2Fblank.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts');

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.ts
@@ -1,4 +1,5 @@
-import { __resetStyles, __resetCSS } from '@griffel/react';
-export const useClassName = __resetCSS('rjefjbm', 'r7z97ji');
+import { __resetCSS as _resetCSS } from '@griffel/react';
+import { __resetStyles } from '@griffel/react';
+export const useClassName = _resetCSS('rjefjbm', 'r7z97ji');
 
 require('./code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts');

--- a/packages/webpack-extraction-plugin/package.json
+++ b/packages/webpack-extraction-plugin/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.13",
+    "@babel/helper-module-imports": "^7.12.13",
     "@babel/helper-plugin-utils": "^7.12.13",
     "stylis": "^4.0.13",
     "tslib": "^2.1.0"

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.test.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.test.ts
@@ -23,8 +23,39 @@ pluginTester({
       },
     }),
 
-  fixtures: fixturesDir,
-  tests: [],
+  tests: [
+    // 🎩 Tip: use "only: true" to run a single test
+    // https://github.com/babel-utils/babel-plugin-tester#only
+    //
+
+    {
+      title: 'basic (makeStyles)',
+      fixture: path.resolve(fixturesDir, 'basic', 'code.ts'),
+      outputFixture: path.resolve(fixturesDir, 'basic', 'output.ts'),
+    },
+    {
+      title: 'basic (makeResetStyles)',
+      fixture: path.resolve(fixturesDir, 'reset', 'code.ts'),
+      outputFixture: path.resolve(fixturesDir, 'reset', 'output.ts'),
+    },
+
+    {
+      title: 'multiple declarations (makeStyles)',
+      fixture: path.resolve(fixturesDir, 'multiple', 'code.ts'),
+      outputFixture: path.resolve(fixturesDir, 'multiple', 'output.ts'),
+    },
+    {
+      title: 'mixed (makeStyles + makeResetStyles)',
+      fixture: path.resolve(fixturesDir, 'mixed', 'code.ts'),
+      outputFixture: path.resolve(fixturesDir, 'mixed', 'output.ts'),
+    },
+
+    {
+      title: 'alias imports (makeStyles)',
+      fixture: path.resolve(fixturesDir, 'alias', 'code.ts'),
+      outputFixture: path.resolve(fixturesDir, 'alias', 'output.ts'),
+    },
+  ],
 
   plugin: babelPluginStripGriffelRuntime,
   pluginName: '@griffel/webpack-extraction-plugin/babel',

--- a/yarn.lock
+++ b/yarn.lock
@@ -15229,6 +15229,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.12.13
     "@babel/generator": ^7.12.13
+    "@babel/helper-module-imports": ^7.12.13
     "@babel/helper-plugin-utils": ^7.12.13
     "@babel/preset-typescript": 7.12.13
     "@babel/template": ^7.12.13


### PR DESCRIPTION
This PR refactors Babel plugin that replace functions and extracts CSS in `@griffel/webpack-extraction-plugin`. The goal is to use references from imports instead of hardcoded names (`__resetStyles` & `__styles`).

The refactor is needed as we will use transforms from Linaria itself (#309) instead of ours. `@linaria/babel-preset` uses `@babel/helper-module-imports` to generate imports that don't collide in the scope (_which is better_):

```js
// Before
import { __css } from '@griffel/react';
// After
import { __css as _css } from '@griffel/react';
import { __css as _css2 } from '@griffel/react';
```

Internally the plugin is almost the same, but now it takes references via `path.scope.getBinding()` instead of trying to target hardcoded identifiers directly. This allows to be compatible with upcoming changes.

- New fixture (`babel/alias/code.ts`) was added to verify the behavior
- Plugin uses `@babel/helper-module-imports` to emit imports, fixtures have been updated