### PR TITLE
refactor: update how griffel chunk is attached

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-327c83f1-4269-4852-a1be-2a21887e293e.json
+++ b/change/@griffel-webpack-extraction-plugin-327c83f1-4269-4852-a1be-2a21887e293e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor: update how griffel chunk is attached",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/code.ts
@@ -1,0 +1,12 @@
+import { __styles } from '@griffel/react';
+
+export const useClasses = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/codeB.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/codeB.ts
@@ -1,0 +1,12 @@
+import { __styles } from '@griffel/react';
+
+export const useClasses = __styles(
+  {
+    root: {
+      Bi91k9c: 'faf35ka',
+    },
+  },
+  {
+    h: ['.faf35ka:hover{color:red;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "bundleB.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/output.css
@@ -1,0 +1,7 @@
+/** griffel.css **/
+.fe3e8s9 {
+  color: red;
+}
+.faf35ka:hover {
+  color: red;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/output.ts
@@ -1,0 +1,13 @@
+import { __styles } from '@griffel/react';
+export const useClasses = __styles(
+  {
+    root: {
+      sj55zd: 'fe3e8s9',
+    },
+  },
+  {
+    d: ['.fe3e8s9{color:red;}'],
+  },
+);
+
+require('./code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts');

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -6,12 +6,13 @@ import * as prettier from 'prettier';
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import { GriffelCSSExtractionPlugin } from './GriffelCSSExtractionPlugin';
+import { GriffelCSSExtractionPlugin, GriffelCSSExtractionPluginOptions } from './GriffelCSSExtractionPlugin';
 import { WebpackLoaderOptions } from './webpackLoader';
 
 type CompileOptions = {
   cssFilename?: string;
   loaderOptions?: WebpackLoaderOptions;
+  pluginOptions?: GriffelCSSExtractionPluginOptions;
   webpackConfig?: webpack.Configuration;
 };
 
@@ -269,5 +270,13 @@ describe('webpackLoader', () => {
   testFixture('with-chunks');
 
   // Unstable
+  testFixture('unstable-attach-to-main', {
+    pluginOptions: { unstable_attachToMainEntryPoint: true },
+    webpackConfig: {
+      entry: {
+        bundleB: path.resolve(__dirname, '..', '__fixtures__', 'webpack', 'unstable-attach-to-main', 'codeB.ts'),
+      },
+    },
+  });
   testFixture('unstable-keep-original-code', { loaderOptions: { unstable_keepOriginalCode: true } });
 });


### PR DESCRIPTION
Fixes #314.

This PR updates how `@griffel/webpack-extraction-plugin` will attach `griffel` chunk. The current way is updated to be under `unstable_attachToMainEntryPoint` option as still required by one of our partners. However, the plugin itself defaults into the behavior of `SplitChunksPlugin` as it does the same job.

> Note: `unstable_attachToMainEntryPoint` will be removed without a further notice, do not rely on it.