### PR TITLE
docs: add @griffel/hook-naming ESLint rule to README

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -28,6 +28,7 @@ This plugin exports recommended configuration that enforce good practices, but y
 {
   "plugins": ["@griffel"],
   "rules": {
+    "@griffel/hook-naming": "error",
     "@griffel/no-shorthands": "warn"
   }
 }
@@ -39,6 +40,7 @@ You can find more info about enabled rules in the [Supported Rules section](#sup
 
 **Key**: 🔧 = fixable
 
-| Name                                                     | Description                    | 🔧  |
-| -------------------------------------------------------- | ------------------------------ | --- |
-| [`@griffel/no-shorthands`](./src/rules/no-shorthands.md) | Enforce usage of CSS longhands |     |
+| Name                                                     | Description                                                                | 🔧  |
+| -------------------------------------------------------- | -------------------------------------------------------------------------- | --- |
+| [`@griffel/hook-naming`](./src/rules/hook-naming.md)     | Ensure that hooks returned by the `makeStyles()` function start with "use" |     |
+| [`@griffel/no-shorthands`](./src/rules/no-shorthands.md) | Enforce usage of CSS longhands                                             |     |


### PR DESCRIPTION
Follow up for #282 (noticed that the rules was not added to README).