### PR TITLE
fix: avoid conflicts with SplitChunksPlugin

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-9ff1e7df-41e1-40ee-bc7e-6568075d0e22.json
+++ b/change/@griffel-webpack-extraction-plugin-9ff1e7df-41e1-40ee-bc7e-6568075d0e22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid conflicts with SplitChunksPlugin",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/chunkA.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/chunkA.ts
@@ -1,0 +1,10 @@
+import { __styles } from '@griffel/react';
+
+export default __styles(
+  {
+    root: { sj55zd: 'fe3e8s9' },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/chunkB.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/chunkB.ts
@@ -1,0 +1,10 @@
+import { __styles } from '@griffel/react';
+
+export default __styles(
+  {
+    root: { sj55zd: 'fe3e8s9' },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/code.ts
@@ -1,0 +1,19 @@
+import { __styles } from '@griffel/react';
+
+export const styles = __styles(
+  {
+    root: {
+      Bi91k9c: 'faf35ka',
+    },
+  },
+  {
+    d: ['.fcnqdeg{background-color:green;}'],
+  },
+);
+
+export async function loadStyles() {
+  const stylesA = await import('./chunkA');
+  const stylesB = await import('./chunkB');
+
+  return [stylesA, stylesB];
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.css", "split.bundle.js"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/output.css
@@ -1,0 +1,7 @@
+/** griffel.css **/
+.fcnqdeg {
+  background-color: green;
+}
+.fe3e8s9 {
+  color: red;
+}

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -235,6 +235,24 @@ describe('webpackLoader', () => {
   // Custom filenames in mini-css-extract-plugin
   testFixture('config-name', { cssFilename: '[name].[contenthash].css' });
 
+  // Config that forces chunk splitting
+  testFixture('config-split-chunks', {
+    webpackConfig: {
+      optimization: {
+        splitChunks: {
+          cacheGroups: {
+            styles: {
+              enforce: true,
+              name: 'split',
+              test: /chunk[A|B]/,
+              chunks: 'all',
+            },
+          },
+        },
+      },
+    },
+  });
+
   // "pathinfo" adds comments with paths to output
   testFixture('basic-rules', { webpackConfig: { output: { pathinfo: true } } });
 

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -124,11 +124,15 @@ export class GriffelCSSExtractionPlugin {
         attachGriffelChunkToMainEntryPoint(compilation, griffelChunk);
       });
 
+      // Adds dummy module here to try make sure that other module
+      // optimization steps won't conflict
       compilation.hooks.afterOptimizeModules.tap(PLUGIN_NAME, () => {
         compilation.modules.add(dummyModule);
         compilation.chunkGraph.connectChunkAndModule(griffelChunk, dummyModule);
       });
 
+      // Remove dummy module once we are sure chunk optimization steps
+      // have finished. i.e. won't conflict with SplitChunksPlugin
       compilation.hooks.afterOptimizeChunks.tap(PLUGIN_NAME, chunks => {
         moveCSSModulesToGriffelChunk(compilation, chunks, griffelChunk);
 

--- a/packages/webpack-extraction-plugin/src/GriffelDummyModule.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelDummyModule.ts
@@ -1,0 +1,28 @@
+import { Module } from 'webpack';
+
+const TYPES = new Set(['unknown']);
+
+export class GriffelDummyModule extends Module {
+  readonly #identifier: string;
+
+  constructor() {
+    super('unknown', undefined);
+
+    this.#identifier = 'griffel-dummy-module';
+
+    this.buildInfo = {};
+    this.buildMeta = {};
+  }
+
+  override identifier() {
+    return this.#identifier;
+  }
+
+  override getSourceTypes() {
+    return TYPES;
+  }
+
+  override size() {
+    return 0;
+  }
+}


### PR DESCRIPTION
This PR fixes compatibility between our plugin and [`SplitChunksPlugin`](https://webpack.js.org/plugins/split-chunks-plugin/).

### What happened?

To process generated CSS `GriffelExtractionPlugin` required to have all CSS under `griffel` chunk. Before this PR `SplitChunksPlugin` could move out CSS from `griffel` chunk and leave unprocessed CSS.

```mermaid
graph TD
    A[GriffelExtractionPlugin] -->|Moves generated CSS to `griffel` chunk| B[SplitChunksPlugin]
    B -->|Moves out CSS from `griffel` chunk| C[GriffelExtractionPlugin fails to process all generated CSS]
```