### PR TITLE
feat(webpack-extraction-plugin): add experimental_resetModuleIndexes

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-f133a3fe-d85a-429a-b88e-77633804e494.json
+++ b/change/@griffel-webpack-extraction-plugin-f133a3fe-d85a-429a-b88e-77633804e494.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add experimental_resetModuleIndexes",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/ComponentA.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/ComponentA.ts
@@ -1,0 +1,6 @@
+import { useBarClasses } from './useBarStyles';
+import { useBazClasses } from './useBazStyles';
+
+export function ComponentA() {
+  return [useBazClasses(), useBarClasses()];
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/ComponentB.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/ComponentB.ts
@@ -1,0 +1,6 @@
+import { useBarClasses } from './useBarStyles';
+import { useQuxClasses } from './useQuxStyles';
+
+export function ComponentB() {
+  return [useQuxClasses(), useBarClasses()];
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/chunk1.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/chunk1.ts
@@ -1,0 +1,6 @@
+import { ComponentA } from './ComponentA';
+import { ComponentB } from './ComponentB';
+
+export function App() {
+  return [ComponentA(), ComponentB()];
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/chunk2.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/chunk2.ts
@@ -1,0 +1,6 @@
+import { ComponentB } from './ComponentB';
+import { ComponentA } from './ComponentA';
+
+export function App() {
+  return [ComponentA(), ComponentB()];
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/code.ts
@@ -1,0 +1,6 @@
+export async function lazy() {
+  const styles1 = await import(/* webpackChunkName: "chunk1" */ './chunk1');
+  const styles2 = await import(/* webpackChunkName: "chunk2" */ './chunk2');
+
+  return [styles1, styles2];
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/fs.json
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "chunk1.js", "chunk2.js", "griffel.css"]

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/output.css
@@ -1,0 +1,13 @@
+/** griffel.css **/
+.fe3e8s9 {
+  color: red;
+}
+.fycuoez {
+  padding-left: 4px;
+}
+.f8wuabp {
+  padding-right: 4px;
+}
+.fcnqdeg {
+  background-color: green;
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/useBarStyles.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/useBarStyles.ts
@@ -1,0 +1,8 @@
+import { __styles } from '@griffel/react';
+
+export const useBarClasses = __styles(
+  {
+    root: { sj55zd: 'fe3e8s9' },
+  },
+  { d: ['.fe3e8s9{color:red;}'] },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/useBazStyles.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/useBazStyles.ts
@@ -1,0 +1,12 @@
+import { __styles } from '@griffel/react';
+
+export const useBazClasses = __styles(
+  {
+    root: {
+      uwmqm3: ['fycuoez', 'f8wuabp'],
+    },
+  },
+  {
+    d: ['.fycuoez{padding-left:4px;}', '.f8wuabp{padding-right:4px;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/useQuxStyles.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/with-chunks-order/useQuxStyles.ts
@@ -1,0 +1,12 @@
+import { __styles } from '@griffel/react';
+
+export const useQuxClasses = __styles(
+  {
+    root: {
+      De3pzq: 'fcnqdeg',
+    },
+  },
+  {
+    d: ['.fcnqdeg{background-color:green;}'],
+  },
+);

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -67,7 +67,7 @@ async function compileSourceWithWebpack(
       ],
     },
     plugins: [
-      new GriffelCSSExtractionPlugin(),
+      new GriffelCSSExtractionPlugin(options.pluginOptions),
       new MiniCssExtractPlugin({
         filename: options.cssFilename ?? '[name].css',
       }),
@@ -103,6 +103,11 @@ async function compileSourceWithWebpack(
 
       if (stats.hasErrors()) {
         reject(stats.toJson().errors![0]);
+        return;
+      }
+
+      if (stats.hasWarnings()) {
+        reject(stats.toJson().warnings![0]);
         return;
       }
 
@@ -220,6 +225,7 @@ function testFixture(fixtureName: string, options: CompileOptions = {}) {
 
 describe('webpackLoader', () => {
   // Basic assertions
+  // --------------------
   testFixture('basic-rules');
   testFixture('reset');
   testFixture('reset-media');
@@ -235,9 +241,13 @@ describe('webpackLoader', () => {
   testFixture('style-buckets');
 
   // Assets
+  // --------------------
   testFixture('assets');
   testFixture('assets-multiple');
   testFixture('reset-assets');
+
+  // Config
+  // --------------------
 
   // Custom filenames in mini-css-extract-plugin
   testFixture('config-name', { cssFilename: '[name].[contenthash].css' });
@@ -269,6 +279,9 @@ describe('webpackLoader', () => {
     },
   });
 
+  // Compatibility
+  // --------------------
+
   // "pathinfo" adds comments with paths to output
   testFixture('basic-rules', { webpackConfig: { output: { pathinfo: true } } });
 
@@ -276,9 +289,16 @@ describe('webpackLoader', () => {
   testFixture('with-css');
 
   // Chunks
+  // --------------------
   testFixture('with-chunks');
 
+  // A fixture that creates a different modules order in different chunks groups
+  testFixture('with-chunks-order', {
+    pluginOptions: { experimental_resetModuleIndexes: true },
+  });
+
   // Unstable
+  // --------------------
   testFixture('unstable-attach-to-main', {
     pluginOptions: { unstable_attachToMainEntryPoint: true },
     webpackConfig: {


### PR DESCRIPTION
This PR adds `experimental_resetModuleIndexes` to avoid warnings caused by `mini-css-extract-plugin`:

```
WARNING in chunk griffel [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader/dist/cjs.js!./node_modules/@griffel/webpack-extraction-plugin/virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fm40iov%7Bcolor%3A%23ccc%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./src/foo-module/baz.js
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader/dist/cjs.js!./node_modules/@griffel/webpack-extraction-plugin/virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.f1e30ogq%7Bcolor%3Ablueviolet%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./src/foo-module/qux.js
   - couldn't fulfill desired order of chunk group(s) 
```