### PR TITLE
chore(core): hide warnings in Node

### DIFF
--- a/change/@griffel-core-858c3d97-f959-46a8-94a1-4e8300b34885.json
+++ b/change/@griffel-core-858c3d97-f959-46a8-94a1-4e8300b34885.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: hide warnings in Node",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/resolveResetStyleRules.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.ts
@@ -119,9 +119,7 @@ function createStringFromStyles(styles: GriffelResetStyle) {
       }
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      warnAboutUnresolvedRule(property, value);
-    }
+    warnAboutUnresolvedRule(property, value);
   }
 
   return [ltrCSS, rtlCSS];

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -319,9 +319,7 @@ export function resolveStyleRules(
           cssRulesByBucket,
         );
       } else {
-        if (process.env.NODE_ENV !== 'production') {
-          warnAboutUnresolvedRule(property, value);
-        }
+        warnAboutUnresolvedRule(property, value);
       }
     }
   }

--- a/packages/core/src/runtime/warnAboutUnresolvedRule-node.test.ts
+++ b/packages/core/src/runtime/warnAboutUnresolvedRule-node.test.ts
@@ -1,0 +1,18 @@
+/*
+ * @jest-environment node
+ */
+
+import { warnAboutUnresolvedRule } from './warnAboutUnresolvedRule';
+
+describe('warnAboutUnresolvedRule', () => {
+  it('does not warn in Node', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    warnAboutUnresolvedRule('div', {
+      color: 'red',
+      ':hover': { color: 'blue' },
+    });
+
+    expect(spy).not.toBeCalled();
+  });
+});

--- a/packages/core/src/runtime/warnAboutUnresolvedRule.ts
+++ b/packages/core/src/runtime/warnAboutUnresolvedRule.ts
@@ -1,6 +1,10 @@
 import type { GriffelResetStyle, GriffelStyle } from '../types';
 
 export function warnAboutUnresolvedRule(property: string, value: GriffelStyle | GriffelResetStyle) {
+  if (process.env.NODE_ENV === 'production' || typeof document === 'undefined') {
+    return;
+  }
+
   const ruleText = JSON.stringify(value, null, 2);
   const message: string[] = [
     '@griffel/react: A rule was not resolved to CSS properly. ' +


### PR DESCRIPTION
As both runtime and build time tools use the same functionality, we will emit warnings in build time. That was not intentional and confuses users, this PR hides warnings for Node env.