### PR TITLE
Add a rule to enforce makeStyles calls only happen in .styles.ts files

### DIFF
--- a/change/@griffel-eslint-plugin-a3b29662-7937-4c57-8d41-9ce578721b9f.json
+++ b/change/@griffel-eslint-plugin-a3b29662-7937-4c57-8d41-9ce578721b9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added a styles-file rule for enforcing makeStyles call be only made in files that end in .styles.ts",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "1581488+christiango@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import { recommendedConfig } from './configs/recommended';
 import { hookNamingRule } from './rules/hook-naming';
 import { noShorthandsRule } from './rules/no-shorthands';
+import { stylesFileRule } from './rules/styles-file';
 
 export = {
   configs: {
@@ -9,5 +10,6 @@ export = {
   rules: {
     'hook-naming': hookNamingRule,
     'no-shorthands': noShorthandsRule,
+    'styles-file': stylesFileRule,
   },
 };

--- a/packages/eslint-plugin/src/rules/styles-file.md
+++ b/packages/eslint-plugin/src/rules/styles-file.md
@@ -1,0 +1,33 @@
+# Enforce that `makeStyles()` calls are placed in a .styles.ts file (`@griffel/styles files`)
+
+Ensures that all makeStyles calls are placed in a .styles.ts file. The primary motivation for enabling rules is to reduce the overhead of Griffel CSS extraction build tools. With this rule enabled, your repo could be configured so the Griffel babel and webpack build tools only look at .styles.ts and .styles.js files rather than all .ts and .js files.
+
+## Rule Details
+
+`makeStyles()` calls should only exist inside .styles.ts files
+
+Examples of **incorrect** code for this rule:
+
+```js
+// filename: component.tsx
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    backgroundColor: 'red',
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// filename: component.styles.ts
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    backgroundColor: 'red',
+  },
+});
+```

--- a/packages/eslint-plugin/src/rules/styles-file.md
+++ b/packages/eslint-plugin/src/rules/styles-file.md
@@ -1,10 +1,10 @@
 # Enforce that `makeStyles()` calls are placed in a .styles.ts file (`@griffel/styles files`)
 
-Ensures that all makeStyles calls are placed in a .styles.ts file. The primary motivation for enabling rules is to reduce the overhead of Griffel CSS extraction build tools. With this rule enabled, your repo could be configured so the Griffel babel and webpack build tools only look at .styles.ts and .styles.js files rather than all .ts and .js files.
+Ensures that all `makeStyles()` and `makeResetStyles()` calls are placed in a `.styles.js` or `.styles.ts` file. The primary motivation for enabling rules is to reduce the overhead of Griffel CSS extraction build tools. With this rule enabled, your repo could be configured so the Griffel babel and webpack build tools only look at `.styles.ts` and `.styles.js` files rather than all .ts and .js files.
 
 ## Rule Details
 
-`makeStyles()` calls should only exist inside .styles.ts files
+`makeStyles()` calls should only exist inside `.styles.js` or `.styles.ts` files.
 
 Examples of **incorrect** code for this rule:
 

--- a/packages/eslint-plugin/src/rules/styles-file.test.ts
+++ b/packages/eslint-plugin/src/rules/styles-file.test.ts
@@ -1,0 +1,78 @@
+import { TSESLint } from '@typescript-eslint/utils';
+import { stylesFileRule, RULE_NAME } from './styles-file';
+import * as path from 'path';
+
+const componentFileName = 'packages/components/components-foo/foo.tsx';
+const stylesFileName = 'packages/components/components-foo/foo.styles.ts';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: path.resolve('./node_modules/@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+const codeWithFluentNamespaceImport = `
+import * as fluent from '@fluentui/react-components';
+
+export const useStyles = fluent.makeStyles({
+  root: { color: 'blue' },
+});
+`;
+const codeWithMakeStylesImport = `
+import { makeStyles } from '@fluentui/react-components';
+
+export const useStyles = makeStyles({
+  root: { color: 'blue' },
+});
+`;
+
+ruleTester.run(RULE_NAME, stylesFileRule, {
+  valid: [
+    {
+      code: `
+        import { Button } from "@fluentui/react-components";
+        const tag = <Button>test content</Button>;
+      `,
+      filename: componentFileName,
+    },
+    // import and use makeStyles in COMPONENT_NAME.styles.ts is okay
+    {
+      code: codeWithFluentNamespaceImport,
+      filename: stylesFileName,
+    },
+    {
+      code: codeWithMakeStylesImport,
+      filename: stylesFileName,
+    },
+    {
+      code: `
+        import { makeStyles } from '@fluentui/react-components';
+
+        const useStyles = makeStyles({
+          root: { color: 'blue' },
+        });
+        const useStyles1 = makeStyles({
+          root: { color: 'red' },
+        });
+
+        export { useStyles as foo, useStyles1 as bar };
+      `,
+      filename: stylesFileName,
+    },
+  ],
+  invalid: [
+    // Error when import and use makeStyles in component
+    {
+      code: codeWithFluentNamespaceImport,
+      errors: [{ messageId: 'foundMakeStylesUsage' }],
+      filename: componentFileName,
+    },
+    {
+      code: codeWithMakeStylesImport,
+      errors: [{ messageId: 'foundMakeStylesUsage' }],
+      filename: componentFileName,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/styles-file.ts
+++ b/packages/eslint-plugin/src/rules/styles-file.ts
@@ -1,0 +1,129 @@
+import { createRule } from '../utils/createRule';
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+const fluentLibraries = new Set([
+  '@fluentui/react-components',
+  '@fluentui/react-icons',
+  '@fluentui/react-shared-contexts',
+  '@fluentui/react-tabster',
+  '@fluentui/react-conformance',
+  '@fluentui/react-utilities',
+  '@griffel/core',
+  '@griffel/react',
+]);
+
+/**
+ * @param libName name of a library
+ * @returns true if the library is a fluent ui v9 library, or its tmp re-export component
+ */
+function isFluentuiLib(libName: string) {
+  return fluentLibraries.has(libName);
+}
+
+const stylesFilePattern = /^.*\.(styles)\.ts$/;
+
+/**
+ * @param fileName
+ * @returns check if a file name follows v9 styles file name convention
+ */
+function isStylesFile(fileName: string) {
+  return stylesFilePattern.test(fileName);
+}
+
+/**
+ * @param node - import node from AST
+ * @returns true if makeStyles is imported, or if the entire library is imported. Otherwise returns false
+ */
+function isMakeStylesImport(node: TSESTree.ImportDeclaration) {
+  if (
+    isFluentuiLib(node.source.value) &&
+    node.specifiers.filter(specifier => {
+      // import * as ... from
+      if (specifier.type === 'ImportNamespaceSpecifier') {
+        return true;
+      }
+
+      if ('imported' in specifier) {
+        return (
+          specifier.imported.name === 'makeStyles' || // import { makeStyles } from
+          specifier.imported.name === 'makeResetStyles' // import { makeResetStyles } from
+        );
+      }
+
+      return false;
+    }).length > 0
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @param callExpression CallExpression node in AST
+ * @returns if this is a makeStyles call or not
+ */
+function isMakeStyleCallExpression({ callee }: TSESTree.CallExpression) {
+  return (
+    ('name' in callee && callee.name === 'makeStyles') || // makeStyles({})
+    ('property' in callee && 'name' in callee.property && callee.property.name === 'makeStyles') // something.makeStyles({})
+  );
+}
+
+export const RULE_NAME = 'styles-file';
+
+export const stylesFileRule: ReturnType<ReturnType<typeof ESLintUtils.RuleCreator>> = createRule({
+  name: RULE_NAME,
+  meta: {
+    docs: {
+      description: 'Enforce that hooks returned from makeStyles() calls are placed in a .styles.ts file',
+      recommended: 'error',
+    },
+    messages: {
+      foundMakeStylesUsage:
+        'Styles created from `makeStyles` should be defined in a .styles.ts file so they can be extracted into static CSS',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const fileName = context.getFilename();
+
+    let isMakeStylesImported = false;
+
+    const makeStylesDeclarations = []; // contains constants from makeStyles calls: `const useStyles = makeStyles({})`
+
+    return {
+      ImportDeclaration(node) {
+        if (!isMakeStylesImported) {
+          isMakeStylesImported = isMakeStylesImport(node);
+        }
+      },
+      CallExpression(node) {
+        if (isMakeStylesImported && isMakeStyleCallExpression(node)) {
+          if (!isStylesFile(fileName)) {
+            context.report({
+              messageId: 'foundMakeStylesUsage',
+              node,
+            });
+          }
+        }
+      },
+      VariableDeclaration(node) {
+        if (isStylesFile(fileName)) {
+          node.declarations?.forEach(declaration => {
+            if (
+              isMakeStylesImported &&
+              declaration.init?.type === 'CallExpression' &&
+              isMakeStyleCallExpression(declaration.init)
+            ) {
+              if (declaration.id.type === 'Identifier') {
+                makeStylesDeclarations.push(declaration.id.name);
+              }
+            }
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
We've seen issues internally where our webpack bundle times have regressed when integrating the griffel CSS extraction plugins and loaders. We found that having all makeStyles in a .styles.ts file lets us limit the scope of where these plugins and loaders run to just files ending in .styles.ts which dramatically improved performance of our bundle tasks.

This code was heavily adapted from existing code by Yuanbo Xue in the Microsoft Teams repository. 