### PR TITLE
chore: bump @types/stylis

### DIFF
--- a/change/@griffel-core-7bc5ba3f-7967-411b-a0ce-d05321febf7f.json
+++ b/change/@griffel-core-7bc5ba3f-7967-411b-a0ce-d05321febf7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove unused ts-expect-error",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
     "@types/styled-components": "5.1.26",
-    "@types/stylis": "4.0.2",
+    "@types/stylis": "4.2.0",
     "@types/tmp": "0.2.3",
     "@types/webpack-env": "^1.17.0",
     "@types/yargs": "^17.0.10",

--- a/packages/core/src/runtime/stylis/sortClassesInAtRulesPlugin.ts
+++ b/packages/core/src/runtime/stylis/sortClassesInAtRulesPlugin.ts
@@ -1,9 +1,4 @@
-import {
-  // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65517
-  LAYER,
-  MEDIA,
-  SUPPORTS,
-} from 'stylis';
+import { LAYER, MEDIA, SUPPORTS } from 'stylis';
 import type { Middleware } from 'stylis';
 
 export const sortClassesInAtRulesPlugin: Middleware = element => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,10 +6576,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/stylis@npm:4.0.2":
-  version: 4.0.2
-  resolution: "@types/stylis@npm:4.0.2"
-  checksum: 5461290afd6e7fbbd713f4896b4c586fa6f3072ef8addcb062feaf112a50168477df98ab474d9b603b19b879696aab6932c5f0bb3cda7472ab9c1622ee7fea60
+"@types/stylis@npm:4.2.0":
+  version: 4.2.0
+  resolution: "@types/stylis@npm:4.2.0"
+  checksum: 02a47584acd2fcb664f7d8270a69686c83752bdfb855f804015d33116a2b09c0b2ac535213a4a7b6d3a78b2915b22b4024cce067ae979beee0e4f8f5fdbc26a9
   languageName: node
   linkType: hard
 
@@ -14203,7 +14203,7 @@ __metadata:
     "@types/react": 18.0.25
     "@types/react-dom": 18.0.9
     "@types/styled-components": 5.1.26
-    "@types/stylis": 4.0.2
+    "@types/stylis": 4.2.0
     "@types/tmp": 0.2.3
     "@types/webpack-env": ^1.17.0
     "@types/yargs": ^17.0.10


### PR DESCRIPTION
This PR bumps `@types/stylis` and removes `@ts-expect-error` in code.