### PR TITLE
fix: handling modules with SplitChunksPlugin

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-44513a3a-1173-4378-9fa4-f581f56dd195.json
+++ b/change/@griffel-webpack-extraction-plugin-44513a3a-1173-4378-9fa4-f581f56dd195.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handling modules with SplitChunksPlugin",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
This fixes a real issue in the product, however I am struggling to write a test for this scenario.

### How it works without `@griffel/webpack-extraction-plugin`?

All modules will be processed by `SplitChunks` as expected and moved to proper chunks ✅

```mermaid
graph LR
    M1[moduleA.js] --> S{SplitChunks}
    M2[moduleB.js] --> S
    M3[moduleC.js] --> S
    S --> C1[Chunk 1]
    S --> C2[Chunk 2]
```

### How it's expected to work with `@griffel/webpack-extraction-plugin`?

The expectation is that chunks will remain the same ("Chunk A" & "Chunk B") and it will be like that:

```mermaid
graph LR
    M1[moduleA.js] --> S{SplitChunksPlugin}
    M2[moduleB.js] --> S
    M3[moduleC.js] --> S
    MC1[moduleA.griffel.css] --> S
    MC2[moduleB.griffel.css] --> S
    MC3[moduleC.griffel.css] --> S
    S --> C1[Chunk 1]
    S --> C2[Chunk 2]
    C1 --> GP{GriffelPlugin}
    C2 --> GP
    GP ---> CC[Griffel Chunk]
    GP ---> CA1[Chunk 1]
    GP ---> CA2[Chunk 2]
```

**However**, the reality is different 💣 `module*.griffel.css` are still Webpack modules and will be part of computations in `SplitChunksPlugin`, so that happens in reality:

```mermaid
graph LR
    M1[moduleA.js] --> S{SplitChunksPlugin}
    M2[moduleB.js] --> S
    M3[moduleC.js] --> S
    MC1[moduleA.griffel.css] --> S
    MC2[moduleB.griffel.css] --> S
    MC3[moduleC.griffel.css] --> S
    S --> C1[Chunk 1]
    S --> C2[Chunk 2]
    S --> C3["Chunk 3 (contains modules from 1)"]
    S --> CD["Chunk 4 (contains modules from 2)"]
    C1 --> GP{GriffelPlugin}
    C2 --> GP
    C3 --> GP
    CD --> GP
    GP ---> CC[Griffel Chunk]
    GP ---> CA1[Chunk 1]
    GP ---> CA2[Chunk 2]
    GP ---> CA3[Chunk 3]
    GP ---> CA4[Chunk 4]
```

Because of CSS modules that we emit, bundling results become completely different, which is not acceptable 💥

### What this PR changes?

This PR moves extraction plugin before `SplitChunks` to ensure that our modules will not affect its results.

```mermaid
graph LR
    M1[moduleA.js] --> GP{GriffelPlugin}
    M2[moduleB.js] --> GP
    M3[moduleC.js] --> GP
    MC1[moduleA.griffel.css] --> GP
    MC2[moduleB.griffel.css] --> GP
    MC3[moduleC.griffel.css] --> GP
    GP --> C(Other chunks)
    GP --> GC1[Griffel Chunk]
    C --> S{SplitChunksPlugin}
    GC1 --> S
    S --> C1[Chunk 1]
    S --> C2[Chunk 2]
    S --> GC2[Griffel Chunk]
```

However, this would create the problem described in #326 as `SplitChunksPlugin` can have a config that moves modules to a specific chunk, for example:

```js
module.exports = {
  optimization: {
    splitChunks: {
      cacheGroups: {
        fluent: {
          name: "fluent",
          test: /@fluentui/,
          chunks: "all"
        }
      }
    }
  }
};
```

To prevent this, we move modules again if `optimization.splitChunks.cacheGroups` are present:

```mermaid
graph LR
    M1[moduleA.js] --> GP{GriffelPlugin}
    M2[moduleB.js] --> GP
    M3[moduleC.js] --> GP
    MC1[moduleA.griffel.css] --> GP
    MC2[moduleB.griffel.css] --> GP
    MC3[moduleC.griffel.css] --> GP
    GP --> C(Other chunks)
    GP --> GC1[Griffel Chunk]
    C --> S{SplitChunksPlugin}
    GC1 --> S
    S --> C1[Chunk 1]
    S --> C2["Chunk 2 (contains .griffel.css)"]
    S --> GC2[Griffel Chunk]
    C1 --> GP2{GriffelPlugin}
    C2 --> GP2
    GC2 --> GP2
    GP2 ---> C11[Chunk 1]
    GP2 ---> C12[Chunk 2]
    GP2 ---> CC[Griffel Chunk]
```
