### PR TITLE
feat(shadow-dom): introduce a render for Shadow DOM

### DIFF
--- a/change/@griffel-core-17ae40bc-b25b-455e-900b-44ba24998b21.json
+++ b/change/@griffel-core-17ae40bc-b25b-455e-900b-44ba24998b21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: export safeInsertRule()",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-shadow-dom-411ce7d0-962d-400a-8a6d-9c143208fd60.json
+++ b/change/@griffel-shadow-dom-411ce7d0-962d-400a-8a6d-9c143208fd60.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: initial release",
+  "packageName": "@griffel/shadow-dom",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/monosize.config.mjs
+++ b/monosize.config.mjs
@@ -17,6 +17,7 @@ export default {
         ...config.resolve,
         alias: {
           '@griffel/core': path.resolve(dirname, './dist/packages/core/index.esm.js'),
+          '@griffel/shadow-dom': path.resolve(dirname, './dist/packages/shadow-dom/index.esm.js'),
           '@griffel/react': path.resolve(dirname, './dist/packages/react/index.esm.js'),
         },
       },

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "react-dom": "18.2.0",
     "react-fela": "12.2.0",
     "react-refresh": "^0.10.0",
+    "react-shadow": "^20.2.0",
     "react-test-renderer": "18.0.0",
     "simple-git-hooks": "2.7.0",
     "styled-components": "^5.3.6",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export const shorthands = {
 export { createDOMRenderer } from './renderer/createDOMRenderer';
 export type { CreateDOMRendererOptions } from './renderer/createDOMRenderer';
 export { rehydrateRendererCache } from './renderer/rehydrateRendererCache';
+export { safeInsertRule } from './renderer/safeInsertRule';
 
 export { mergeClasses } from './mergeClasses';
 export { makeStyles } from './makeStyles';

--- a/packages/core/src/renderer/safeInsertRule.ts
+++ b/packages/core/src/renderer/safeInsertRule.ts
@@ -1,0 +1,29 @@
+/**
+ * Suffixes to be ignored in case of error
+ */
+const ignoreSuffixes = [
+  '-moz-placeholder',
+  '-moz-focus-inner',
+  '-moz-focusring',
+  '-ms-input-placeholder',
+  '-moz-read-write',
+  '-moz-read-only',
+].join('|');
+const ignoreSuffixesRegex = new RegExp(`:(${ignoreSuffixes})`);
+
+/**
+ * @internal
+ *
+ * Calls `sheet.insertRule` and catches errors related to browser prefixes.
+ */
+export function safeInsertRule(sheet: { insertRule(rule: string): number | undefined }, ruleCSS: string): void {
+  try {
+    sheet.insertRule(ruleCSS);
+  } catch (e) {
+    // We've disabled these warnings due to false-positive errors with browser prefixes
+    if (process.env.NODE_ENV !== 'production' && !ignoreSuffixesRegex.test(ruleCSS)) {
+      // eslint-disable-next-line no-console
+      console.error(`There was a problem inserting the following rule: "${ruleCSS}"`, e);
+    }
+  }
+}

--- a/packages/shadow-dom/.babelrc
+++ b/packages/shadow-dom/.babelrc
@@ -1,0 +1,12 @@
+{
+  "plugins": ["annotate-pure-calls"],
+  "presets": ["@babel/preset-react"],
+  "env": {
+    "development": {
+      "presets": ["@nrwl/react/babel"]
+    },
+    "test": {
+      "presets": ["@nrwl/react/babel"]
+    }
+  }
+}

--- a/packages/shadow-dom/.eslintrc.json
+++ b/packages/shadow-dom/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nrwl/nx/react", "../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/shadow-dom/.storybook/main.js
+++ b/packages/shadow-dom/.storybook/main.js
@@ -1,0 +1,21 @@
+const rootMain = require('../../../.storybook/main');
+
+module.exports = {
+  ...rootMain,
+
+  core: { ...rootMain.core, builder: 'webpack5' },
+
+  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],
+
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};

--- a/packages/shadow-dom/.storybook/tsconfig.json
+++ b/packages/shadow-dom/.storybook/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "emitDecoratorMetadata": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noEmit": true,
+    "outDir": ""
+  },
+  "files": [
+    "../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts",
+    "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": ["../**/*.spec.ts", "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx", "jest.config.ts"],
+  "include": ["../src/**/*", "*.js"]
+}

--- a/packages/shadow-dom/README.md
+++ b/packages/shadow-dom/README.md
@@ -1,0 +1,27 @@
+# Griffel for Shadow DOM
+
+A package with wrappers and APIs to be used with Shadow DOM.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Install](#install)
+- [`createShadowDOMRenderer()`](#createshadowdomrenderer)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Install
+
+```bash
+npm install @griffel/shadow-dom
+# or
+yarn add @griffel/shadow-dom
+```
+
+## `createShadowDOMRenderer()`
+
+```ts
+import { createShadowDOMRenderer } from '@griffel/shadow-dom';
+
+const render = createShadowDOMRenderer(element.shadowRoot);
+```

--- a/packages/shadow-dom/bundle-size/createShadowDOMRenderer.fixture.js
+++ b/packages/shadow-dom/bundle-size/createShadowDOMRenderer.fixture.js
@@ -1,0 +1,7 @@
+import { createShadowDOMRenderer } from '@griffel/shadow-dom';
+
+console.log(createShadowDOMRenderer);
+
+export default {
+  name: 'createShadowDOMRenderer',
+};

--- a/packages/shadow-dom/jest.config.ts
+++ b/packages/shadow-dom/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+  displayName: 'shadow-dom',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/react/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/packages/shadow-dom',
+};

--- a/packages/shadow-dom/package.json
+++ b/packages/shadow-dom/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@griffel/shadow-dom",
+  "version": "0.0.1",
+  "description": "Shadow DOM implementation of Griffel Atomic CSS-in-JS",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/griffel"
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "@griffel/core": "^1.12.1",
+    "tslib": "^2.1.0"
+  }
+}

--- a/packages/shadow-dom/project.json
+++ b/packages/shadow-dom/project.json
@@ -1,0 +1,109 @@
+{
+  "name": "@griffel/shadow-dom",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/shadow-dom/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nrwl/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "outputPath": "dist/packages/shadow-dom",
+        "tsConfig": "packages/shadow-dom/tsconfig.lib.json",
+        "project": "packages/shadow-dom/package.json",
+        "entryFile": "packages/shadow-dom/src/index.ts",
+        "compiler": "babel",
+        "rollupConfig": ["@nrwl/react/plugins/bundle-rollup", "tools/getRollupOptions.js"],
+        "updateBuildableProjectDepsInPackageJson": false,
+        "external": ["tslib"],
+        "format": ["esm", "cjs"],
+        "skipTypeField": true,
+        "assets": [
+          {
+            "glob": "packages/shadow-dom/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "LICENSE.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/shadow-dom/**/*.{ts,tsx,js,jsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/packages/shadow-dom"],
+      "options": {
+        "jestConfig": "packages/shadow-dom/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "bundle-size": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": "self"
+        }
+      ],
+      "options": {
+        "cwd": "packages/shadow-dom",
+        "commands": [
+          {
+            "command": "monosize measure"
+          }
+        ]
+      }
+    },
+    "storybook": {
+      "executor": "@nrwl/storybook:storybook",
+      "options": {
+        "uiFramework": "@storybook/react",
+        "port": 4400,
+        "config": {
+          "configFolder": "packages/shadow-dom/.storybook"
+        }
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    },
+    "build-storybook": {
+      "executor": "@nrwl/storybook:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "uiFramework": "@storybook/react",
+        "outputPath": "dist/storybook/@griffel/shadow-dom",
+        "config": {
+          "configFolder": "packages/shadow-dom/.storybook"
+        }
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/shadow-dom",
+        "commands": [{ "command": "tsc -b --pretty" }],
+        "outputPath": []
+      }
+    }
+  }
+}

--- a/packages/shadow-dom/src/createFallbackRenderer.ts
+++ b/packages/shadow-dom/src/createFallbackRenderer.ts
@@ -1,0 +1,14 @@
+import { createDOMRenderer } from '@griffel/core';
+import type { GriffelRenderer } from '@griffel/core';
+
+/**
+ * Creates a renderer that renders <style> elements if .adoptedStyleSheets is not supported.
+ */
+export const createFallbackRenderer = (shadowRoot: ShadowRoot): GriffelRenderer => {
+  const documentFallback: Partial<Document> = {
+    head: shadowRoot as unknown as HTMLHeadElement,
+    createElement: shadowRoot.ownerDocument.createElement.bind(shadowRoot.ownerDocument),
+  };
+
+  return createDOMRenderer(documentFallback as Document);
+};

--- a/packages/shadow-dom/src/createShadowDOMRenderer.ts
+++ b/packages/shadow-dom/src/createShadowDOMRenderer.ts
@@ -1,0 +1,105 @@
+import { normalizeCSSBucketEntry, safeInsertRule } from '@griffel/core';
+import type { GriffelRenderer, StyleBucketName } from '@griffel/core';
+
+import { createFallbackRenderer } from './createFallbackRenderer';
+import { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';
+import { findInsertionPoint } from './findInsertionPoint';
+
+const SUPPORTS_CONSTRUCTABLE_STYLESHEETS: boolean = (() => {
+  try {
+    new CSSStyleSheet();
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+let rendererId = 0;
+
+function getCSSStyleSheetForBucket(
+  cssSheetsCache: Record<string, ExtendedCSSStyleSheet>,
+
+  bucketName: StyleBucketName,
+  metadata: Record<string, unknown> = {},
+
+  onStyleSheetInsert: (stylesheet: ExtendedCSSStyleSheet) => void,
+): ExtendedCSSStyleSheet {
+  const isMediaBucket = bucketName === 'm';
+  const styleSheetKey: StyleBucketName | string = isMediaBucket ? ((bucketName + metadata['m']) as string) : bucketName;
+
+  if (!cssSheetsCache[styleSheetKey]) {
+    const styleSheet = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+
+    styleSheet.bucketName = bucketName;
+    styleSheet.metadata = metadata;
+
+    cssSheetsCache[styleSheetKey] = styleSheet;
+    onStyleSheetInsert(styleSheet);
+  }
+
+  return cssSheetsCache[styleSheetKey];
+}
+
+function insertAfter<T extends CSSStyleSheet | ExtendedCSSStyleSheet>(
+  arr: T[],
+  sheetToInsert: T,
+  targetSheet: T | null,
+): T[] {
+  if (targetSheet === null) {
+    return [sheetToInsert, ...arr];
+  }
+
+  const index = arr.indexOf(targetSheet);
+
+  return [...arr.slice(0, index + 1), sheetToInsert, ...arr.slice(index + 1)];
+}
+
+export function createShadowDOMRenderer(shadowRoot: ShadowRoot) {
+  if (!SUPPORTS_CONSTRUCTABLE_STYLESHEETS) {
+    return createFallbackRenderer(shadowRoot) as GriffelRenderer & {
+      adoptedStyleSheets?: never;
+    };
+  }
+
+  const cssSheetsCache: Record<string, ExtendedCSSStyleSheet> = {};
+  const renderer: GriffelShadowDOMRenderer = {
+    id: `shadow-dom:${rendererId++}`,
+
+    adoptedStyleSheets: [],
+    insertionCache: {},
+    stylesheets: {},
+
+    compareMediaQueries: (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0),
+    insertCSSRules(cssRules) {
+      for (const [_styleBucketName, cssBucketEntries] of Object.entries(cssRules)) {
+        const styleBucketName = _styleBucketName as StyleBucketName;
+
+        for (let i = 0, l = cssBucketEntries.length; i < l; i++) {
+          const [ruleCSS, metadata] = normalizeCSSBucketEntry(cssBucketEntries[i]);
+          const sheet = getCSSStyleSheetForBucket(
+            cssSheetsCache,
+
+            styleBucketName,
+            metadata,
+
+            styleSheet => {
+              const targetStyleSheet = findInsertionPoint(renderer, styleSheet);
+
+              renderer.adoptedStyleSheets = insertAfter(renderer.adoptedStyleSheets, styleSheet, targetStyleSheet);
+              shadowRoot.adoptedStyleSheets = insertAfter(shadowRoot.adoptedStyleSheets, styleSheet, targetStyleSheet);
+            },
+          );
+
+          if (renderer.insertionCache[ruleCSS]) {
+            continue;
+          }
+
+          renderer.insertionCache[ruleCSS] = styleBucketName;
+          safeInsertRule(sheet, ruleCSS);
+        }
+      }
+    },
+  };
+
+  return renderer;
+}

--- a/packages/shadow-dom/src/findInsertionPoint.test.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.test.ts
@@ -1,0 +1,105 @@
+import type { StyleBucketName } from '@griffel/core';
+
+import { findInsertionPoint } from './findInsertionPoint';
+import type { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';
+
+function createRendererMock(adoptedStyleSheets: ExtendedCSSStyleSheet[]) {
+  const mediaQueryOrder = ['(max-width: 1px)', '(max-width: 2px)', '(max-width: 3px)', '(max-width: 4px)'];
+  const renderer: Partial<GriffelShadowDOMRenderer> = {
+    adoptedStyleSheets,
+    compareMediaQueries(a, b) {
+      return mediaQueryOrder.indexOf(a) - mediaQueryOrder.indexOf(b);
+    },
+  };
+
+  return renderer as GriffelShadowDOMRenderer;
+}
+
+function createStyleSheetMock(bucketName: StyleBucketName, metadata: Record<string, unknown>) {
+  const sheet = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+
+  sheet.bucketName = bucketName;
+  sheet.metadata = metadata;
+
+  return sheet;
+}
+
+describe('findInsertionPoint', () => {
+  it('finds a position in empty array', () => {
+    const renderer = createRendererMock([]);
+    const styleSheet = createStyleSheetMock('d', {});
+
+    expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
+  });
+
+  it('finds a position at beginning', () => {
+    const renderer = createRendererMock([createStyleSheetMock('d', {}), createStyleSheetMock('a', {})]);
+    const styleSheet = createStyleSheetMock('r', {});
+
+    expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
+  });
+
+  it('finds a position in middle', () => {
+    const renderer = createRendererMock([createStyleSheetMock('d', {}), createStyleSheetMock('a', {})]);
+    const styleSheet = createStyleSheetMock('h', {});
+
+    expect(findInsertionPoint(renderer, styleSheet)).toHaveProperty('bucketName', 'd');
+  });
+
+  it('finds a position at end', () => {
+    const renderer = createRendererMock([createStyleSheetMock('d', {}), createStyleSheetMock('a', {})]);
+    const styleSheet = createStyleSheetMock('t', {});
+
+    expect(findInsertionPoint(renderer, styleSheet)).toHaveProperty('bucketName', 'a');
+  });
+
+  describe('media queries', () => {
+    it('finds a position in empty array', () => {
+      const renderer = createRendererMock([]);
+      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
+
+      expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
+    });
+
+    it('finds a position at beginning', () => {
+      const renderer = createRendererMock([createStyleSheetMock('c', {})]);
+      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
+
+      expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
+    });
+
+    it('finds a position in middle', () => {
+      const renderer = createRendererMock([createStyleSheetMock('t', {}), createStyleSheetMock('c', {})]);
+      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
+
+      expect(findInsertionPoint(renderer, styleSheet)).toHaveProperty('bucketName', 't');
+    });
+
+    it('finds a position at end', () => {
+      const renderer = createRendererMock([createStyleSheetMock('d', {}), createStyleSheetMock('a', {})]);
+      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
+
+      expect(findInsertionPoint(renderer, styleSheet)).toHaveProperty('bucketName', 'a');
+    });
+
+    it('finds a position in media queries', () => {
+      const renderer = createRendererMock([
+        createStyleSheetMock('d', {}),
+        createStyleSheetMock('t', {}),
+        createStyleSheetMock('m', { m: '(max-width: 1px)' }),
+        createStyleSheetMock('m', { m: '(max-width: 3px)' }),
+        createStyleSheetMock('c', {}),
+      ]);
+
+      const resultA = findInsertionPoint(renderer, createStyleSheetMock('m', { m: '(max-width: 2px)' }));
+
+      expect(resultA).toHaveProperty('bucketName', 'm');
+      expect(resultA).toHaveProperty('metadata.m', '(max-width: 1px)');
+
+      const resultB = findInsertionPoint(renderer, createStyleSheetMock('m', { m: '(max-width: 4px)' }));
+
+      expect(resultB).toHaveProperty('bucketName', 'm');
+      expect(resultB).toHaveProperty('metadata.m', '(max-width: 3px)');
+    });
+  });
+});

--- a/packages/shadow-dom/src/findInsertionPoint.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.ts
@@ -1,0 +1,37 @@
+import { StyleBucketName, styleBucketOrdering } from '@griffel/core';
+import type { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';
+
+const styleBucketOrderingMap = styleBucketOrdering.reduce((acc, cur, j) => {
+  acc[cur as StyleBucketName] = j;
+  return acc;
+}, {} as Record<StyleBucketName, number>);
+
+export function findInsertionPoint(
+  renderer: GriffelShadowDOMRenderer,
+  styleSheet: ExtendedCSSStyleSheet,
+): ExtendedCSSStyleSheet | null {
+  let styleSheets = renderer.adoptedStyleSheets;
+  const targetOrder = styleBucketOrderingMap[styleSheet.bucketName];
+
+  let comparer = (sheet: ExtendedCSSStyleSheet): number => targetOrder - styleBucketOrderingMap[sheet.bucketName];
+
+  if (styleSheet.bucketName === 'm' && styleSheet.metadata) {
+    const mediaElements = renderer.adoptedStyleSheets.filter(styleSheet => styleSheet.bucketName === 'm');
+
+    if (mediaElements.length) {
+      styleSheets = mediaElements;
+      comparer = sheet =>
+        renderer.compareMediaQueries(styleSheet.metadata['m'] as string, sheet.metadata['m'] as string);
+    }
+  }
+
+  for (let l = styleSheets.length, i = l - 1; i >= 0; i--) {
+    const styleElement = styleSheets[i];
+
+    if (comparer(styleElement) > 0) {
+      return styleElement;
+    }
+  }
+
+  return null;
+}

--- a/packages/shadow-dom/src/index.ts
+++ b/packages/shadow-dom/src/index.ts
@@ -1,0 +1,2 @@
+export { createShadowDOMRenderer } from './createShadowDOMRenderer';
+export type { GriffelShadowDOMRenderer } from './types';

--- a/packages/shadow-dom/src/stories/createShadowDOMRenderer.stories.tsx
+++ b/packages/shadow-dom/src/stories/createShadowDOMRenderer.stories.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+// @ts-expect-error Typings are missing
+import { createProxy as _createProxy, default as _root } from 'react-shadow';
+
+import { makeStyles, RendererProvider, shorthands } from '@griffel/react';
+import { createShadowDOMRenderer } from '../../src';
+
+type Root = typeof _root;
+
+type CreateProxyRenderFn = ({ children }: { children: React.ReactNode; root: ShadowRoot }) => React.ReactNode;
+type CreateProxyFn = (target: unknown, id: string, render: CreateProxyRenderFn) => Root;
+
+const createProxy: CreateProxyFn = _createProxy;
+
+const ReactComponentsWrapper: React.FC<{
+  children: React.ReactNode;
+  root: ShadowRoot;
+}> = ({ children, root }) => {
+  const renderer = React.useMemo(() => createShadowDOMRenderer(root), [root]);
+
+  React.useLayoutEffect(() => {
+    if (renderer.adoptedStyleSheets && renderer.adoptedStyleSheets.length > 0) {
+      if (root.adoptedStyleSheets.find(styleSheet => styleSheet === renderer.adoptedStyleSheets[0])) {
+        return;
+      }
+
+      root.adoptedStyleSheets = [...root.adoptedStyleSheets, ...renderer.adoptedStyleSheets];
+    }
+  }, [renderer.adoptedStyleSheets, root.adoptedStyleSheets]);
+
+  return <RendererProvider renderer={renderer}>{children}</RendererProvider>;
+};
+
+const root = createProxy({}, '@griffel/shadow-dom', ({ children, root }) => (
+  <ReactComponentsWrapper root={root}>{children}</ReactComponentsWrapper>
+));
+
+const useStyles = makeStyles({
+  root: {
+    color: 'black',
+    ...shorthands.borderRadius('5px'),
+    ...shorthands.padding('10px'),
+    ...shorthands.border('3px', 'dotted', 'magenta'),
+    width: '300px',
+  },
+  button: {
+    ...shorthands.borderRadius('5px'),
+    ...shorthands.padding('5px'),
+    ...shorthands.border('2px', 'solid', 'black'),
+    backgroundColor: 'white',
+  },
+  p: {
+    marginTop: 0,
+    fontSize: '18px',
+  },
+});
+
+const ExampleComponent: React.FC = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <p className={classes.p}>Hello world!</p>
+      <button className={classes.button}>Click me</button>
+    </div>
+  );
+};
+
+export const CreateShadowDOMRenderer = () => {
+  return (
+    <root.div>
+      <ExampleComponent />
+    </root.div>
+  );
+};

--- a/packages/shadow-dom/src/stories/index.stories.tsx
+++ b/packages/shadow-dom/src/stories/index.stories.tsx
@@ -1,0 +1,5 @@
+export { CreateShadowDOMRenderer } from './createShadowDOMRenderer.stories';
+
+export default {
+  title: 'createShadowDOMRenderer',
+};

--- a/packages/shadow-dom/src/types.ts
+++ b/packages/shadow-dom/src/types.ts
@@ -1,0 +1,9 @@
+import type { GriffelRenderer, StyleBucketName } from '@griffel/core';
+
+export type ExtendedCSSStyleSheet = CSSStyleSheet & {
+  bucketName: StyleBucketName;
+  metadata: Record<string, unknown>;
+};
+export type GriffelShadowDOMRenderer = GriffelRenderer & {
+  adoptedStyleSheets: ExtendedCSSStyleSheet[];
+};

--- a/packages/shadow-dom/tsconfig.json
+++ b/packages/shadow-dom/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
+    }
+  ]
+}

--- a/packages/shadow-dom/tsconfig.lib.json
+++ b/packages/shadow-dom/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "environment"]
+  },
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx",
+    "**/*.stories.ts",
+    "**/*.stories.js",
+    "**/*.stories.jsx",
+    "**/*.stories.tsx",
+    "jest.config.ts"
+  ],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/packages/shadow-dom/tsconfig.spec.json
+++ b/packages/shadow-dom/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node", "environment"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14262,6 +14262,7 @@ __metadata:
     react-dom: 18.2.0
     react-fela: 12.2.0
     react-refresh: ^0.10.0
+    react-shadow: ^20.2.0
     react-test-renderer: 18.0.0
     rtl-css-js: ^1.16.1
     simple-git-hooks: 2.7.0
@@ -14917,6 +14918,13 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"humps@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "humps@npm:2.0.1"
+  checksum: 7d5a674cfca2f34c04562f6fd0d129b4c43a5caf85fcc1c9eacf5d0729554c9375db362c4232519b37369c94dd2560d85f96ad4091a8fbf4af4e625ab5214a30
   languageName: node
   linkType: hard
 
@@ -21321,6 +21329,19 @@ __metadata:
   peerDependencies:
     react: ">=15"
   checksum: 52a9f28fa97577fda18a8ed2922b658704eafe873e444fe07202640d55d9e81e67c03efd2b2a5b80e3a80e8be8352df826a227ce5f42b33b91bef853c74d4841
+  languageName: node
+  linkType: hard
+
+"react-shadow@npm:^20.2.0":
+  version: 20.2.0
+  resolution: "react-shadow@npm:20.2.0"
+  dependencies:
+    humps: ^2.0.1
+  peerDependencies:
+    prop-types: ^15.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: ab3a7c2231cfc63f309646e94380aff585834bac87ce71a0d41a23ddb841f9b445084fed5c9364cebe696241992d25898ad58bf11104c44cd345aa36cdb1e4e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #369.

Ports implementation from https://github.com/microsoft/fluentui-contrib/tree/main/packages/react-shadow.