### PR TITLE
feat(core): add shorthand for `text-decoration`

### DIFF
--- a/change/@griffel-core-5ba8b312-008d-4c33-92c6-67ba1fa04e57.json
+++ b/change/@griffel-core-5ba8b312-008d-4c33-92c6-67ba1fa04e57.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add shorthand function for `text-decoration`",
+  "packageName": "@griffel/core",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/shorthands/textDecoration.test.ts
+++ b/packages/core/src/shorthands/textDecoration.test.ts
@@ -1,0 +1,43 @@
+import { textDecoration } from './textDecoration';
+
+describe('textDecoration', () => {
+  it('for a given style', () => {
+    expect(textDecoration('double')).toEqual({
+      textDecorationStyle: 'double',
+    });
+  });
+
+  it('for a given line', () => {
+    expect(textDecoration('none')).toEqual({
+      textDecorationLine: 'none',
+    });
+
+    expect(textDecoration('overline underline line-through')).toEqual({
+      textDecorationLine: 'overline underline line-through',
+    });
+  });
+
+  it('for a given line and style', () => {
+    expect(textDecoration('underline', 'double')).toEqual({
+      textDecorationLine: 'underline',
+      textDecorationStyle: 'double',
+    });
+  });
+
+  it('for a given line, style and color', () => {
+    expect(textDecoration('underline', 'double', 'red')).toEqual({
+      textDecorationLine: 'underline',
+      textDecorationStyle: 'double',
+      textDecorationColor: 'red',
+    });
+  });
+
+  it('for a given line, style, color and thickness', () => {
+    expect(textDecoration('underline', 'double', 'red', '2px')).toEqual({
+      textDecorationLine: 'underline',
+      textDecorationStyle: 'double',
+      textDecorationColor: 'red',
+      textDecorationThickness: '2px',
+    });
+  });
+});

--- a/packages/core/src/shorthands/textDecoration.ts
+++ b/packages/core/src/shorthands/textDecoration.ts
@@ -1,0 +1,64 @@
+import type { GriffelStylesStrictCSSObject } from '../types';
+import {
+  TextDecorationColorInput,
+  TextDecorationLineInput,
+  TextDecorationStyleInput,
+  TextDecorationThicknessInput,
+} from './types';
+
+type TextDecorationStyle = Pick<
+  GriffelStylesStrictCSSObject,
+  'textDecorationStyle' | 'textDecorationLine' | 'textDecorationColor' | 'textDecorationThickness'
+>;
+
+export function textDecoration(style: TextDecorationStyleInput): TextDecorationStyle;
+export function textDecoration(line: TextDecorationLineInput): TextDecorationStyle;
+
+export function textDecoration(line: TextDecorationLineInput, style: TextDecorationStyleInput): TextDecorationStyle;
+export function textDecoration(
+  line: TextDecorationLineInput,
+  style: TextDecorationStyleInput,
+  color: TextDecorationColorInput,
+): TextDecorationStyle;
+export function textDecoration(
+  line: TextDecorationLineInput,
+  style: TextDecorationStyleInput,
+  color: TextDecorationColorInput,
+  thickness: TextDecorationThicknessInput,
+): TextDecorationStyle;
+
+/**
+ * A function that implements expansion for "textDecoration" to all sides of an element, it's simplified - check usage examples.
+ *
+ * @example
+ *  textDecoration('none')
+ *  textDecoration('dotted')
+ *  textDecoration('underline', 'dotted')
+ *  textDecoration('underline', 'dotted', 'red')
+ *  textDecoration('underline', 'dotted', 'red', '2px')
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration
+ */
+export function textDecoration(
+  value: TextDecorationLineInput | TextDecorationStyleInput,
+  ...values: [TextDecorationStyleInput?, TextDecorationColorInput?, TextDecorationThicknessInput?]
+): TextDecorationStyle {
+  if (values.length === 0) {
+    return isTextDecorationStyleInput(value) ? { textDecorationStyle: value } : { textDecorationLine: value };
+  } else {
+    const [textDecorationStyle, textDecorationColor, textDecorationThickness] = values;
+    return {
+      textDecorationLine: value,
+      ...(textDecorationStyle && { textDecorationStyle }),
+      ...(textDecorationColor && { textDecorationColor }),
+      ...(textDecorationThickness && { textDecorationThickness }),
+    };
+  }
+}
+
+const textDecorationStyleInputs: TextDecorationStyleInput[] = ['dashed', 'dotted', 'double', 'solid', 'wavy'];
+function isTextDecorationStyleInput(
+  value: TextDecorationLineInput | TextDecorationStyleInput,
+): value is TextDecorationStyleInput {
+  return textDecorationStyleInputs.includes(value as TextDecorationStyleInput);
+}

--- a/packages/core/src/shorthands/types.ts
+++ b/packages/core/src/shorthands/types.ts
@@ -34,3 +34,8 @@ export type TransitionDurationInput = CSS.Property.TransitionDuration;
 export type TransitionDelayInput = CSS.Property.TransitionDelay;
 export type TransitionTimingFunctionInput = CSS.Property.TransitionTimingFunction;
 export type TransitionGlobalInput = CSS.Globals;
+
+export type TextDecorationStyleInput = CSS.Property.TextDecorationStyle;
+export type TextDecorationLineInput = ValueOrArray<CSS.Property.TextDecorationLine>;
+export type TextDecorationColorInput = ValueOrArray<CSS.Property.TextDecorationColor>;
+export type TextDecorationThicknessInput = ValueOrArray<CSS.Property.TextDecorationThickness>;


### PR DESCRIPTION
Fix: #193 