### PR TITLE
chore: use modern APIs in tests

### DIFF
--- a/change/@griffel-react-43329235-82d9-463b-aebe-f0609c2617bc.json
+++ b/change/@griffel-react-43329235-82d9-463b-aebe-f0609c2617bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use modern APIs in tests",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/jest.config.ts
+++ b/packages/react/jest.config.ts
@@ -5,6 +5,9 @@ export default {
   transform: {
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/react/babel'] }],
   },
+  globals: {
+    IS_REACT_ACT_ENVIRONMENT: true,
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/packages/react',
 };

--- a/packages/react/src/makeResetStyles.test.tsx
+++ b/packages/react/src/makeResetStyles.test.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 
-import { makeStyles } from './makeStyles';
+import { makeResetStyles } from './makeResetStyles';
 
-describe('makeStyles', () => {
+describe('makeResetStyles', () => {
   it('works outside of React components', () => {
-    expect(() => makeStyles({ root: { color: 'red' } })).not.toThrow();
+    expect(() => makeResetStyles({ root: { color: 'red' } })).not.toThrow();
   });
 
   it('throws inside React components', () => {
@@ -14,14 +14,14 @@ describe('makeStyles', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const Example: React.FC = () => {
-      makeStyles({ root: { color: 'red' } });
+      makeResetStyles({ color: 'red' });
       return null;
     };
     const root = createRoot(document.createElement('div'));
 
-    expect(() => act(() => root.render(<Example />))).toThrow(/All makeStyles\(\) calls should be top level/);
+    expect(() => act(() => root.render(<Example />))).toThrow(/All makeResetStyles\(\) calls should be top level/);
 
     // Should not throw outside React components after rendering
-    expect(() => makeStyles({ root: { color: 'red' } })).not.toThrow();
+    expect(() => makeResetStyles({ color: 'red' })).not.toThrow();
   });
 });

--- a/packages/react/src/renderToStyleElements.test.tsx
+++ b/packages/react/src/renderToStyleElements.test.tsx
@@ -1,7 +1,9 @@
 import { createDOMRenderer, GriffelRenderer } from '@griffel/core';
 import * as prettier from 'prettier';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom/server';
+import { createRoot } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { act } from 'react-dom/test-utils';
 
 import { makeStyles } from './makeStyles';
 import { makeResetStyles } from './makeResetStyles';
@@ -43,14 +45,17 @@ describe('renderToStyleElements (DOM)', () => {
 
       return <div className={classes.root} />;
     };
+    const root = createRoot(document.createElement('div'));
 
-    ReactDOM.renderToStaticMarkup(
-      <RendererProvider renderer={renderer}>
-        <ExampleComponent />
-      </RendererProvider>,
-    );
+    act(() => {
+      root.render(
+        <RendererProvider renderer={renderer}>
+          <ExampleComponent />
+        </RendererProvider>,
+      );
+    });
 
-    expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
+    expect(renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
       <style data-make-styles-bucket="d" data-make-styles-rehydration="true">
         .fe3e8s9 {
           color: red;
@@ -71,14 +76,17 @@ describe('renderToStyleElements (DOM)', () => {
     const ExampleComponent: React.FC = () => {
       return <div className={useClassName()} />;
     };
+    const root = createRoot(document.createElement('div'));
 
-    ReactDOM.renderToStaticMarkup(
-      <RendererProvider renderer={renderer}>
-        <ExampleComponent />
-      </RendererProvider>,
-    );
+    act(() => {
+      root.render(
+        <RendererProvider renderer={renderer}>
+          <ExampleComponent />
+        </RendererProvider>,
+      );
+    });
 
-    expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
+    expect(renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
         <style data-make-styles-bucket="r" data-make-styles-rehydration="true">
           .r1tsu58y {
             color: red;


### PR DESCRIPTION
This modifies tests to use non-deprecated APIs from React 18. Also adds some new assertions to existing tests.