### PR TITLE
docs: Add docs for pseudo elements

### DIFF
--- a/apps/website/docs/react/api/make-styles.md
+++ b/apps/website/docs/react/api/make-styles.md
@@ -98,6 +98,30 @@ const useClasses = makeStyles({
 }
 ```
 
+### Pseudo-elements
+
+Griffel supports pseudo-elements like `::before` and `::after`.
+
+```ts
+import { makeStyles } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    '::after': {
+      content: '""', // Note the nested quotes
+    },
+  },
+});
+```
+
+:::caution
+
+When setting content on pseudo elements, make sure to use nested quotes, e.g. `content: '"hello"'`
+
+This also applies for empty content: `content: '""'`.
+
+:::
+
 ### `:global()` selector
 
 Another useful feature is `:global()` selector, it associates local styles with global selectors.


### PR DESCRIPTION
The documentation was missing mention of pseudo-elements, more specifically the part about nested quotes being needed to successfully provide content to a pseudo-element.

<img width="856" alt="Screenshot 2023-01-13 at 10 46 13" src="https://user-images.githubusercontent.com/2070479/212289339-647deafd-cec6-4514-9db0-45c8afa4d8f4.png">
