### PR TITLE
feat(core): support variadic arguments in border* shorthands

### DIFF
--- a/change/@griffel-core-970bda89-cefa-47c5-962d-a558027ec2cc.json
+++ b/change/@griffel-core-970bda89-cefa-47c5-962d-a558027ec2cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: support variadic arguments in border* shorthands",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/shorthands/border.test.ts
+++ b/packages/core/src/shorthands/border.test.ts
@@ -10,6 +10,15 @@ describe('border', () => {
     });
   });
 
+  it('for a given style', () => {
+    expect(border('none')).toEqual({
+      borderBottomStyle: 'none',
+      borderLeftStyle: 'none',
+      borderRightStyle: 'none',
+      borderTopStyle: 'none',
+    });
+  });
+
   it('for a given width and style', () => {
     expect(border('2px', 'solid')).toEqual({
       borderBottomWidth: '2px',
@@ -23,6 +32,19 @@ describe('border', () => {
     });
   });
 
+  it('for a given style and width', () => {
+    expect(border('solid', '2px')).toEqual({
+      borderBottomStyle: 'solid',
+      borderLeftStyle: 'solid',
+      borderRightStyle: 'solid',
+      borderTopStyle: 'solid',
+      borderBottomWidth: '2px',
+      borderLeftWidth: '2px',
+      borderRightWidth: '2px',
+      borderTopWidth: '2px',
+    });
+  });
+
   it('for a given width, style and color', () => {
     expect(border('2px', 'solid', 'red')).toEqual({
       borderBottomWidth: '2px',
@@ -33,6 +55,23 @@ describe('border', () => {
       borderLeftStyle: 'solid',
       borderRightStyle: 'solid',
       borderTopStyle: 'solid',
+      borderBottomColor: 'red',
+      borderLeftColor: 'red',
+      borderRightColor: 'red',
+      borderTopColor: 'red',
+    });
+  });
+
+  it('for a given style, width and color', () => {
+    expect(border('solid', '2px', 'red')).toEqual({
+      borderBottomStyle: 'solid',
+      borderLeftStyle: 'solid',
+      borderRightStyle: 'solid',
+      borderTopStyle: 'solid',
+      borderBottomWidth: '2px',
+      borderLeftWidth: '2px',
+      borderRightWidth: '2px',
+      borderTopWidth: '2px',
       borderBottomColor: 'red',
       borderLeftColor: 'red',
       borderRightColor: 'red',

--- a/packages/core/src/shorthands/border.ts
+++ b/packages/core/src/shorthands/border.ts
@@ -1,8 +1,10 @@
 import type { GriffelStyle } from '@griffel/style-types';
+
 import { borderWidth } from './borderWidth';
 import { borderStyle } from './borderStyle';
 import { borderColor } from './borderColor';
 import type { BorderColorInput, BorderStyleInput, BorderWidthInput } from './types';
+import { isBorderStyle } from './utils';
 
 type BorderStyle = Pick<
   GriffelStyle,
@@ -29,15 +31,28 @@ export function border(width: BorderWidthInput, style: BorderStyleInput, color: 
  *
  * @example
  *  border('2px')
+ *  border('solid')
  *  border('2px', 'solid')
+ *  border('solid', '2px')
  *  border('2px', 'solid', 'red')
+ *  border('solid', '2px', 'red')
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/border
  */
-export function border(...values: [BorderWidthInput, BorderStyleInput?, BorderColorInput?]): BorderStyle {
+export function border(
+  ...values: [BorderWidthInput | BorderStyleInput, (BorderWidthInput | BorderStyleInput)?, BorderColorInput?]
+): BorderStyle {
+  if (isBorderStyle(values[0])) {
+    return {
+      ...borderStyle(values[0]),
+      ...(values[1] && borderWidth(values[1])),
+      ...(values[2] && borderColor(values[2])),
+    };
+  }
+
   return {
     ...borderWidth(values[0]),
-    ...(values[1] && borderStyle(values[1])),
+    ...(values[1] && borderStyle(values[1] as BorderStyleInput)),
     ...(values[2] && borderColor(values[2])),
   };
 }

--- a/packages/core/src/shorthands/borderBottom.test.ts
+++ b/packages/core/src/shorthands/borderBottom.test.ts
@@ -7,8 +7,21 @@ describe('borderBottom', () => {
     });
   });
 
+  it('for a given style', () => {
+    expect(borderBottom('none')).toEqual({
+      borderBottomStyle: 'none',
+    });
+  });
+
   it('for a given width and style', () => {
     expect(borderBottom('2px', 'solid')).toEqual({
+      borderBottomWidth: '2px',
+      borderBottomStyle: 'solid',
+    });
+  });
+
+  it('for a given style and width', () => {
+    expect(borderBottom('solid', '2px')).toEqual({
       borderBottomWidth: '2px',
       borderBottomStyle: 'solid',
     });
@@ -18,6 +31,14 @@ describe('borderBottom', () => {
     expect(borderBottom('2px', 'solid', 'red')).toEqual({
       borderBottomWidth: '2px',
       borderBottomStyle: 'solid',
+      borderBottomColor: 'red',
+    });
+  });
+
+  it('for a given style, width and color', () => {
+    expect(borderBottom('solid', '2px', 'red')).toEqual({
+      borderBottomStyle: 'solid',
+      borderBottomWidth: '2px',
       borderBottomColor: 'red',
     });
   });

--- a/packages/core/src/shorthands/borderBottom.ts
+++ b/packages/core/src/shorthands/borderBottom.ts
@@ -1,27 +1,49 @@
 import type { GriffelStyle } from '@griffel/style-types';
-import type { BorderColorInput, BorderStyleInput, BorderWidthInput } from './types';
 
-type BorderBottomStyle = Pick<GriffelStyle, 'borderBottomWidth' | 'borderBottomStyle' | 'borderBottomColor'>;
+import type { BorderColorInput, BorderStyleInput, BorderWidthInput } from './types';
+import { isBorderStyle } from './utils';
+
+type BorderBottomStyle = Pick<GriffelStyle, 'borderBottomColor' | 'borderBottomStyle' | 'borderBottomWidth'>;
 
 export function borderBottom(width: BorderWidthInput): BorderBottomStyle;
+export function borderBottom(style: BorderStyleInput): BorderBottomStyle;
 export function borderBottom(width: BorderWidthInput, style: BorderStyleInput): BorderBottomStyle;
+export function borderBottom(style: BorderStyleInput, width: BorderWidthInput): BorderBottomStyle;
 export function borderBottom(
   width: BorderWidthInput,
   style: BorderStyleInput,
   color: BorderColorInput,
 ): BorderBottomStyle;
+export function borderBottom(
+  style: BorderStyleInput,
+  width: BorderWidthInput,
+  color: BorderColorInput,
+): BorderBottomStyle;
 
 /**
- * A function that implements expansion for "border-bottom", it's simplified - check usage examples.
+ * A function that implements expansion for "border-Bottom", it's simplified - check usage examples.
  *
  * @example
  *  borderBottom('2px')
+ *  borderBottom('solid')
  *  borderBottom('2px', 'solid')
+ *  borderBottom('solid', '2px')
  *  borderBottom('2px', 'solid', 'red')
+ *  borderBottom('solid', '2px', 'red')
  *
- * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-Bottom
  */
-export function borderBottom(...values: [BorderWidthInput, BorderStyleInput?, BorderColorInput?]): BorderBottomStyle {
+export function borderBottom(
+  ...values: [BorderWidthInput | BorderStyleInput, (BorderWidthInput | BorderStyleInput)?, BorderColorInput?]
+): BorderBottomStyle {
+  if (isBorderStyle(values[0])) {
+    return {
+      borderBottomStyle: values[0],
+      ...(values[1] && ({ borderBottomWidth: values[1] } as BorderBottomStyle)),
+      ...(values[2] && { borderBottomColor: values[2] }),
+    };
+  }
+
   return {
     borderBottomWidth: values[0],
     ...(values[1] && ({ borderBottomStyle: values[1] } as BorderBottomStyle)),

--- a/packages/core/src/shorthands/borderLeft.test.ts
+++ b/packages/core/src/shorthands/borderLeft.test.ts
@@ -7,8 +7,21 @@ describe('borderLeft', () => {
     });
   });
 
+  it('for a given style', () => {
+    expect(borderLeft('none')).toEqual({
+      borderLeftStyle: 'none',
+    });
+  });
+
   it('for a given width and style', () => {
     expect(borderLeft('2px', 'solid')).toEqual({
+      borderLeftWidth: '2px',
+      borderLeftStyle: 'solid',
+    });
+  });
+
+  it('for a given style and width', () => {
+    expect(borderLeft('solid', '2px')).toEqual({
       borderLeftWidth: '2px',
       borderLeftStyle: 'solid',
     });
@@ -18,6 +31,14 @@ describe('borderLeft', () => {
     expect(borderLeft('2px', 'solid', 'red')).toEqual({
       borderLeftWidth: '2px',
       borderLeftStyle: 'solid',
+      borderLeftColor: 'red',
+    });
+  });
+
+  it('for a given style, width and color', () => {
+    expect(borderLeft('solid', '2px', 'red')).toEqual({
+      borderLeftStyle: 'solid',
+      borderLeftWidth: '2px',
       borderLeftColor: 'red',
     });
   });

--- a/packages/core/src/shorthands/borderLeft.ts
+++ b/packages/core/src/shorthands/borderLeft.ts
@@ -1,23 +1,41 @@
 import type { GriffelStyle } from '@griffel/style-types';
+
 import type { BorderColorInput, BorderStyleInput, BorderWidthInput } from './types';
+import { isBorderStyle } from './utils';
 
 type BorderLeftStyle = Pick<GriffelStyle, 'borderLeftColor' | 'borderLeftStyle' | 'borderLeftWidth'>;
 
 export function borderLeft(width: BorderWidthInput): BorderLeftStyle;
+export function borderLeft(style: BorderStyleInput): BorderLeftStyle;
 export function borderLeft(width: BorderWidthInput, style: BorderStyleInput): BorderLeftStyle;
+export function borderLeft(style: BorderStyleInput, width: BorderWidthInput): BorderLeftStyle;
 export function borderLeft(width: BorderWidthInput, style: BorderStyleInput, color: BorderColorInput): BorderLeftStyle;
+export function borderLeft(style: BorderStyleInput, width: BorderWidthInput, color: BorderColorInput): BorderLeftStyle;
 
 /**
  * A function that implements expansion for "border-left", it's simplified - check usage examples.
  *
  * @example
  *  borderLeft('2px')
+ *  borderLeft('solid')
  *  borderLeft('2px', 'solid')
+ *  borderLeft('solid', '2px')
  *  borderLeft('2px', 'solid', 'red')
+ *  borderLeft('solid', '2px', 'red')
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-left
  */
-export function borderLeft(...values: [BorderWidthInput, BorderStyleInput?, BorderColorInput?]): BorderLeftStyle {
+export function borderLeft(
+  ...values: [BorderWidthInput | BorderStyleInput, (BorderWidthInput | BorderStyleInput)?, BorderColorInput?]
+): BorderLeftStyle {
+  if (isBorderStyle(values[0])) {
+    return {
+      borderLeftStyle: values[0],
+      ...(values[1] && ({ borderLeftWidth: values[1] } as BorderLeftStyle)),
+      ...(values[2] && { borderLeftColor: values[2] }),
+    };
+  }
+
   return {
     borderLeftWidth: values[0],
     ...(values[1] && ({ borderLeftStyle: values[1] } as BorderLeftStyle)),

--- a/packages/core/src/shorthands/borderRight.test.ts
+++ b/packages/core/src/shorthands/borderRight.test.ts
@@ -7,8 +7,21 @@ describe('borderRight', () => {
     });
   });
 
+  it('for a given style', () => {
+    expect(borderRight('none')).toEqual({
+      borderRightStyle: 'none',
+    });
+  });
+
   it('for a given width and style', () => {
     expect(borderRight('2px', 'solid')).toEqual({
+      borderRightWidth: '2px',
+      borderRightStyle: 'solid',
+    });
+  });
+
+  it('for a given style and width', () => {
+    expect(borderRight('solid', '2px')).toEqual({
       borderRightWidth: '2px',
       borderRightStyle: 'solid',
     });
@@ -18,6 +31,14 @@ describe('borderRight', () => {
     expect(borderRight('2px', 'solid', 'red')).toEqual({
       borderRightWidth: '2px',
       borderRightStyle: 'solid',
+      borderRightColor: 'red',
+    });
+  });
+
+  it('for a given style, width and color', () => {
+    expect(borderRight('solid', '2px', 'red')).toEqual({
+      borderRightStyle: 'solid',
+      borderRightWidth: '2px',
       borderRightColor: 'red',
     });
   });

--- a/packages/core/src/shorthands/borderRight.ts
+++ b/packages/core/src/shorthands/borderRight.ts
@@ -1,13 +1,22 @@
 import type { GriffelStyle } from '@griffel/style-types';
+
 import type { BorderColorInput, BorderStyleInput, BorderWidthInput } from './types';
+import { isBorderStyle } from './utils';
 
 type BorderRightStyle = Pick<GriffelStyle, 'borderRightWidth' | 'borderRightStyle' | 'borderRightColor'>;
 
 export function borderRight(width: BorderWidthInput): BorderRightStyle;
+export function borderRight(style: BorderStyleInput): BorderRightStyle;
 export function borderRight(width: BorderWidthInput, style: BorderStyleInput): BorderRightStyle;
+export function borderRight(style: BorderStyleInput, width: BorderWidthInput): BorderRightStyle;
 export function borderRight(
   width: BorderWidthInput,
   style: BorderStyleInput,
+  color: BorderColorInput,
+): BorderRightStyle;
+export function borderRight(
+  style: BorderStyleInput,
+  width: BorderWidthInput,
   color: BorderColorInput,
 ): BorderRightStyle;
 
@@ -16,12 +25,25 @@ export function borderRight(
  *
  * @example
  *  borderRight('2px')
+ *  borderRight('solid')
  *  borderRight('2px', 'solid')
+ *  borderRight('solid', '2px')
  *  borderRight('2px', 'solid', 'red')
+ *  borderRight('solid', '2px', 'red')
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-right
  */
-export function borderRight(...values: [BorderWidthInput, BorderStyleInput?, BorderColorInput?]): BorderRightStyle {
+export function borderRight(
+  ...values: [BorderWidthInput | BorderStyleInput, (BorderWidthInput | BorderStyleInput)?, BorderColorInput?]
+): BorderRightStyle {
+  if (isBorderStyle(values[0])) {
+    return {
+      borderRightStyle: values[0],
+      ...(values[1] && { borderRightWidth: values[1] }),
+      ...(values[2] && { borderRightColor: values[2] }),
+    };
+  }
+
   return {
     borderRightWidth: values[0],
     ...(values[1] && ({ borderRightStyle: values[1] } as BorderRightStyle)),

--- a/packages/core/src/shorthands/borderTop.test.ts
+++ b/packages/core/src/shorthands/borderTop.test.ts
@@ -7,6 +7,12 @@ describe('borderTop', () => {
     });
   });
 
+  it('for a given style', () => {
+    expect(borderTop('none')).toEqual({
+      borderTopStyle: 'none',
+    });
+  });
+
   it('for a given width and style', () => {
     expect(borderTop('2px', 'solid')).toEqual({
       borderTopWidth: '2px',
@@ -14,8 +20,23 @@ describe('borderTop', () => {
     });
   });
 
+  it('for a given style and width', () => {
+    expect(borderTop('solid', '2px')).toEqual({
+      borderTopStyle: 'solid',
+      borderTopWidth: '2px',
+    });
+  });
+
   it('for a given width, style and color', () => {
     expect(borderTop('2px', 'solid', 'red')).toEqual({
+      borderTopWidth: '2px',
+      borderTopStyle: 'solid',
+      borderTopColor: 'red',
+    });
+  });
+
+  it('for a given style, width and color', () => {
+    expect(borderTop('solid', '2px', 'red')).toEqual({
       borderTopWidth: '2px',
       borderTopStyle: 'solid',
       borderTopColor: 'red',

--- a/packages/core/src/shorthands/borderTop.ts
+++ b/packages/core/src/shorthands/borderTop.ts
@@ -1,23 +1,41 @@
 import type { GriffelStyle } from '@griffel/style-types';
-import { BorderColorInput, BorderStyleInput, BorderWidthInput } from './types';
 
-type BorderTopStyle = Pick<GriffelStyle, 'borderTopWidth' | 'borderTopStyle' | 'borderTopColor'>;
+import type { BorderColorInput, BorderStyleInput, BorderWidthInput } from './types';
+import { isBorderStyle } from './utils';
+
+type BorderTopStyle = Pick<GriffelStyle, 'borderTopColor' | 'borderTopStyle' | 'borderTopWidth'>;
 
 export function borderTop(width: BorderWidthInput): BorderTopStyle;
+export function borderTop(style: BorderStyleInput): BorderTopStyle;
 export function borderTop(width: BorderWidthInput, style: BorderStyleInput): BorderTopStyle;
+export function borderTop(style: BorderStyleInput, width: BorderWidthInput): BorderTopStyle;
 export function borderTop(width: BorderWidthInput, style: BorderStyleInput, color: BorderColorInput): BorderTopStyle;
+export function borderTop(style: BorderStyleInput, width: BorderWidthInput, color: BorderColorInput): BorderTopStyle;
 
 /**
- * A function that implements expansion for "border-top", it's simplified - check usage examples.
+ * A function that implements expansion for "border-Top", it's simplified - check usage examples.
  *
  * @example
  *  borderTop('2px')
+ *  borderTop('solid')
  *  borderTop('2px', 'solid')
+ *  borderTop('solid', '2px')
  *  borderTop('2px', 'solid', 'red')
+ *  borderTop('solid', '2px', 'red')
  *
- * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-top
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-Top
  */
-export function borderTop(...values: [BorderWidthInput, BorderStyleInput?, BorderColorInput?]): BorderTopStyle {
+export function borderTop(
+  ...values: [BorderWidthInput | BorderStyleInput, (BorderWidthInput | BorderStyleInput)?, BorderColorInput?]
+): BorderTopStyle {
+  if (isBorderStyle(values[0])) {
+    return {
+      borderTopStyle: values[0],
+      ...(values[1] && ({ borderTopWidth: values[1] } as BorderTopStyle)),
+      ...(values[2] && { borderTopColor: values[2] }),
+    };
+  }
+
   return {
     borderTopWidth: values[0],
     ...(values[1] && ({ borderTopStyle: values[1] } as BorderTopStyle)),

--- a/packages/core/src/shorthands/utils.ts
+++ b/packages/core/src/shorthands/utils.ts
@@ -1,0 +1,19 @@
+import type { GriffelStylesCSSValue } from '@griffel/style-types';
+import * as CSS from 'csstype';
+
+const LINE_STYLES: CSS.DataType.LineStyle[] = [
+  'none',
+  'hidden',
+  'dotted',
+  'dashed',
+  'solid',
+  'double',
+  'groove',
+  'ridge',
+  'inset',
+  'outset',
+];
+
+export function isBorderStyle(value: GriffelStylesCSSValue | GriffelStylesCSSValue[]): value is CSS.DataType.LineStyle {
+  return LINE_STYLES.includes(value as CSS.DataType.LineStyle);
+}


### PR DESCRIPTION
This PR adds functionality to `border*` shorthands functions to support the different order of arguments. For example,

```diff
border('2px')
+border('solid')
+border('none')
border('2px', 'solid')
+border('solid', '2px')
border('2px', 'solid', 'red')
+border('solid', '2px', 'red')
```

Fixes #393.