### PR TITLE
chore: cleanup workflows

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -9,33 +9,24 @@ jobs:
   bundle-size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@v3
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version: '18'
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: |
-            yarn-cache-folder-
 
       - run: yarn install --immutable
 
+      #
       # Steps for PRs
+      #
+
       - name: Measure affected packages
         if: ${{ github.event_name == 'pull_request' }}
         run: yarn nx affected --target=bundle-size --parallel --max-parallel=2
@@ -58,7 +49,10 @@ jobs:
             monosize.md
             pr.txt
 
+      #
       # Steps for "main" branch
+      #
+
       - name: Measure all packages
         if: ${{ github.event_name != 'pull_request' }}
         run: yarn nx run-many --all --target=bundle-size --parallel --max-parallel=2

--- a/.github/workflows/ci-change.yml
+++ b/.github/workflows/ci-change.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,70 +8,22 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout [main]
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v2
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
+          cache: 'yarn'
           node-version: '16'
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: |
-            yarn-cache-folder-
 
       - run: yarn install --immutable
       - run: yarn check-dependencies
-      - run: yarn nx affected --target=lint --parallel --max-parallel=3
-      - run: yarn nx affected --target=type-check --parallel --max-parallel=3
-      - run: yarn nx affected --target=build --parallel --max-parallel=3
-      - run: yarn nx affected --target=test --parallel --max-parallel=2
 
-  pr:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '16'
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: |
-            yarn-cache-folder-
-
-      - run: yarn install --immutable
-      - run: yarn check-dependencies
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=type-check --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
 name: GitHub Pages
-
 on:
   push:
     branches:
@@ -14,27 +13,12 @@ jobs:
     if: ${{ contains(github.event.head_commit.message, 'applying package updates') || github.event_name == 'workflow_dispatch' }}
 
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout [main]
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
+          cache: 'yarn'
           node-version: '16'
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: |
-            yarn-cache-folder-
 
       - run: yarn install --immutable
       - run: yarn nx run-many --target=build --projects=@griffel/website --parallel --max-parallel=3

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -17,8 +17,7 @@ jobs:
       status: ${{ steps.verify-extension-changed.outputs.any_changed }}
 
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout [main]
+      - uses: actions/checkout@v3
 
       - name: Verify extension has changed
         uses: tj-actions/changed-files@v23.1
@@ -33,25 +32,12 @@ jobs:
     if: ${{ needs.check.outputs.status == 'true' || github.event_name == 'workflow_dispatch' }}
 
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout [main]
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
+          cache: 'yarn'
           node-version: '16'
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: |
-            yarn-cache-folder-
 
       - run: yarn install --immutable
       - run: yarn nx run-many --target=build --projects=@griffel/devtools --parallel --max-parallel=3


### PR DESCRIPTION
- Actions have been bumped to latest versions
- Now cache for `yarn` is used from `actions/setup-node`
- `.github/workflows/ci.yml` have been simplified as we were running the same steps for `main` & PRs