### PR TITLE
feat: Prefix according to browser support matrix

### DIFF
--- a/change/@griffel-core-2d6dd71b-5fd3-4866-9472-5d90f34a392b.json
+++ b/change/@griffel-core-2d6dd71b-5fd3-4866-9472-5d90f34a392b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Prefix according to browser support matrix",
+  "packageName": "@griffel/core",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/__fixtures__/assets-urls/output.ts
+++ b/packages/babel-preset/__fixtures__/assets-urls/output.ts
@@ -27,7 +27,7 @@ export const useStyles = __styles(
       `.fcrzfig{background-image:url("https://www.example.com");}`,
       `.f1b0d1k8{background-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);}`,
       `.f15gfcnl{background-image:url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" height="32" aria-hidden="true" viewBox="0 0 16 16" width="32" data-view-component="true" class="octicon octicon-mark-github v-align-middle"%3E%3Cpath fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"%3E%3C/path%3E%3C/svg%3E');}`,
-      `.f1bk4c0y{-webkit-filter:url(#a);filter:url(#a);}`,
+      `.f1bk4c0y{filter:url(#a);}`,
     ],
   },
 );

--- a/packages/babel-preset/__fixtures__/assets/output.ts
+++ b/packages/babel-preset/__fixtures__/assets/output.ts
@@ -24,7 +24,7 @@ export const useStyles = __styles(
     d: [
       `.fnwsaxv{background-image:url(${_asset});}`,
       `.f1ryfumh{background-image:url(${_asset2});}`,
-      `.fv04sme{-webkit-filter:url(${_asset3}#a);filter:url(${_asset3}#a);}`,
+      `.fv04sme{filter:url(${_asset3}#a);}`,
     ],
   },
 );

--- a/packages/babel-preset/__fixtures__/keyframes/output.ts
+++ b/packages/babel-preset/__fixtures__/keyframes/output.ts
@@ -10,18 +10,15 @@ export const useStyles = __styles(
   },
   {
     k: [
-      '@-webkit-keyframes f1q8eu9e{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-moz-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}',
-      '@-webkit-keyframes f55c0se{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(-360deg);-moz-transform:rotate(-360deg);-ms-transform:rotate(-360deg);transform:rotate(-360deg);}}',
-      '@keyframes f1q8eu9e{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-moz-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}',
-      '@keyframes f55c0se{from{-webkit-transform:rotate(0deg);-moz-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(-360deg);-moz-transform:rotate(-360deg);-ms-transform:rotate(-360deg);transform:rotate(-360deg);}}',
-      '@-webkit-keyframes f19fnzg9{from{height:100px;}to{height:200px;}}',
+      '@keyframes f1q8eu9e{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}',
+      '@keyframes f55c0se{from{transform:rotate(0deg);}to{transform:rotate(-360deg);}}',
       '@keyframes f19fnzg9{from{height:100px;}to{height:200px;}}',
     ],
     d: [
-      '.f1g6ul6r{-webkit-animation-name:f1q8eu9e;animation-name:f1q8eu9e;}',
-      '.f1fp4ujf{-webkit-animation-name:f55c0se;animation-name:f55c0se;}',
-      '.f1e467oh{-webkit-animation-name:f1q8eu9e,f19fnzg9;animation-name:f1q8eu9e,f19fnzg9;}',
-      '.f1w9bd63{-webkit-animation-name:f55c0se,f19fnzg9;animation-name:f55c0se,f19fnzg9;}',
+      '.f1g6ul6r{animation-name:f1q8eu9e;}',
+      '.f1fp4ujf{animation-name:f55c0se;}',
+      '.f1e467oh{animation-name:f1q8eu9e,f19fnzg9;}',
+      '.f1w9bd63{animation-name:f55c0se,f19fnzg9;}',
     ],
   },
 );

--- a/packages/babel-preset/__fixtures__/object-mixins/output.ts
+++ b/packages/babel-preset/__fixtures__/object-mixins/output.ts
@@ -25,13 +25,13 @@ export const useStyles = __styles(
   },
   {
     d: [
-      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
-      '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',
+      '.f22iagw{display:flex;}',
+      '.f1vx9l62{flex-direction:column;}',
       '.figsok6{font-weight:var(--fontWeightRegular);}',
       '.f16wzh4i{font-weight:bold;}',
       '.fe3e8s9{color:red;}',
-      '.f13qh94s{display:-ms-grid;display:grid;}',
-      '.f85kjgz{-ms-grid-row-gap:10px;grid-row-gap:10px;}',
+      '.f13qh94s{display:grid;}',
+      '.f85kjgz{grid-row-gap:10px;}',
       '.fka9v86{color:green;}',
     ],
   },

--- a/packages/babel-preset/__fixtures__/object-nesting/output.ts
+++ b/packages/babel-preset/__fixtures__/object-nesting/output.ts
@@ -10,10 +10,7 @@ export const useStyles = __styles(
     },
   },
   {
-    d: [
-      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
-      '.fh8e7tb .foo:hover{color:green;}',
-    ],
+    d: ['.f22iagw{display:flex;}', '.fh8e7tb .foo:hover{color:green;}'],
     h: ['.faf35ka:hover{color:red;}'],
     f: ['.f17t1d3d:focus:hover{color:blue;}'],
   },

--- a/packages/babel-preset/__fixtures__/shared-mixins/output.ts
+++ b/packages/babel-preset/__fixtures__/shared-mixins/output.ts
@@ -13,10 +13,6 @@ export const useStyles = __styles(
     },
   },
   {
-    d: [
-      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
-      '.f13qh94s{display:-ms-grid;display:grid;}',
-      '.fe3e8s9{color:red;}',
-    ],
+    d: ['.f22iagw{display:flex;}', '.f13qh94s{display:grid;}', '.fe3e8s9{color:red;}'],
   },
 );

--- a/packages/babel-preset/__fixtures__/tokens/output.ts
+++ b/packages/babel-preset/__fixtures__/tokens/output.ts
@@ -15,7 +15,7 @@ export const useStyles = __styles(
     d: [
       '.f1734hy{background-color:black;}',
       '.ff34w31{color:var(--colorPaletteBlueBorder2);}',
-      '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
+      '.f22iagw{display:flex;}',
       '.f1817uup{color:var(--colorBrandBackground);}',
     ],
   },

--- a/packages/core/src/devtools/getDebugTree.test.ts
+++ b/packages/core/src/devtools/getDebugTree.test.ts
@@ -47,7 +47,7 @@ describe('getDebugTree', () => {
           ],
           direction: dir,
           rules: {
-            f13qh94s: '.f13qh94s{display:-ms-grid;display:grid;}',
+            f13qh94s: '.f13qh94s{display:grid;}',
           },
           sequenceHash: sequenceGrid,
           slot: 'grid',

--- a/packages/core/src/devtools/store.test.ts
+++ b/packages/core/src/devtools/store.test.ts
@@ -45,7 +45,7 @@ describe('debugData', () => {
 
     expect(debugData.getCSSRules()).toEqual([
       '.ftgm304{display:block;}',
-      '.f13qh94s{display:-ms-grid;display:grid;}',
+      '.f13qh94s{display:grid;}',
       '.f1oou7ox{margin-left:10px;}',
       '.f1pxv85q{margin-right:10px;}',
     ]);

--- a/packages/core/src/makeResetStyles.test.ts
+++ b/packages/core/src/makeResetStyles.test.ts
@@ -27,8 +27,6 @@ describe('makeResetStyles', () => {
     expect(renderer).toMatchInlineSnapshot(`
       .r7lmmpp {
         color: red;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
         flex-direction: row;
       }
     `);

--- a/packages/core/src/makeStaticStyles.test.ts
+++ b/packages/core/src/makeStaticStyles.test.ts
@@ -30,7 +30,6 @@ describe('makeStaticStyles', () => {
     expect(renderer).toMatchInlineSnapshot(`
       body {
         background: blue;
-        -webkit-transition: all 4s ease;
         transition: all 4s ease;
       }
       .foo {

--- a/packages/core/src/makeStyles.test.ts
+++ b/packages/core/src/makeStyles.test.ts
@@ -106,76 +106,32 @@ describe('makeStyles', () => {
     expect(computeClasses({ dir: 'rtl', renderer }).root).toBe('___3kh5ri0 f1fp4ujf f1cpbl36 f1t9cprh');
 
     expect(renderer).toMatchInlineSnapshot(`
-      @-webkit-keyframes f1q8eu9e {
-        from {
-          -webkit-transform: rotate(0deg);
-          -moz-transform: rotate(0deg);
-          -ms-transform: rotate(0deg);
-          transform: rotate(0deg);
-        }
-        to {
-          -webkit-transform: rotate(360deg);
-          -moz-transform: rotate(360deg);
-          -ms-transform: rotate(360deg);
-          transform: rotate(360deg);
-        }
-      }
-      @-webkit-keyframes f55c0se {
-        from {
-          -webkit-transform: rotate(0deg);
-          -moz-transform: rotate(0deg);
-          -ms-transform: rotate(0deg);
-          transform: rotate(0deg);
-        }
-        to {
-          -webkit-transform: rotate(-360deg);
-          -moz-transform: rotate(-360deg);
-          -ms-transform: rotate(-360deg);
-          transform: rotate(-360deg);
-        }
-      }
       @keyframes f1q8eu9e {
         from {
-          -webkit-transform: rotate(0deg);
-          -moz-transform: rotate(0deg);
-          -ms-transform: rotate(0deg);
           transform: rotate(0deg);
         }
         to {
-          -webkit-transform: rotate(360deg);
-          -moz-transform: rotate(360deg);
-          -ms-transform: rotate(360deg);
           transform: rotate(360deg);
         }
       }
       @keyframes f55c0se {
         from {
-          -webkit-transform: rotate(0deg);
-          -moz-transform: rotate(0deg);
-          -ms-transform: rotate(0deg);
           transform: rotate(0deg);
         }
         to {
-          -webkit-transform: rotate(-360deg);
-          -moz-transform: rotate(-360deg);
-          -ms-transform: rotate(-360deg);
           transform: rotate(-360deg);
         }
       }
       .f1g6ul6r {
-        -webkit-animation-name: f1q8eu9e;
         animation-name: f1q8eu9e;
       }
       .f1fp4ujf {
-        -webkit-animation-name: f55c0se;
         animation-name: f55c0se;
       }
       .f1cpbl36 {
-        -webkit-animation-iteration-count: infinite;
         animation-iteration-count: infinite;
       }
       .f1t9cprh {
-        -webkit-animation-duration: 5s;
         animation-duration: 5s;
       }
     `);

--- a/packages/core/src/runtime/__snapshots__/compileAtomicCSSRule.test.ts.snap
+++ b/packages/core/src/runtime/__snapshots__/compileAtomicCSSRule.test.ts.snap
@@ -1,0 +1,217 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compileAtomicCSSRule does not prefix align-content:center 1`] = `
+Array [
+  ".foo{align-content:center;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix align-items:center 1`] = `
+Array [
+  ".foo{align-items:center;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix align-self:center 1`] = `
+Array [
+  ".foo{align-self:center;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation:3s linear 1s slidein; 1`] = `
+Array [
+  ".foo{animation:3s linear 1s slidein;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-delay:3s 1`] = `
+Array [
+  ".foo{animation-delay:3s;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-direction:normal 1`] = `
+Array [
+  ".foo{animation-direction:normal;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-duration:3s 1`] = `
+Array [
+  ".foo{animation-duration:3s;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-fill-mode:both 1`] = `
+Array [
+  ".foo{animation-fill-mode:both;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-iteration-count:10 1`] = `
+Array [
+  ".foo{animation-iteration-count:10;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-name:foo 1`] = `
+Array [
+  ".foo{animation-name:foo;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-play-state:running 1`] = `
+Array [
+  ".foo{animation-play-state:running;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix animation-timing-function:linear 1`] = `
+Array [
+  ".foo{animation-timing-function:linear;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix background-clip:text 1`] = `
+Array [
+  ".foo{background-clip:text;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix clip-path:circle(40%) 1`] = `
+Array [
+  ".foo{clip-path:circle(40%);}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix columns:2 1`] = `
+Array [
+  ".foo{columns:2;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix display:flex 1`] = `
+Array [
+  ".foo{display:flex;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix display:grid 1`] = `
+Array [
+  ".foo{display:grid;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix display:inline-flex 1`] = `
+Array [
+  ".foo{display:inline-flex;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix display:inline-grid 1`] = `
+Array [
+  ".foo{display:inline-grid;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix filter:blur(5px) 1`] = `
+Array [
+  ".foo{filter:blur(5px);}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix flex-basis:auto 1`] = `
+Array [
+  ".foo{flex-basis:auto;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix flex-direction:column 1`] = `
+Array [
+  ".foo{flex-direction:column;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix flex-grow:1 1`] = `
+Array [
+  ".foo{flex-grow:1;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix flex-shrink:1 1`] = `
+Array [
+  ".foo{flex-shrink:1;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix justify-content:center 1`] = `
+Array [
+  ".foo{justify-content:center;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix order:1 1`] = `
+Array [
+  ".foo{order:1;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix position:sticky 1`] = `
+Array [
+  ".foo{position:sticky;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix scroll-margin:0 1`] = `
+Array [
+  ".foo{scroll-margin:0;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix scroll-snap-type:none 1`] = `
+Array [
+  ".foo{scroll-snap-type:none;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix text-decoration:none 1`] = `
+Array [
+  ".foo{text-decoration:none;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix text-size-adjust:none 1`] = `
+Array [
+  ".foo{text-size-adjust:none;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix transform:none 1`] = `
+Array [
+  ".foo{transform:none;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix transition:margin-right 4s 1`] = `
+Array [
+  ".foo{transition:margin-right 4s;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix width:fit-content 1`] = `
+Array [
+  ".foo{width:fit-content;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix width:min-block-size 1`] = `
+Array [
+  ".foo{width:min-block-size;}",
+]
+`;
+
+exports[`compileAtomicCSSRule does not prefix writing-mode:vertical-lr 1`] = `
+Array [
+  ".foo{writing-mode:vertical-lr;}",
+]
+`;

--- a/packages/core/src/runtime/compileAtomicCSSRule.test.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.test.ts
@@ -14,6 +14,53 @@ const defaultOptions: Pick<
 };
 
 describe('compileAtomicCSSRule', () => {
+  it.only.each([
+    ['transform', 'none'],
+    ['flex-grow', '1'],
+    ['flex-shrink', '1'],
+    ['flex-basis', 'auto'],
+    ['flex-direction', 'column'],
+    ['align-self', 'center'],
+    ['align-content', 'center'],
+    ['align-items', 'center'],
+    ['order', '1'],
+    ['justify-content', 'center'],
+    ['display', 'flex'],
+    ['display', 'inline-flex'],
+    ['display', 'grid'],
+    ['display', 'inline-grid'],
+    ['transition', 'margin-right 4s'],
+    ['writing-mode', 'vertical-lr'],
+    ['columns', '2'],
+    ['text-size-adjust', 'none'],
+    ['text-decoration', 'none'],
+    ['filter', 'blur(5px)'],
+    ['position', 'sticky'],
+    ['clip-path', 'circle(40%)'],
+    ['width', 'fit-content'],
+    ['width', 'min-block-size'],
+    ['background-clip', 'text'],
+    ['animation', '3s linear 1s slidein;'],
+    ['animation-delay', '3s'],
+    ['animation-direction', 'normal'],
+    ['animation-duration', '3s'],
+    ['animation-fill-mode', 'both'],
+    ['animation-iteration-count', '10'],
+    ['animation-name', 'foo'],
+    ['animation-play-state', 'running'],
+    ['animation-timing-function', 'linear'],
+    ['scroll-snap-type', 'none'],
+    ['scroll-margin', '0'],
+  ])('does not prefix %s:%s', (property, value) => {
+    expect(
+      compileAtomicCSSRule({
+        ...defaultOptions,
+        property,
+        value,
+      }),
+    ).toMatchSnapshot();
+  });
+
   it('handles pseudo', () => {
     expect(
       compileAtomicCSSRule({
@@ -148,10 +195,10 @@ describe('compileAtomicCSSRule', () => {
           value: 'red',
         }),
       ).toMatchInlineSnapshot(`
-      Array [
-        "body .foo{color:red;}",
-      ]
-    `);
+              Array [
+                "body .foo{color:red;}",
+              ]
+          `);
       expect(
         compileAtomicCSSRule({
           ...defaultOptions,
@@ -160,10 +207,10 @@ describe('compileAtomicCSSRule', () => {
           value: 'red',
         }),
       ).toMatchInlineSnapshot(`
-      Array [
-        ".fui-FluentProvider .foo .focus:hover{color:red;}",
-      ]
-    `);
+              Array [
+                ".fui-FluentProvider .foo .focus:hover{color:red;}",
+              ]
+          `);
     });
 
     it('compiles global rules with RTL', () => {
@@ -178,11 +225,11 @@ describe('compileAtomicCSSRule', () => {
           rtlValue: '10px',
         }),
       ).toMatchInlineSnapshot(`
-      Array [
-        "body .foo{padding-left:10px;}",
-        "body .rtl-foo{padding-right:10px;}",
-      ]
-    `);
+              Array [
+                "body .foo{padding-left:10px;}",
+                "body .rtl-foo{padding-right:10px;}",
+              ]
+          `);
     });
   });
 });

--- a/packages/core/src/runtime/compileAtomicCSSRule.test.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.test.ts
@@ -14,7 +14,7 @@ const defaultOptions: Pick<
 };
 
 describe('compileAtomicCSSRule', () => {
-  it.only.each([
+  it.each([
     ['transform', 'none'],
     ['flex-grow', '1'],
     ['flex-shrink', '1'],

--- a/packages/core/src/runtime/compileCSSRules.ts
+++ b/packages/core/src/runtime/compileCSSRules.ts
@@ -1,7 +1,8 @@
-import { compile, middleware, prefixer, rulesheet, serialize, stringify } from 'stylis';
+import { compile, middleware, rulesheet, serialize, stringify } from 'stylis';
 
 import { globalPlugin } from './stylis/globalPlugin';
 import { sortClassesInAtRulesPlugin } from './stylis/sortClassesInAtRulesPlugin';
+import { prefixer } from './prefixer';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop() {}
@@ -14,6 +15,7 @@ export function compileCSSRules(cssRules: string, sortClassesInAtRules: boolean)
     middleware([
       globalPlugin,
       sortClassesInAtRules ? sortClassesInAtRulesPlugin : noop,
+      // prefixer,
       prefixer,
       stringify,
 

--- a/packages/core/src/runtime/compileKeyframeCSS.test.ts
+++ b/packages/core/src/runtime/compileKeyframeCSS.test.ts
@@ -32,7 +32,6 @@ describe('compileKeyframeCSS', () => {
 
     expect(result).toMatchInlineSnapshot(`
       Array [
-        "@-webkit-keyframes foo{from{height:10px;}to{height:50px;}}",
         "@keyframes foo{from{height:10px;}to{height:50px;}}",
       ]
     `);

--- a/packages/core/src/runtime/compileKeyframeCSS.ts
+++ b/packages/core/src/runtime/compileKeyframeCSS.ts
@@ -1,5 +1,6 @@
 import { GriffelAnimation } from '../types';
-import { compile, middleware, serialize, rulesheet, stringify, prefixer } from 'stylis';
+import { compile, middleware, serialize, rulesheet, stringify } from 'stylis';
+import { prefixer } from './prefixer';
 import { cssifyObject } from './utils/cssifyObject';
 
 export function compileKeyframeRule(keyframeObject: GriffelAnimation): string {
@@ -23,9 +24,8 @@ export function compileKeyframesCSS(keyframeName: string, keyframeCSS: string): 
   serialize(
     compile(cssRule),
     middleware([
-      prefixer,
       stringify,
-
+      prefixer,
       // 💡 we are using `.insertRule()` API for DOM operations, which does not support
       // insertion of multiple CSS rules in a single call. `rulesheet` plugin extracts
       // individual rules to be used with this API

--- a/packages/core/src/runtime/prefixer.test.ts
+++ b/packages/core/src/runtime/prefixer.test.ts
@@ -1,0 +1,330 @@
+import { prefix } from './prefixer';
+
+const globalCssValues = ['inherit', 'initial', 'unset', 'revert', 'revert-layer'];
+
+describe('prefix', () => {
+  describe('should prefix', () => {
+    test('cursor', () => {
+      expect(prefix(`cursor:none;`, 6)).toEqual([`cursor:none;`].join(''));
+      expect(prefix(`cursor:image-set(url(foo.jpg) 2x), pointer;`, 6)).toEqual(
+        [`cursor:-webkit-image-set(url(foo.jpg) 2x), pointer;`, `cursor:image-set(url(foo.jpg) 2x), pointer;`].join(''),
+      );
+      expect(prefix(`cursor:image-set(url(foo.jpg) 2x), grab;`, 6)).toEqual(
+        [`cursor:-webkit-image-set(url(foo.jpg) 2x), grab;`, `cursor:image-set(url(foo.jpg) 2x), grab;`].join(''),
+      );
+    });
+
+    test('backface-visibility', () => {
+      expect(prefix(`backface-visibility:hidden;`, 19)).toEqual(
+        [`-webkit-backface-visibility:hidden;`, `backface-visibility:hidden;`].join(''),
+      );
+    });
+
+    test('text', () => {
+      expect(prefix(`text-align:left;`, 10)).toEqual([`text-align:left;`].join(''));
+      expect(prefix(`text-transform:none;`, 14)).toEqual([`text-transform:none;`].join(''));
+      expect(prefix(`text-shadow:none;`, 11)).toEqual([`text-shadow:none;`].join(''));
+    });
+
+    test('mask', () => {
+      expect(prefix(`mask:none;`, 10)).toEqual([`-webkit-mask:none;`, `mask:none;`].join(''));
+      expect(prefix(`mask-image:none;`, 10)).toEqual([`-webkit-mask-image:none;`, `mask-image:none;`].join(''));
+      expect(prefix(`mask-image:linear-gradient(#fff);`, 10)).toEqual(
+        [`-webkit-mask-image:linear-gradient(#fff);`, `mask-image:linear-gradient(#fff);`].join(''),
+      );
+      expect(prefix(`mask-mode:none;`, 10)).toEqual([`-webkit-mask-mode:none;`, `mask-mode:none;`].join(''));
+      expect(prefix(`mask-clip:none;`, 10)).toEqual([`-webkit-mask-clip:none;`, `mask-clip:none;`].join(''));
+      expect(prefix(`mask-size:none;`, 10)).toEqual([`-webkit-mask-size:none;`, `mask-size:none;`].join(''));
+      expect(prefix(`mask-repeat:none;`, 10)).toEqual([`-webkit-mask-repeat:none;`, `mask-repeat:none;`].join(''));
+      expect(prefix(`mask-origin:none;`, 10)).toEqual([`-webkit-mask-origin:none;`, `mask-origin:none;`].join(''));
+      expect(prefix(`mask-position:none;`, 10)).toEqual(
+        [`-webkit-mask-position:none;`, `mask-position:none;`].join(''),
+      );
+      expect(prefix(`mask-composite:none;`, 10)).toEqual(
+        [`-webkit-mask-composite:none;`, `mask-composite:none;`].join(''),
+      );
+    });
+
+    test('position', () => {
+      expect(prefix(`position:relative;`, 8)).toEqual([`position:relative;`].join(''));
+      expect(prefix(`position:static;`, 8)).toEqual([`position:static;`].join(''));
+      expect(prefix(`position:fixed;`, 8)).toEqual([`position:fixed;`].join(''));
+      expect(prefix(`position:absolute;`, 8)).toEqual([`position:absolute;`].join(''));
+      globalCssValues.forEach(v => expect(prefix(`position:${v};`, 8)).toEqual([`position:${v};`].join()));
+    });
+
+    test('color-adjust', () => {
+      expect(prefix(`color:none;`, 5)).toEqual([`color:none;`].join(''));
+      expect(prefix(`color-adjust:none;`, 12)).toEqual(
+        [`-webkit-print-color-adjust:none;`, `color-adjust:none;`].join(''),
+      );
+    });
+
+    test('box', () => {
+      expect(prefix(`box-decoration-break:slice;`, 20)).toEqual(
+        [`-webkit-box-decoration-break:slice;`, `box-decoration-break:slice;`].join(''),
+      );
+      expect(prefix(`box-sizing:border-box;`, 10)).toEqual([`box-sizing:border-box;`].join(''));
+    });
+
+    test('size', () => {
+      expect(prefix(`width:auto;`, 5)).toEqual([`width:auto;`].join(''));
+      expect(prefix(`width:unset;`, 5)).toEqual([`width:unset;`].join(''));
+      expect(prefix(`width:initial;`, 5)).toEqual([`width:initial;`].join(''));
+      expect(prefix(`width:inherit;`, 5)).toEqual([`width:inherit;`].join(''));
+      expect(prefix(`width:10;`, 5)).toEqual([`width:10;`].join(''));
+      expect(prefix(`width:min();`, 5)).toEqual([`width:min();`].join(''));
+      expect(prefix(`width:var(--foo-content);`, 5)).toEqual([`width:var(--foo-content);`].join(''));
+      expect(prefix(`width:var(-content);`, 5)).toEqual([`width:var(-content);`].join(''));
+      expect(prefix(`width:var(--max-content);`, 5)).toEqual([`width:var(--max-content);`].join(''));
+      expect(prefix(`width:--max-content;`, 5)).toEqual([`width:--max-content;`].join(''));
+      expect(prefix(`width:stackWidth;`, 5)).toEqual([`width:stackWidth;`].join(''));
+      expect(prefix(`height:fill-available;`, 6)).toEqual(
+        [`height:-webkit-fill-available;`, `height:-moz-available;`, `height:fill-available;`].join(''),
+      );
+      expect(prefix(`width:stretch;`, 5)).toEqual(
+        [`width:-webkit-fill-available;`, `width:-moz-available;`, `width:fill-available;`, `width:stretch;`].join(''),
+      );
+      expect(prefix(`width:stretch !important;`, 5)).toEqual(
+        [
+          `width:-webkit-fill-available !important;`,
+          `width:-moz-available !important;`,
+          `width:fill-available !important;`,
+          `width:stretch !important;`,
+        ].join(''),
+      );
+      expect(prefix(`width:max(250px, 100px);`, 5)).toEqual([`width:max(250px, 100px);`].join(''));
+      expect(prefix(`height:min(150px, 200px);`, 6)).toEqual([`height:min(150px, 200px);`].join(''));
+      expect(prefix(`min-width:min(100px, 50px);`, 9)).toEqual([`min-width:min(100px, 50px);`].join(''));
+      expect(prefix(`max-width:max(150px, 200px);`, 9)).toEqual([`max-width:max(150px, 200px);`].join(''));
+      expect(prefix(`min-height:max(100px, 50px);`, 10)).toEqual([`min-height:max(100px, 50px);`].join(''));
+      expect(prefix(`max-height:min(150px, 200px);`, 10)).toEqual([`max-height:min(150px, 200px);`].join(''));
+    });
+
+    test('zoom', () => {
+      expect(prefix(`min-zoom:0;`, 8)).toEqual([`min-zoom:0;`].join(''));
+    });
+
+    test('background', () => {
+      expect(prefix(`background:none;`, 10)).toEqual([`background:none;`].join(''));
+      expect(prefix(`background:image-set(url(foo.jpg) 2x);`, 10)).toEqual(
+        [`background:-webkit-image-set(url(foo.jpg) 2x);`, `background:image-set(url(foo.jpg) 2x);`].join(''),
+      );
+      expect(prefix(`background-image:image-set(url(foo.jpg) 2x);`, 16)).toEqual(
+        [`background-image:-webkit-image-set(url(foo.jpg) 2x);`, `background-image:image-set(url(foo.jpg) 2x);`].join(
+          '',
+        ),
+      );
+    });
+
+    test('margin-inline', () => {
+      expect(prefix(`margin-inline-start:20px;`, 19)).toEqual(
+        [`-webkit-margin-start:20px;`, `margin-inline-start:20px;`].join(''),
+      );
+      expect(prefix(`margin-inline-end:20px;`, 17)).toEqual(
+        [`-webkit-margin-end:20px;`, `margin-inline-end:20px;`].join(''),
+      );
+    });
+
+    test('user-select', () => {
+      expect(prefix(`user-select:none;`, 11)).toEqual(
+        [`-webkit-user-select:none;`, `-moz-user-select:none;`, `-ms-user-select:none;`, `user-select:none;`].join(''),
+      );
+    });
+
+    test('appearance', () => {
+      expect(prefix(`appearance:none;`, 10)).toEqual(
+        [`-webkit-appearance:none;`, `-moz-appearance:none;`, `-ms-appearance:none;`, `appearance:none;`].join(''),
+      );
+    });
+
+    test('tab-size', () => {
+      expect(prefix(`tab-size:1;`, 8)).toEqual([`-moz-tab-size:1;`, `tab-size:1;`].join(''));
+    });
+
+    test('css variables', () => {
+      expect(prefix(`--CircularProgress-animation:0.5s linear;`, 28)).toEqual(
+        '--CircularProgress-animation:0.5s linear;',
+      );
+    });
+  });
+
+  describe('should not prefix', () => {
+    test('flex-box', () => {
+      expect(prefix(`display:flex!important;`, 7)).toMatchInlineSnapshot(`"display:flex!important;"`);
+      expect(prefix(`display:flex !important;`, 7)).toMatchInlineSnapshot(`"display:flex !important;"`);
+      expect(prefix(`display:flex     !important;`, 7)).toMatchInlineSnapshot(`"display:flex     !important;"`);
+      expect(prefix(`display:inline-flex;`, 7)).toMatchInlineSnapshot(`"display:inline-flex;"`);
+      expect(prefix(`flex:inherit;`, 4)).toMatchInlineSnapshot(`"flex:inherit;"`);
+      expect(prefix(`flex-grow:none;`, 9)).toMatchInlineSnapshot(`"flex-grow:none;"`);
+      expect(prefix(`flex-shrink:none;`, 11)).toMatchInlineSnapshot(`"flex-shrink:none;"`);
+      expect(prefix(`flex-basis:none;`, 10)).toMatchInlineSnapshot(`"flex-basis:none;"`);
+      expect(prefix(`align-self:flex-start;`, 10)).toMatchInlineSnapshot(`"align-self:flex-start;"`);
+      expect(prefix(`align-self:flex-end;`, 10)).toMatchInlineSnapshot(`"align-self:flex-end;"`);
+      expect(prefix(`align-self:baseline;`, 10)).toMatchInlineSnapshot(`"align-self:baseline;"`);
+      expect(prefix(`align-self:first baseline;`, 10)).toMatchInlineSnapshot(`"align-self:first baseline;"`);
+      expect(prefix(`align-content:value;`, 13)).toMatchInlineSnapshot(`"align-content:value;"`);
+      expect(prefix(`align-content:flex-start;`, 13)).toMatchInlineSnapshot(`"align-content:flex-start;"`);
+      expect(prefix(`align-content:flex-end;`, 13)).toMatchInlineSnapshot(`"align-content:flex-end;"`);
+      expect(prefix(`align-items:value;`, 11)).toMatchInlineSnapshot(`"align-items:value;"`);
+      expect(prefix(`justify-content:flex-end;`, 15)).toMatchInlineSnapshot(`"justify-content:flex-end;"`);
+      expect(prefix(`justify-content:flex-start;`, 15)).toMatchInlineSnapshot(`"justify-content:flex-start;"`);
+      expect(prefix(`justify-content:justify;`, 15)).toMatchInlineSnapshot(`"justify-content:justify;"`);
+      expect(prefix(`justify-content:space-between;`, 15)).toMatchInlineSnapshot(`"justify-content:space-between;"`);
+      expect(prefix(`justify-items:center;`, 13)).toMatchInlineSnapshot(`"justify-items:center;"`);
+      expect(prefix(`order:flex;`, 5)).toMatchInlineSnapshot(`"order:flex;"`);
+      expect(prefix(`flex-direction:column;`, 14)).toMatchInlineSnapshot(`"flex-direction:column;"`);
+    });
+    test('transform', () => {
+      expect(prefix(`transform:rotate(30deg);`, 9)).toMatchInlineSnapshot(`"transform:rotate(30deg);"`);
+    });
+    test('cursor', () => {
+      expect(prefix(`cursor:grab;`, 6)).toMatchInlineSnapshot(`"cursor:grab;"`);
+    });
+    test('transition', () => {
+      expect(prefix(`transition:transform 1s,transform all 400ms,text-transform;`, 10)).toMatchInlineSnapshot(
+        `"transition:transform 1s,transform all 400ms,text-transform;"`,
+      );
+    });
+    test('writing-mode', () => {
+      expect(prefix(`writing-mode:none;`, 12)).toMatchInlineSnapshot(`"writing-mode:none;"`);
+      expect(prefix(`writing-mode:vertical-lr;`, 12)).toMatchInlineSnapshot(`"writing-mode:vertical-lr;"`);
+      expect(prefix(`writing-mode:vertical-rl;`, 12)).toMatchInlineSnapshot(`"writing-mode:vertical-rl;"`);
+      expect(prefix(`writing-mode:horizontal-tb;`, 12)).toMatchInlineSnapshot(`"writing-mode:horizontal-tb;"`);
+      expect(prefix(`writing-mode:sideways-rl;`, 12)).toMatchInlineSnapshot(`"writing-mode:sideways-rl;"`);
+      expect(prefix(`writing-mode:sideways-lr;`, 12)).toMatchInlineSnapshot(`"writing-mode:sideways-lr;"`);
+    });
+    test('columns', () => {
+      expect(prefix(`columns:auto;`, 7)).toMatchInlineSnapshot(`"columns:auto;"`);
+      expect(prefix(`column-count:auto;`, 12)).toMatchInlineSnapshot(`"column-count:auto;"`);
+      expect(prefix(`column-fill:auto;`, 11)).toMatchInlineSnapshot(`"column-fill:auto;"`);
+      expect(prefix(`column-gap:auto;`, 10)).toMatchInlineSnapshot(`"column-gap:auto;"`);
+      expect(prefix(`column-rule:auto;`, 11)).toMatchInlineSnapshot(`"column-rule:auto;"`);
+      expect(prefix(`column-rule-color:auto;`, 17)).toMatchInlineSnapshot(`"column-rule-color:auto;"`);
+      expect(prefix(`column-rule-style:auto;`, 17)).toMatchInlineSnapshot(`"column-rule-style:auto;"`);
+      expect(prefix(`column-rule-width:auto;`, 17)).toMatchInlineSnapshot(`"column-rule-width:auto;"`);
+      expect(prefix(`column-span:auto;`, 11)).toMatchInlineSnapshot(`"column-span:auto;"`);
+      expect(prefix(`column-width:auto;`, 12)).toMatchInlineSnapshot(`"column-width:auto;"`);
+    });
+
+    test('text', () => {
+      expect(prefix(`text-align:left;`, 10)).toMatchInlineSnapshot(`"text-align:left;"`);
+      expect(prefix(`text-transform:none;`, 14)).toMatchInlineSnapshot(`"text-transform:none;"`);
+      expect(prefix(`text-shadow:none;`, 11)).toMatchInlineSnapshot(`"text-shadow:none;"`);
+      expect(prefix(`text-size-adjust:none;`, 16)).toMatchInlineSnapshot(`"text-size-adjust:none;"`);
+      expect(prefix(`text-decoration:none;`, 15)).toMatchInlineSnapshot(`"text-decoration:none;"`);
+    });
+
+    test('filter', () => {
+      expect(prefix(`filter:grayscale(100%);`, 6)).toMatchInlineSnapshot(`"filter:grayscale(100%);"`);
+      expect(prefix(`fill:red;`, 4)).toMatchInlineSnapshot(`"fill:red;"`);
+    });
+
+    test('position', () => {
+      expect(prefix(`position:relative;`, 8)).toMatchInlineSnapshot(`"position:relative;"`);
+      expect(prefix(`position:static;`, 8)).toMatchInlineSnapshot(`"position:static;"`);
+      expect(prefix(`position:fixed;`, 8)).toMatchInlineSnapshot(`"position:fixed;"`);
+      expect(prefix(`position:absolute;`, 8)).toMatchInlineSnapshot(`"position:absolute;"`);
+
+      expect(prefix(`position:sticky;`, 8)).toMatchInlineSnapshot(`"position:sticky;"`);
+      expect(prefix(`position:sticky!important;`, 8)).toMatchInlineSnapshot(`"position:sticky!important;"`);
+      expect(prefix(`position:sticky !important;`, 8)).toMatchInlineSnapshot(`"position:sticky !important;"`);
+      expect(prefix(`position:sticky      !important;`, 8)).toMatchInlineSnapshot(`"position:sticky      !important;"`);
+    });
+
+    test('size', () => {
+      expect(prefix(`width:auto;`, 5)).toMatchInlineSnapshot(`"width:auto;"`);
+      expect(prefix(`width:unset;`, 5)).toMatchInlineSnapshot(`"width:unset;"`);
+      expect(prefix(`width:initial;`, 5)).toMatchInlineSnapshot(`"width:initial;"`);
+      expect(prefix(`width:inherit;`, 5)).toMatchInlineSnapshot(`"width:inherit;"`);
+      expect(prefix(`width:10;`, 5)).toMatchInlineSnapshot(`"width:10;"`);
+      expect(prefix(`width:min();`, 5)).toMatchInlineSnapshot(`"width:min();"`);
+      expect(prefix(`width:var(--foo-content);`, 5)).toMatchInlineSnapshot(`"width:var(--foo-content);"`);
+      expect(prefix(`width:var(-content);`, 5)).toMatchInlineSnapshot(`"width:var(-content);"`);
+      expect(prefix(`width:var(--max-content);`, 5)).toMatchInlineSnapshot(`"width:var(--max-content);"`);
+      expect(prefix(`width:--max-content;`, 5)).toMatchInlineSnapshot(`"width:--max-content;"`);
+      expect(prefix(`width:fit-content;`, 5)).toMatchInlineSnapshot(`"width:fit-content;"`);
+      expect(prefix(`width:stackWidth;`, 5)).toMatchInlineSnapshot(`"width:stackWidth;"`);
+      expect(prefix(`min-width:max-content;`, 9)).toMatchInlineSnapshot(`"min-width:max-content;"`);
+      expect(prefix(`max-width:min-content;`, 9)).toMatchInlineSnapshot(`"max-width:min-content;"`);
+      expect(prefix(`height:fill-available;`, 6)).toMatchInlineSnapshot(
+        `"height:-webkit-fill-available;height:-moz-available;height:fill-available;"`,
+      );
+      expect(prefix(`min-block-size:max-content;`, 14)).toMatchInlineSnapshot(`"min-block-size:max-content;"`);
+      expect(prefix(`min-inline-size:max-content;`, 15)).toMatchInlineSnapshot(`"min-inline-size:max-content;"`);
+      expect(prefix(`max-height:fit-content;`, 10)).toMatchInlineSnapshot(`"max-height:fit-content;"`);
+      expect(prefix(`width:max(250px, 100px);`, 5)).toMatchInlineSnapshot(`"width:max(250px, 100px);"`);
+      expect(prefix(`height:min(150px, 200px);`, 6)).toMatchInlineSnapshot(`"height:min(150px, 200px);"`);
+      expect(prefix(`min-width:min(100px, 50px);`, 9)).toMatchInlineSnapshot(`"min-width:min(100px, 50px);"`);
+      expect(prefix(`max-width:max(150px, 200px);`, 9)).toMatchInlineSnapshot(`"max-width:max(150px, 200px);"`);
+      expect(prefix(`min-height:max(100px, 50px);`, 10)).toMatchInlineSnapshot(`"min-height:max(100px, 50px);"`);
+      expect(prefix(`max-height:min(150px, 200px);`, 10)).toMatchInlineSnapshot(`"max-height:min(150px, 200px);"`);
+    });
+
+    test('background-clip', () => {
+      expect(prefix(`background-clip:text;`, 15)).toMatchInlineSnapshot(`"background-clip:text;"`);
+    });
+
+    test('animation', () => {
+      expect(prefix(`animation:inherit;`, 9)).toMatchInlineSnapshot(`"animation:inherit;"`);
+      expect(prefix(`animation-duration:0.6s;`, 18)).toMatchInlineSnapshot(`"animation-duration:0.6s;"`);
+      expect(prefix(`animation-name:slidein;`, 14)).toMatchInlineSnapshot(`"animation-name:slidein;"`);
+      expect(prefix(`animation-iteration-count:infinite;`, 25)).toMatchInlineSnapshot(
+        `"animation-iteration-count:infinite;"`,
+      );
+      expect(prefix(`animation-timing-function:cubic-bezier(0.1,0.7,1.0,0.1);`, 25)).toMatchInlineSnapshot(
+        `"animation-timing-function:cubic-bezier(0.1,0.7,1.0,0.1);"`,
+      );
+    });
+
+    test('grid', () => {
+      expect(prefix('display:grid;', 7)).toMatchInlineSnapshot(`"display:grid;"`);
+      expect(prefix('display:inline-grid;', 7)).toMatchInlineSnapshot(`"display:inline-grid;"`);
+      expect(prefix('display:inline-grid!important;', 7)).toMatchInlineSnapshot(`"display:inline-grid!important;"`);
+      expect(prefix('display:inline-grid !important;', 7)).toMatchInlineSnapshot(`"display:inline-grid !important;"`);
+      expect(prefix(`align-self:value;`, 10)).toMatchInlineSnapshot(`"align-self:value;"`);
+      expect(prefix(`align-self:safe center;`, 10)).toMatchInlineSnapshot(`"align-self:safe center;"`);
+      expect(prefix('align-self:stretch;', 10)).toMatchInlineSnapshot(`"align-self:stretch;"`);
+      expect(prefix('align-self:start;', 10)).toMatchInlineSnapshot(`"align-self:start;"`);
+      expect(prefix('align-self:flex-start;', 12)).toMatchInlineSnapshot(`"align-self:flex-start;"`);
+      expect(prefix('justify-self:end;', 12)).toMatchInlineSnapshot(`"justify-self:end;"`);
+      expect(prefix('justify-self:self-end;', 12)).toMatchInlineSnapshot(`"justify-self:self-end;"`);
+      expect(prefix('justify-self:flex-start;', 12)).toMatchInlineSnapshot(`"justify-self:flex-start;"`);
+      expect(prefix('justify-self:baseline;', 12)).toMatchInlineSnapshot(`"justify-self:baseline;"`);
+      expect(prefix('justify-self:safe center;', 12)).toMatchInlineSnapshot(`"justify-self:safe center;"`);
+      expect(prefix('grid-template-columns:1fr auto;', 21)).toMatchInlineSnapshot(`"grid-template-columns:1fr auto;"`);
+      expect(prefix('grid-template-columns:1fr [header content] auto;', 21)).toMatchInlineSnapshot(
+        `"grid-template-columns:1fr [header content] auto;"`,
+      );
+      expect(prefix('grid-template-rows:1fr auto;', 18)).toMatchInlineSnapshot(`"grid-template-rows:1fr auto;"`);
+      // grid-(column|row) - simple position value
+      expect(prefix('grid-column:5;', 11)).toMatchInlineSnapshot(`"grid-column:5;"`);
+      expect(prefix('grid-column:20;', 11)).toMatchInlineSnapshot(`"grid-column:20;"`);
+      expect(prefix('grid-row:3;', 8)).toMatchInlineSnapshot(`"grid-row:3;"`);
+      expect(prefix('grid-row:17;', 8)).toMatchInlineSnapshot(`"grid-row:17;"`);
+      // grid-(column|row) - expand short hand
+      expect(prefix('grid-column:3 / 5;', 11)).toMatchInlineSnapshot(`"grid-column:3 / 5;"`);
+      expect(prefix('grid-column:3 / span 1;', 11)).toMatchInlineSnapshot(`"grid-column:3 / span 1;"`);
+      expect(prefix('grid-row:2 / 7;', 8)).toMatchInlineSnapshot(`"grid-row:2 / 7;"`);
+      expect(prefix('grid-row:2 / span 3;', 8)).toMatchInlineSnapshot(`"grid-row:2 / span 3;"`);
+      expect(prefix('grid-row:2 / span 3!important;', 8)).toMatchInlineSnapshot(`"grid-row:2 / span 3!important;"`);
+      // grid-column - ignore non-numeric values (IE11 doesn't support line-names)
+      expect(prefix('grid-column:main-start / main-end;', 11)).toMatchInlineSnapshot(
+        `"grid-column:main-start / main-end;"`,
+      );
+      expect(prefix('grid-row:main-start / main-end;', 11)).toMatchInlineSnapshot(`"grid-row:main-start / main-end;"`);
+      expect(prefix('grid-row:main-start / main-end!important;', 11)).toMatchInlineSnapshot(
+        `"grid-row:main-start / main-end!important;"`,
+      );
+    });
+
+    test('scroll-snap', () => {
+      expect(prefix(`scroll-snap-type:none;`, 16)).toMatchInlineSnapshot(`"scroll-snap-type:none;"`);
+      expect(prefix(`scroll-margin:0;`, 13)).toMatchInlineSnapshot(`"scroll-margin:0;"`);
+      expect(prefix(`scroll-margin-top:0;`, 17)).toMatchInlineSnapshot(`"scroll-margin-top:0;"`);
+      expect(prefix(`scroll-margin-right:0;`, 19)).toMatchInlineSnapshot(`"scroll-margin-right:0;"`);
+      expect(prefix(`scroll-margin-bottom:0;`, 20)).toMatchInlineSnapshot(`"scroll-margin-bottom:0;"`);
+      expect(prefix(`scroll-margin-left:0;`, 18)).toMatchInlineSnapshot(`"scroll-margin-left:0;"`);
+    });
+  });
+});

--- a/packages/core/src/runtime/prefixer.ts
+++ b/packages/core/src/runtime/prefixer.ts
@@ -1,0 +1,161 @@
+/* eslint-disable no-fallthrough */
+import {
+  hash,
+  charat,
+  strlen,
+  indexof,
+  replace,
+  match,
+  MS,
+  MOZ,
+  WEBKIT,
+  Element,
+  copy,
+  serialize,
+  DECLARATION,
+  RULESET,
+  combine,
+  Middleware,
+} from 'stylis';
+
+export function prefix(value: string, length: number, children?: Element[]): string {
+  switch (hash(value, length)) {
+    // color-adjust
+    case 5103:
+      return WEBKIT + 'print-' + value + value;
+    //   backface-visibility, column, box-decoration-break
+    case 3191:
+    case 6645:
+    case 3005:
+    // mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite,
+    case 6391:
+    case 5879:
+    case 5623:
+    case 6135:
+    case 4599:
+    case 4855:
+      return WEBKIT + value + value;
+    // tab-size
+    case 4789:
+      return MOZ + value + value;
+    // appearance, user-select, hyphens
+    case 5349:
+    case 4246:
+    case 6968:
+      return WEBKIT + value + MOZ + value + MS + value + value;
+    // cursor
+    // @ts-expect-error fall through is intentional here
+    case 6187:
+      if (!match(value, /grab/)) {
+        return (
+          replace(replace(replace(value, /(zoom-|grab)/, WEBKIT + '$1'), /(image-set)/, WEBKIT + '$1'), value, '') +
+          value
+        );
+      }
+    // background, background-image
+    case 5495:
+    case 3959:
+      return replace(value, /(image-set\([^]*)/, WEBKIT + '$1' + '$`$1');
+    // (margin|padding)-inline-(start|end)
+    case 4095:
+    case 3583:
+    case 4068:
+    case 2532:
+      return replace(value, /(.+)-inline(.+)/, WEBKIT + '$1$2') + value;
+    // (min|max)?(width|height|inline-size|block-size)
+    case 8116:
+    case 7059:
+    case 5753:
+    case 5535:
+    case 5445:
+    case 5701:
+    case 4933:
+    case 4677:
+    case 5533:
+    case 5789:
+    case 5021:
+    case 4765:
+      // stretch fill-available
+      if (strlen(value) - 1 - length > 6)
+        switch (charat(value, length + 1)) {
+          // (f)ill-available
+          // @ts-expect-error fall through is intentional here
+          case 102:
+            if (charat(value, length + 3) === 108) {
+              return (
+                replace(
+                  value,
+                  /(.+:)(.+)-([^]+)/,
+                  '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + (charat(value, length + 3) == 108 ? '$3' : '$2-$3'),
+                ) + value
+              );
+            }
+          // (s)tretch
+          case 115:
+            return ~indexof(value, 'stretch')
+              ? prefix(replace(value, 'stretch', 'fill-available'), length, children) + value
+              : value;
+        }
+      break;
+  }
+
+  return value;
+}
+
+/**
+ * @param {object} element
+ * @param {number} index
+ * @param {object[]} children
+ * @param {function} callback
+ */
+export function prefixer(
+  element: Element,
+  index: number,
+  children: Element[],
+  callback: Middleware,
+): string | undefined {
+  if (element.length > -1)
+    if (!element.return)
+      switch (element.type) {
+        case DECLARATION:
+          element.return = prefix(element.value, element.length, children);
+          return;
+        case RULESET:
+          if (element.length)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            return combine(element.props, function (value) {
+              switch (match(value, /(::plac\w+|:read-\w+)/)) {
+                // :read-(only|write)
+                case ':read-only':
+                case ':read-write':
+                  return serialize(
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    [copy(element, { props: [replace(value, /:(read-\w+)/, ':' + MOZ + '$1')] })],
+                    callback,
+                  );
+                // :placeholder
+                case '::placeholder':
+                  return serialize(
+                    [
+                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                      // @ts-ignore
+                      copy(element, { props: [replace(value, /:(plac\w+)/, ':' + WEBKIT + 'input-$1')] }),
+                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                      // @ts-ignore
+                      copy(element, { props: [replace(value, /:(plac\w+)/, ':' + MOZ + '$1')] }),
+                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                      // @ts-ignore
+                      copy(element, { props: [replace(value, /:(plac\w+)/, MS + 'input-$1')] }),
+                    ],
+                    callback,
+                  );
+              }
+
+              return '';
+            });
+      }
+
+  return undefined;
+}

--- a/packages/core/src/runtime/prefixer.ts
+++ b/packages/core/src/runtime/prefixer.ts
@@ -55,6 +55,7 @@ export function prefix(value: string, length: number, children?: Element[]): str
     // background, background-image
     case 5495:
     case 3959:
+      // eslint-disable-next-line no-useless-concat
       return replace(value, /(image-set\([^]*)/, WEBKIT + '$1' + '$`$1');
     // (margin|padding)-inline-(start|end)
     case 4095:
@@ -86,6 +87,7 @@ export function prefix(value: string, length: number, children?: Element[]): str
                 replace(
                   value,
                   /(.+:)(.+)-([^]+)/,
+                  // eslint-disable-next-line no-useless-concat, eqeqeq
                   '$1' + WEBKIT + '$2-$3' + '$1' + MOZ + (charat(value, length + 3) == 108 ? '$3' : '$2-$3'),
                 ) + value
               );

--- a/packages/core/src/runtime/resolveResetStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.test.ts
@@ -243,7 +243,6 @@ describe('resolveResetStyleRules', () => {
 
       expect(result).toMatchInlineSnapshot(`
         .reh730q {
-          -webkit-animation-name: foo;
           animation-name: foo;
         }
       `);
@@ -258,25 +257,8 @@ describe('resolveResetStyleRules', () => {
       });
 
       expect(result).toMatchInlineSnapshot(`
-        .r9hyr5r {
-          -webkit-animation-name: r1kgwxhb;
+        .rgmpmil {
           animation-name: r1kgwxhb;
-        }
-        @-webkit-keyframes r1kgwxhb {
-          from {
-            height: 10px;
-          }
-          to {
-            height: 20px;
-          }
-        }
-        @-webkit-keyframes r1kgwxhb {
-          from {
-            height: 10px;
-          }
-          to {
-            height: 20px;
-          }
         }
         @keyframes r1kgwxhb {
           from {
@@ -287,7 +269,6 @@ describe('resolveResetStyleRules', () => {
           }
         }
         .r1u04j3e {
-          -webkit-animation-name: r1kgwxhb;
           animation-name: r1kgwxhb;
         }
       `);
@@ -308,25 +289,8 @@ describe('resolveResetStyleRules', () => {
       });
 
       expect(result).toMatchInlineSnapshot(`
-        .r14v303j {
-          -webkit-animation-name: r1sekkel, r5j8bii;
+        .rw8vs22 {
           animation-name: r1sekkel, r5j8bii;
-        }
-        @-webkit-keyframes r1sekkel {
-          from {
-            top: 0;
-          }
-          to {
-            top: 100px;
-          }
-        }
-        @-webkit-keyframes r1sekkel {
-          from {
-            top: 0;
-          }
-          to {
-            top: 100px;
-          }
         }
         @keyframes r1sekkel {
           from {
@@ -334,22 +298,6 @@ describe('resolveResetStyleRules', () => {
           }
           to {
             top: 100px;
-          }
-        }
-        @-webkit-keyframes r5j8bii {
-          from {
-            opacity: 0;
-          }
-          to {
-            opacity: 1;
-          }
-        }
-        @-webkit-keyframes r5j8bii {
-          from {
-            opacity: 0;
-          }
-          to {
-            opacity: 1;
           }
         }
         @keyframes r5j8bii {
@@ -361,7 +309,6 @@ describe('resolveResetStyleRules', () => {
           }
         }
         .rcoo9tn {
-          -webkit-animation-name: r1sekkel, r5j8bii;
           animation-name: r1sekkel, r5j8bii;
         }
       `);

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -149,9 +149,6 @@ describe('resolveStyleRules', () => {
     it('performs vendor prefixing', () => {
       expect(resolveStyleRules({ display: 'flex' })).toMatchInlineSnapshot(`
         .f22iagw {
-          display: -webkit-box;
-          display: -webkit-flex;
-          display: -ms-flexbox;
           display: flex;
         }
       `);
@@ -688,15 +685,12 @@ describe('resolveStyleRules', () => {
         }),
       ).toMatchInlineSnapshot(`
         .fc59ano {
-          -webkit-animation-name: fade-in slide-out;
           animation-name: fade-in slide-out;
         }
         .f1cpbl36 {
-          -webkit-animation-iteration-count: infinite;
           animation-iteration-count: infinite;
         }
         .f1t9cprh {
-          -webkit-animation-duration: 5s;
           animation-duration: 5s;
         }
       `);
@@ -717,76 +711,32 @@ describe('resolveStyleRules', () => {
           animationDuration: '5s',
         }),
       ).toMatchInlineSnapshot(`
-        @-webkit-keyframes f1q8eu9e {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(360deg);
-            -moz-transform: rotate(360deg);
-            -ms-transform: rotate(360deg);
-            transform: rotate(360deg);
-          }
-        }
-        @-webkit-keyframes f55c0se {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(-360deg);
-            -moz-transform: rotate(-360deg);
-            -ms-transform: rotate(-360deg);
-            transform: rotate(-360deg);
-          }
-        }
         @keyframes f1q8eu9e {
           from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
             transform: rotate(0deg);
           }
           to {
-            -webkit-transform: rotate(360deg);
-            -moz-transform: rotate(360deg);
-            -ms-transform: rotate(360deg);
             transform: rotate(360deg);
           }
         }
         @keyframes f55c0se {
           from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
             transform: rotate(0deg);
           }
           to {
-            -webkit-transform: rotate(-360deg);
-            -moz-transform: rotate(-360deg);
-            -ms-transform: rotate(-360deg);
             transform: rotate(-360deg);
           }
         }
         .f1g6ul6r {
-          -webkit-animation-name: f1q8eu9e;
           animation-name: f1q8eu9e;
         }
         .f1fp4ujf {
-          -webkit-animation-name: f55c0se;
           animation-name: f55c0se;
         }
         .f1cpbl36 {
-          -webkit-animation-iteration-count: infinite;
           animation-iteration-count: infinite;
         }
         .f1t9cprh {
-          -webkit-animation-duration: 5s;
           animation-duration: 5s;
         }
       `);
@@ -813,72 +763,25 @@ describe('resolveStyleRules', () => {
               },
             },
           ],
+
           animationIterationCount: 'infinite',
           animationDuration: '5s',
         }),
       ).toMatchInlineSnapshot(`
-        @-webkit-keyframes f1q8eu9e {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(360deg);
-            -moz-transform: rotate(360deg);
-            -ms-transform: rotate(360deg);
-            transform: rotate(360deg);
-          }
-        }
-        @-webkit-keyframes f55c0se {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(-360deg);
-            -moz-transform: rotate(-360deg);
-            -ms-transform: rotate(-360deg);
-            transform: rotate(-360deg);
-          }
-        }
         @keyframes f1q8eu9e {
           from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
             transform: rotate(0deg);
           }
           to {
-            -webkit-transform: rotate(360deg);
-            -moz-transform: rotate(360deg);
-            -ms-transform: rotate(360deg);
             transform: rotate(360deg);
           }
         }
         @keyframes f55c0se {
           from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
             transform: rotate(0deg);
           }
           to {
-            -webkit-transform: rotate(-360deg);
-            -moz-transform: rotate(-360deg);
-            -ms-transform: rotate(-360deg);
             transform: rotate(-360deg);
-          }
-        }
-        @-webkit-keyframes f5j8bii {
-          from {
-            opacity: 0;
-          }
-          to {
-            opacity: 1;
           }
         }
         @keyframes f5j8bii {
@@ -890,19 +793,15 @@ describe('resolveStyleRules', () => {
           }
         }
         .fng7zue {
-          -webkit-animation-name: f1q8eu9e, f5j8bii;
           animation-name: f1q8eu9e, f5j8bii;
         }
         .f12eevt1 {
-          -webkit-animation-name: f55c0se, f5j8bii;
           animation-name: f55c0se, f5j8bii;
         }
         .f1cpbl36 {
-          -webkit-animation-iteration-count: infinite;
           animation-iteration-count: infinite;
         }
         .f1t9cprh {
-          -webkit-animation-duration: 5s;
           animation-duration: 5s;
         }
       `);

--- a/packages/react/src/createDOMRenderer.test.tsx
+++ b/packages/react/src/createDOMRenderer.test.tsx
@@ -93,9 +93,9 @@ describe('createDOMRenderer', () => {
     // - makeStyles
     //   - "animationName"
     //   - "color"
-    //   - @keyframes + prefixed
+    //   - @keyframes
     //   - @media
-    expect(Object.keys(clientRenderer.insertionCache)).toHaveLength(7);
+    expect(Object.keys(clientRenderer.insertionCache)).toHaveLength(6);
     insertRules.forEach(insertRule => {
       expect(insertRule).not.toHaveBeenCalled();
     });

--- a/packages/react/src/renderToStyleElements-node.test.tsx
+++ b/packages/react/src/renderToStyleElements-node.test.tsx
@@ -243,67 +243,25 @@ describe('renderToStyleElements (node)', () => {
       expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
               <style data-make-styles-bucket="d" data-make-styles-rehydration="true">
                 .f1g6ul6r {
-                  -webkit-animation-name: f1q8eu9e;
                   animation-name: f1q8eu9e;
                 }
                 .f1fp4ujf {
-                  -webkit-animation-name: f55c0se;
                   animation-name: f55c0se;
                 }</style
               ><style data-make-styles-bucket="k" data-make-styles-rehydration="true">
-                @-webkit-keyframes f1q8eu9e {
-                  from {
-                    -webkit-transform: rotate(0deg);
-                    -moz-transform: rotate(0deg);
-                    -ms-transform: rotate(0deg);
-                    transform: rotate(0deg);
-                  }
-                  to {
-                    -webkit-transform: rotate(360deg);
-                    -moz-transform: rotate(360deg);
-                    -ms-transform: rotate(360deg);
-                    transform: rotate(360deg);
-                  }
-                }
-                @-webkit-keyframes f55c0se {
-                  from {
-                    -webkit-transform: rotate(0deg);
-                    -moz-transform: rotate(0deg);
-                    -ms-transform: rotate(0deg);
-                    transform: rotate(0deg);
-                  }
-                  to {
-                    -webkit-transform: rotate(-360deg);
-                    -moz-transform: rotate(-360deg);
-                    -ms-transform: rotate(-360deg);
-                    transform: rotate(-360deg);
-                  }
-                }
                 @keyframes f1q8eu9e {
                   from {
-                    -webkit-transform: rotate(0deg);
-                    -moz-transform: rotate(0deg);
-                    -ms-transform: rotate(0deg);
                     transform: rotate(0deg);
                   }
                   to {
-                    -webkit-transform: rotate(360deg);
-                    -moz-transform: rotate(360deg);
-                    -ms-transform: rotate(360deg);
                     transform: rotate(360deg);
                   }
                 }
                 @keyframes f55c0se {
                   from {
-                    -webkit-transform: rotate(0deg);
-                    -moz-transform: rotate(0deg);
-                    -ms-transform: rotate(0deg);
                     transform: rotate(0deg);
                   }
                   to {
-                    -webkit-transform: rotate(-360deg);
-                    -moz-transform: rotate(-360deg);
-                    -ms-transform: rotate(-360deg);
                     transform: rotate(-360deg);
                   }
                 }


### PR DESCRIPTION
Copies the source from the [stylis prefixer](https://github.com/thysultan/stylis/blob/master/src/Prefixer.js) and updates it so that prefixing is only applied according the the browser support matrix. We follow the [browser support matrix](https://github.com/microsoft/fluentui/blob/master/rfcs/shared/build-system/06-browser-support-for-v9.md) of Fluent UI

Fixes #379