### PR TITLE
feat: implement "unstable_keepOriginalCode" for extraction plugin

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-1c5a4879-b2c1-43e5-af5e-7cca09556b45.json
+++ b/change/@griffel-webpack-extraction-plugin-1c5a4879-b2c1-43e5-af5e-7cca09556b45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: implement \"unstable_keepOriginalCode\" for extraction plugin",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/code.ts
@@ -1,0 +1,17 @@
+import { __resetStyles, __styles } from '@griffel/react';
+
+export const useClasses = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+
+export const useClassName = __resetStyles('rjefjbm', 'r7z97ji', [
+  '.rjefjbm{color:red;padding-left:4px;}',
+  '.r7z97ji{color:red;padding-right:4px;}',
+]);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.css
@@ -1,0 +1,12 @@
+/** griffel.css **/
+.rjefjbm {
+  color: red;
+  padding-left: 4px;
+}
+.r7z97ji {
+  color: red;
+  padding-right: 4px;
+}
+.fe3e8s9 {
+  color: red;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.ts
@@ -1,0 +1,17 @@
+import { __resetStyles, __styles } from '@griffel/react';
+export const useClasses = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+export const useClassName = __resetStyles('rjefjbm', 'r7z97ji', [
+  '.rjefjbm{color:red;padding-left:4px;}',
+  '.r7z97ji{color:red;padding-right:4px;}',
+]);
+
+require('./code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts');

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -7,9 +7,11 @@ import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
 import { GriffelCSSExtractionPlugin } from './GriffelCSSExtractionPlugin';
+import { WebpackLoaderOptions } from './webpackLoader';
 
 type CompileOptions = {
   cssFilename?: string;
+  loaderOptions?: WebpackLoaderOptions;
   webpackConfig?: webpack.Configuration;
 };
 
@@ -47,6 +49,7 @@ async function compileSourceWithWebpack(
           include: path.dirname(entryPath),
           use: {
             loader: GriffelCSSExtractionPlugin.loader,
+            options: options.loaderOptions,
           },
         },
         {
@@ -241,5 +244,5 @@ describe('webpackLoader', () => {
   testFixture('with-chunks');
 
   // Unstable
-  testFixture('unstable-keep-original-code');
+  testFixture('unstable-keep-original-code', { loaderOptions: { unstable_keepOriginalCode: true } });
 });

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -239,4 +239,7 @@ describe('webpackLoader', () => {
 
   // Chunks
   testFixture('with-chunks');
+
+  // Unstable
+  testFixture('unstable-keep-original-code');
 });

--- a/packages/webpack-extraction-plugin/src/transformSync.ts
+++ b/packages/webpack-extraction-plugin/src/transformSync.ts
@@ -8,6 +8,8 @@ export type TransformOptions = {
 
   inputSourceMap: Babel.TransformOptions['inputSourceMap'];
   enableSourceMaps: boolean;
+
+  unstable_keepOriginalCode?: boolean;
 };
 
 export type TransformResult = {
@@ -38,7 +40,7 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
     // Ignore all user's configs and apply only our plugin
     babelrc: false,
     configFile: false,
-    plugins: [babelPluginStripGriffelRuntime],
+    plugins: [[babelPluginStripGriffelRuntime, { unstable_keepOriginalCode: options.unstable_keepOriginalCode }]],
 
     filename: options.filename,
 

--- a/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
@@ -5,7 +5,10 @@ import * as prettier from 'prettier';
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
+import type { WebpackLoaderOptions } from './webpackLoader';
+
 type CompileOptions = {
+  loaderOptions?: WebpackLoaderOptions;
   webpackConfig?: webpack.Configuration;
 };
 
@@ -36,6 +39,7 @@ async function compileSourceWithWebpack(entryPath: string, options: CompileOptio
           include: path.dirname(entryPath),
           use: {
             loader: path.resolve(__dirname, './webpackLoader.ts'),
+            options: options.loaderOptions,
           },
         },
         {
@@ -193,4 +197,7 @@ describe('webpackLoader', () => {
 
   // Ensures that a file without __styles calls remains unprocessed
   testFixture('missing-calls');
+
+  // Unstable
+  testFixture('unstable-keep-original-code', { loaderOptions: { unstable_keepOriginalCode: true } });
 });

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -4,7 +4,12 @@ import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
 
-type WebpackLoaderOptions = never;
+export type WebpackLoaderOptions = {
+  /**
+   * Please never use this feature, it will be removed without further notice.
+   */
+  unstable_keepOriginalCode?: boolean;
+};
 
 type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLoaderOptions>>;
 
@@ -46,6 +51,8 @@ function webpackLoader(
     return;
   }
 
+  const { unstable_keepOriginalCode } = this.getOptions();
+
   let result: TransformResult | null = null;
   let error: Error | null = null;
 
@@ -55,6 +62,8 @@ function webpackLoader(
 
       enableSourceMaps: this.sourceMap || false,
       inputSourceMap: parseSourceMap(inputSourceMap),
+
+      unstable_keepOriginalCode,
     });
   } catch (err) {
     error = err as Error;


### PR DESCRIPTION
This PR adds `unstable_keepOriginalCode` to Webpack loader options in `@griffel/webpack-extraction-plugin`.

⚠️ **Please never use this option, it will be remove without further notice.**