### PR TITLE
chore: run tests for extraction plugin in production mode

### DIFF
--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/fs.json
@@ -1,1 +1,1 @@
-["bundle.js", "griffel.3f25ad2d330c015ca6fa.css"]
+["bundle.js", "griffel.6a29fbe5fff1646cc55d.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-name/output.css
@@ -1,4 +1,4 @@
-/** griffel.3f25ad2d330c015ca6fa.css **/
+/** griffel.6a29fbe5fff1646cc55d.css **/
 .fe3e8s9 {
   color: red;
 }

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/config-split-chunks/fs.json
@@ -1,1 +1,1 @@
-["bundle.js", "griffel.css", "split.bundle.js"]
+["bundle.js", "griffel.css", "split.js"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks/fs.json
@@ -1,1 +1,1 @@
-["bundle.js", "chunkA.bundle.js", "chunkA.css", "chunkB.bundle.js", "chunkB.css", "griffel.css"]
+["bundle.js", "chunkA.css", "chunkA.js", "chunkB.css", "chunkB.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/fs.json
@@ -1,1 +1,1 @@
-["bundle.js", "griffel.css", "main.css"]
+["bundle.css", "bundle.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-css/output.css
@@ -1,11 +1,12 @@
-/** griffel.css **/
-.fe3e8s9 {
-  color: red;
-}
-/** main.css **/
+/** bundle.css **/
 .foo {
   color: red;
 }
 .bar {
   color: yellow;
+}
+
+/** griffel.css **/
+.fe3e8s9 {
+  color: red;
 }

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -28,13 +28,16 @@ async function compileSourceWithWebpack(
 }> {
   const defaultConfig: webpack.Configuration = {
     context: __dirname,
-    entry: entryPath,
+    entry: {
+      bundle: entryPath,
+    },
 
-    mode: 'development',
+    mode: 'production',
+    devtool: false,
 
     output: {
       path: path.resolve(__dirname),
-      filename: 'bundle.js',
+      filename: '[name].js',
       pathinfo: false,
       assetModuleFilename: '[name][ext]',
     },
@@ -69,6 +72,9 @@ async function compileSourceWithWebpack(
       }),
     ],
 
+    optimization: {
+      minimizer: [],
+    },
     resolve: {
       extensions: ['.js', '.ts'],
     },


### PR DESCRIPTION
This PR forces to run tests for extraction plugin in production mode, so Webpack will run its optimizations like module concatenation, empty chunks removal, etc. Minimizer are turned off to keep code readable.