### PR TITLE
chore(extraction-plugin): re-implement unstable_keepOriginalCode

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-93419209-40a5-47a0-90bc-1da1031b755a.json
+++ b/change/@griffel-webpack-extraction-plugin-93419209-40a5-47a0-90bc-1da1031b755a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(extraction-plugin): re-implement unstable_keepOriginalCode",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.ts
@@ -1,4 +1,5 @@
 import { __resetStyles, __styles } from '@griffel/react';
+
 export const useClasses = __styles(
   {
     root: {
@@ -9,6 +10,7 @@ export const useClasses = __styles(
     d: ['.fe3e8s9{color:red;}'],
   },
 );
+
 export const useClassName = __resetStyles('rjefjbm', 'r7z97ji', [
   '.rjefjbm{color:red;padding-left:4px;}',
   '.r7z97ji{color:red;padding-right:4px;}',

--- a/packages/webpack-extraction-plugin/src/transformSync.ts
+++ b/packages/webpack-extraction-plugin/src/transformSync.ts
@@ -8,8 +8,6 @@ export type TransformOptions = {
 
   inputSourceMap: Babel.TransformOptions['inputSourceMap'];
   enableSourceMaps: boolean;
-
-  unstable_keepOriginalCode?: boolean;
 };
 
 export type TransformResult = {
@@ -40,7 +38,7 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
     // Ignore all user's configs and apply only our plugin
     babelrc: false,
     configFile: false,
-    plugins: [[babelPluginStripGriffelRuntime, { unstable_keepOriginalCode: options.unstable_keepOriginalCode }]],
+    plugins: [babelPluginStripGriffelRuntime],
 
     filename: options.filename,
 

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -62,14 +62,15 @@ function webpackLoader(
 
       enableSourceMaps: this.sourceMap || false,
       inputSourceMap: parseSourceMap(inputSourceMap),
-
-      unstable_keepOriginalCode,
     });
   } catch (err) {
     error = err as Error;
   }
 
   if (result) {
+    const resultCode = unstable_keepOriginalCode ? sourceCode : result.code;
+    const resultSourceMap = unstable_keepOriginalCode ? inputSourceMap : result.sourceMap;
+
     if (result.cssRulesByBucket) {
       const css = Object.entries(result.cssRulesByBucket).reduce((acc, [cssBucketName, cssBucketRules]) => {
         if (cssBucketName === 'm') {
@@ -109,13 +110,13 @@ function webpackLoader(
         // Heads up!
         // This is probably a bug, but "import" does not work properly there: files from node_modules are processed, but
         // they will not be present in chunks 😳
-        `${result.code}\n\nrequire(${stringifiedRequest});`,
-        result.sourceMap,
+        `${resultCode}\n\nrequire(${stringifiedRequest});`,
+        resultSourceMap,
       );
       return;
     }
 
-    this.callback(null, result.code, result.sourceMap);
+    this.callback(null, resultCode, resultSourceMap);
     return;
   }
 


### PR DESCRIPTION
This PR re-implements `unstable_keepOriginalCode` (#323).

- Reverts changes (#323) in a Babel plugin as they are not needed
- Moves conditions directly to Webpack loader