### PR TITLE
feat: insertionFactory API for @griffel/core

### DIFF
--- a/change/@griffel-core-80492b15-83a7-4ca1-8c1b-b5aeb0c3aa58.json
+++ b/change/@griffel-core-80492b15-83a7-4ca1-8c1b-b5aeb0c3aa58.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add API for styles insertion",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/__resetStyles.ts
+++ b/packages/core/src/__resetStyles.ts
@@ -1,25 +1,24 @@
 import { DEBUG_RESET_CLASSES } from './constants';
+import { insertionFactory } from './insertionFactory';
 import type { MakeResetStylesOptions } from './makeResetStyles';
+import type { GriffelInsertionFactory } from './types';
 
 /**
  * @internal
  */
-export function __resetStyles(ltrClassName: string, rtlClassName: string | null, cssRules: string[]) {
-  const insertionCache: Record<string, boolean> = {};
+export function __resetStyles(
+  ltrClassName: string,
+  rtlClassName: string | null,
+  cssRules: string[],
+  factory: GriffelInsertionFactory = insertionFactory,
+) {
+  const insertStyles = factory();
 
   function computeClassName(options: MakeResetStylesOptions): string {
     const { dir, renderer } = options;
+    const className = dir === 'ltr' ? ltrClassName : rtlClassName || ltrClassName;
 
-    const isLTR = dir === 'ltr';
-    // As RTL classes are different they should have a different cache key for insertion
-    const rendererId = isLTR ? renderer.id : renderer.id + 'r';
-
-    if (insertionCache[rendererId] === undefined) {
-      renderer.insertCSSRules({ r: cssRules! });
-      insertionCache[rendererId] = true;
-    }
-
-    const className = isLTR ? ltrClassName : rtlClassName || ltrClassName;
+    insertStyles(renderer, { r: cssRules });
 
     if (process.env.NODE_ENV !== 'production') {
       DEBUG_RESET_CLASSES[className] = 1;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,7 @@ export {
   StyleBucketName,
   // Util
   GriffelRenderer,
+  GriffelInsertionFactory,
 } from './types';
 
 // Private exports, are used by devtools

--- a/packages/core/src/insertionFactory.ts
+++ b/packages/core/src/insertionFactory.ts
@@ -1,0 +1,18 @@
+import type { CSSRulesByBucket, GriffelInsertionFactory, GriffelRenderer } from './types';
+
+/**
+ * Default implementation of insertion factory. Inserts styles only once per renderer and performs
+ * insertion immediately after styles computation.
+ *
+ * @internal
+ */
+export const insertionFactory: GriffelInsertionFactory = () => {
+  const insertionCache: Record<string, boolean> = {};
+
+  return function insertStyles(renderer: GriffelRenderer, cssRules: CSSRulesByBucket) {
+    if (insertionCache[renderer.id] === undefined) {
+      renderer.insertCSSRules(cssRules!);
+      insertionCache[renderer.id] = true;
+    }
+  };
+};

--- a/packages/core/src/makeStaticStyles.ts
+++ b/packages/core/src/makeStaticStyles.ts
@@ -1,31 +1,27 @@
 import type { GriffelStaticStyles } from '@griffel/style-types';
 
+import { insertionFactory } from './insertionFactory';
 import { resolveStaticStyleRules } from './runtime/resolveStaticStyleRules';
 import type { GriffelRenderer } from './types';
+import type { GriffelInsertionFactory } from './types';
 
 export interface MakeStaticStylesOptions {
   renderer: GriffelRenderer;
 }
 
-/**
- * Register static css.
- * @param styles - styles object or string.
- */
-export function makeStaticStyles(styles: GriffelStaticStyles | GriffelStaticStyles[]) {
-  const styleCache: Record<string, true> = {};
+export function makeStaticStyles(
+  styles: GriffelStaticStyles | GriffelStaticStyles[],
+  factory: GriffelInsertionFactory = insertionFactory,
+) {
+  const insertStyles = factory();
   const stylesSet: GriffelStaticStyles[] = Array.isArray(styles) ? styles : [styles];
 
   function useStaticStyles(options: MakeStaticStylesOptions): void {
-    const { renderer } = options;
-    const cacheKey = renderer.id;
-
-    if (!styleCache[cacheKey]) {
-      renderer.insertCSSRules({
-        // 👇 static rules should be inserted into default bucket
-        d: resolveStaticStyleRules(stylesSet),
-      });
-      styleCache[cacheKey] = true;
-    }
+    insertStyles(
+      options.renderer,
+      // 👇 static rules should be inserted into default bucket
+      { d: resolveStaticStyleRules(stylesSet) },
+    );
   }
 
   return useStaticStyles;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -87,6 +87,8 @@ export type CSSRulesByBucket = {
   c?: CSSBucketEntry[];
 };
 
+export type GriffelInsertionFactory = () => (renderer: GriffelRenderer, cssRules: CSSRulesByBucket) => void;
+
 /** @internal */
 export type CSSBucketEntry = string | [string, Record<string, unknown>];
 


### PR DESCRIPTION
This PR adds `insertionFactory` API to `@griffel/core` and related functions (`makeStyles`, `makeResetStyles`, etc.).

Every factory should return `insertStyles` function:

```ts
import type { GriffelInsertionFactory } from '@griffel/react'

const insertionFactory: GriffelInsertionFactory = () => {
  return function insertStyles() {
    /* do smth */
  }
}
```

While customization of insertion can be done by custom renderers (https://griffel.js.org/react/api/create-dom-renderer), the goal of this API is to allow customization of insertion process. For example, instead of inserting styles immediately it can be done via `useInsertionEffect()`.


```ts
import type { GriffelInsertionFactory } from '@griffel/react'

const insertionFactory: GriffelInsertionFactory = () => {
  return function insertStyles(renderer, cssRules) {
    React.useInsertionEffect(
      () => {
        renderer.insertRules(cssRules)
      },
      [renderer, cssRules]
  }
}
```