### PR TITLE
feat: add "insertionPoint" option to createDOMRenderer()

### DIFF
--- a/apps/website/docs/react/api/create-dom-renderer.md
+++ b/apps/website/docs/react/api/create-dom-renderer.md
@@ -22,6 +22,30 @@ function App(props) {
 }
 ```
 
+### insertionPoint
+
+If specified, a renderer will insert created style tags after this element:
+
+```js
+import { createDOMRenderer } from '@griffel/react';
+
+const insertionPoint = document.head.querySelector('#foo');
+const renderer = createDOMRenderer(document, {
+  insertionPoint,
+});
+```
+
+```html
+<html>
+  <head>
+    <style id="foo" />
+    <!-- Style elements created by Griffel will be inserted after "#foo" element -->
+    <style data-make-styles-bucket="d" />
+    <style id="bar" />
+  </head>
+</html>
+```
+
 ### styleElementAttributes
 
 A map of attributes that's passed to the generated style elements. For example, is useful to set ["nonce" attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce).
@@ -29,7 +53,7 @@ A map of attributes that's passed to the generated style elements. For example, 
 ```js
 import { createDOMRenderer } from '@griffel/react';
 
-const renderer = createDOMRenderer(targetDocument, {
+const renderer = createDOMRenderer(document, {
   styleElementAttributes: {
     nonce: 'random',
   },

--- a/change/@griffel-core-78fefbae-6966-49fb-b7cb-7f29a5dd05c7.json
+++ b/change/@griffel-core-78fefbae-6966-49fb-b7cb-7f29a5dd05c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add \"insertionPoint\" option to createDOMRenderer()",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/renderer/createDOMRenderer.test.ts
+++ b/packages/core/src/renderer/createDOMRenderer.test.ts
@@ -99,6 +99,7 @@ describe('createDOMRenderer', () => {
     // CSS rules are redundant for this test, but they are necessary as they trigger style nodes creation
     const cssRules: CSSRulesByBucket = {
       d: ['.foo { color: red; }'],
+      h: ['.foo:hover { color: blue; }'],
     };
 
     renderer.insertCSSRules(cssRules);
@@ -110,6 +111,9 @@ describe('createDOMRenderer', () => {
         />,
         <style
           data-make-styles-bucket="d"
+        />,
+        <style
+          data-make-styles-bucket="h"
         />,
         <style
           data-test="B"

--- a/packages/core/src/renderer/createDOMRenderer.test.ts
+++ b/packages/core/src/renderer/createDOMRenderer.test.ts
@@ -81,4 +81,40 @@ describe('createDOMRenderer', () => {
       ]
     `);
   });
+
+  it('handles "insertionPoint"', () => {
+    const elementA = document.createElement('style');
+    const elementB = document.createElement('style');
+
+    elementA.setAttribute('data-test', 'A');
+    elementB.setAttribute('data-test', 'B');
+
+    document.head.appendChild(elementA);
+    document.head.appendChild(elementB);
+
+    const renderer = createDOMRenderer(document, {
+      insertionPoint: elementA,
+    });
+
+    // CSS rules are redundant for this test, but they are necessary as they trigger style nodes creation
+    const cssRules: CSSRulesByBucket = {
+      d: ['.foo { color: red; }'],
+    };
+
+    renderer.insertCSSRules(cssRules);
+
+    expect(document.head.children).toMatchInlineSnapshot(`
+      HTMLCollection [
+        <style
+          data-test="A"
+        />,
+        <style
+          data-make-styles-bucket="d"
+        />,
+        <style
+          data-test="B"
+        />,
+      ]
+    `);
+  });
 });

--- a/packages/core/src/renderer/getStyleSheetForBucket.test.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.test.ts
@@ -10,6 +10,33 @@ function createFakeDocument(): Document {
 }
 
 describe('getStyleSheetForBucket', () => {
+  it('creates elements order', () => {
+    const target = createFakeDocument();
+    const renderer = createDOMRenderer();
+
+    getStyleSheetForBucket('l', target, null, renderer);
+    getStyleSheetForBucket('r', target, null, renderer);
+    getStyleSheetForBucket('a', target, null, renderer);
+    getStyleSheetForBucket('d', target, null, renderer);
+
+    expect(target.head.children).toMatchInlineSnapshot(`
+      HTMLCollection [
+        <style
+          data-make-styles-bucket="r"
+        />,
+        <style
+          data-make-styles-bucket="d"
+        />,
+        <style
+          data-make-styles-bucket="l"
+        />,
+        <style
+          data-make-styles-bucket="a"
+        />,
+      ]
+    `);
+  });
+
   it('sets "data-make-styles-bucket" attribute in order', () => {
     const target = createFakeDocument();
     const renderer = createDOMRenderer();
@@ -122,10 +149,10 @@ describe('getStyleSheetForBucket', () => {
           data-test="B"
         />,
         <style
-          data-make-styles-bucket="d"
+          data-make-styles-bucket="r"
         />,
         <style
-          data-make-styles-bucket="r"
+          data-make-styles-bucket="d"
         />,
         <style
           data-test="C"

--- a/packages/core/src/renderer/getStyleSheetForBucket.test.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.test.ts
@@ -1,6 +1,6 @@
-import { getStyleSheetForBucket, styleBucketOrdering } from './getStyleSheetForBucket';
-import { createDOMRenderer } from './createDOMRenderer';
 import { DATA_BUCKET_ATTR } from '../constants';
+import { createDOMRenderer } from './createDOMRenderer';
+import { getStyleSheetForBucket, styleBucketOrdering } from './getStyleSheetForBucket';
 
 function createFakeDocument(): Document {
   const doc = document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null);
@@ -14,18 +14,18 @@ describe('getStyleSheetForBucket', () => {
     const target = createFakeDocument();
     const renderer = createDOMRenderer();
 
-    getStyleSheetForBucket('r', target, renderer);
-    getStyleSheetForBucket('l', target, renderer);
-    getStyleSheetForBucket('d', target, renderer);
-    getStyleSheetForBucket('v', target, renderer);
-    getStyleSheetForBucket('a', target, renderer);
-    getStyleSheetForBucket('i', target, renderer);
-    getStyleSheetForBucket('h', target, renderer);
-    getStyleSheetForBucket('m', target, renderer);
-    getStyleSheetForBucket('w', target, renderer);
-    getStyleSheetForBucket('t', target, renderer);
-    getStyleSheetForBucket('k', target, renderer);
-    getStyleSheetForBucket('f', target, renderer);
+    getStyleSheetForBucket('r', target, null, renderer);
+    getStyleSheetForBucket('l', target, null, renderer);
+    getStyleSheetForBucket('d', target, null, renderer);
+    getStyleSheetForBucket('v', target, null, renderer);
+    getStyleSheetForBucket('a', target, null, renderer);
+    getStyleSheetForBucket('i', target, null, renderer);
+    getStyleSheetForBucket('h', target, null, renderer);
+    getStyleSheetForBucket('m', target, null, renderer);
+    getStyleSheetForBucket('w', target, null, renderer);
+    getStyleSheetForBucket('t', target, null, renderer);
+    getStyleSheetForBucket('k', target, null, renderer);
+    getStyleSheetForBucket('f', target, null, renderer);
 
     const styleElements = target.head.querySelectorAll(`[${DATA_BUCKET_ATTR}]`);
     const styleElementOrder = Array.from(styleElements).map(styleElement =>
@@ -43,27 +43,27 @@ describe('getStyleSheetForBucket', () => {
       },
     });
 
-    getStyleSheetForBucket('l', target, renderer);
-    getStyleSheetForBucket('d', target, renderer);
-    getStyleSheetForBucket('v', target, renderer);
+    getStyleSheetForBucket('l', target, null, renderer);
+    getStyleSheetForBucket('d', target, null, renderer);
+    getStyleSheetForBucket('v', target, null, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 3px)' });
+    getStyleSheetForBucket('m', target, null, renderer, { m: '(max-width: 3px)' });
 
-    getStyleSheetForBucket('a', target, renderer);
-    getStyleSheetForBucket('i', target, renderer);
+    getStyleSheetForBucket('a', target, null, renderer);
+    getStyleSheetForBucket('i', target, null, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 1px)' });
+    getStyleSheetForBucket('m', target, null, renderer, { m: '(max-width: 1px)' });
 
-    getStyleSheetForBucket('h', target, renderer);
+    getStyleSheetForBucket('h', target, null, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 4px)' });
+    getStyleSheetForBucket('m', target, null, renderer, { m: '(max-width: 4px)' });
 
-    getStyleSheetForBucket('w', target, renderer);
-    getStyleSheetForBucket('t', target, renderer);
-    getStyleSheetForBucket('k', target, renderer);
-    getStyleSheetForBucket('f', target, renderer);
+    getStyleSheetForBucket('w', target, null, renderer);
+    getStyleSheetForBucket('t', target, null, renderer);
+    getStyleSheetForBucket('k', target, null, renderer);
+    getStyleSheetForBucket('f', target, null, renderer);
 
-    getStyleSheetForBucket('m', target, renderer, { m: '(max-width: 2px)' });
+    getStyleSheetForBucket('m', target, null, renderer, { m: '(max-width: 2px)' });
 
     const styleElements = target.head.querySelectorAll(`[${DATA_BUCKET_ATTR}]`);
     const styleElementOrder = Array.from(styleElements).map(styleElement =>
@@ -92,5 +92,45 @@ describe('getStyleSheetForBucket', () => {
       .map(styleElement => styleElement.getAttribute('media'))
       .filter(Boolean);
     expect(actualMediaQueryOrder).toEqual(mediaQueryOrder);
+  });
+
+  it('handles "insertionPoint"', () => {
+    const target = createFakeDocument();
+    const renderer = createDOMRenderer();
+
+    const elementA = target.createElement('style');
+    const elementB = target.createElement('style');
+    const elementC = target.createElement('style');
+
+    elementA.setAttribute('data-test', 'A');
+    elementB.setAttribute('data-test', 'B');
+    elementC.setAttribute('data-test', 'C');
+
+    target.head.appendChild(elementA);
+    target.head.appendChild(elementB);
+    target.head.appendChild(elementC);
+
+    getStyleSheetForBucket('r', target, elementB, renderer);
+    getStyleSheetForBucket('d', target, elementB, renderer);
+
+    expect(target.head.children).toMatchInlineSnapshot(`
+      HTMLCollection [
+        <style
+          data-test="A"
+        />,
+        <style
+          data-test="B"
+        />,
+        <style
+          data-make-styles-bucket="d"
+        />,
+        <style
+          data-make-styles-bucket="r"
+        />,
+        <style
+          data-test="C"
+        />,
+      ]
+    `);
   });
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,6 +15,7 @@ A package with wrappers and APIs to be used with React.js.
 - [`makeStaticStyles()`](#makestaticstyles)
 - [`makeResetStyles()`](#makeresetstyles)
 - [`createDOMRenderer()`, `RendererProvider`](#createdomrenderer-rendererprovider)
+  - [insertionPoint](#insertionpoint)
   - [styleElementAttributes](#styleelementattributes)
 - [`TextDirectionProvider`](#textdirectionprovider)
 - [Shorthands](#shorthands)
@@ -375,6 +376,30 @@ function App(props) {
 }
 ```
 
+### insertionPoint
+
+If specified, a renderer will insert created style tags after this element:
+
+```js
+import { createDOMRenderer } from '@griffel/react';
+
+const insertionPoint = document.head.querySelector('#foo');
+const renderer = createDOMRenderer(document, {
+  insertionPoint,
+});
+```
+
+```html
+<html>
+  <head>
+    <style id="foo" />
+    <!-- Style elements created by Griffel will be inserted after "#foo" element -->
+    <style data-make-styles-bucket="d" />
+    <style id="bar" />
+  </head>
+</html>
+```
+
 ### styleElementAttributes
 
 A map of attributes that's passed to the generated style elements. For example, is useful to set ["nonce" attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce).
@@ -382,7 +407,7 @@ A map of attributes that's passed to the generated style elements. For example, 
 ```js
 import { createDOMRenderer } from '@griffel/react';
 
-const renderer = createDOMRenderer(targetDocument, {
+const renderer = createDOMRenderer(document, {
   styleElementAttributes: {
     nonce: 'random',
   },


### PR DESCRIPTION
Fixes #332.

This PR adds `insertionPoint` option. If specified, a renderer will insert created style tags after this element:

```js
import { createDOMRenderer } from '@griffel/react';

const insertionPoint = document.head.querySelector('#foo');
const renderer = createDOMRenderer(document, {
  insertionPoint,
});
```

```html
<html>
  <head>
    <style id="foo" />
    <!-- Style elements created by Griffel will be inserted after "#foo" element -->
    <style data-make-styles-bucket="d" />
    <style id="bar" />
  </head>
</html>
```