### PR TITLE
chore: show bucket names in snapshots

### DIFF
--- a/change/@griffel-core-b81ce223-ebf6-413e-bd24-8908243f9ab4.json
+++ b/change/@griffel-core-b81ce223-ebf6-413e-bd24-8908243f9ab4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: show bucket names in snapshots",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/core/src/makeResetStyles.test.ts
+++ b/packages/core/src/makeResetStyles.test.ts
@@ -25,6 +25,7 @@ describe('makeResetStyles', () => {
 
     expect(computeClassName({ dir: 'ltr', renderer })).toEqual('r7lmmpp');
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "r" **/
       .r7lmmpp {
         color: red;
         flex-direction: row;
@@ -41,6 +42,7 @@ describe('makeResetStyles', () => {
     expect(computeClassName({ dir: 'rtl', renderer })).toEqual('rjhindo');
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "r" **/
       .rgb6zd6 {
         padding: 40px 20px 10px 5px;
       }

--- a/packages/core/src/makeStaticStyles.test.ts
+++ b/packages/core/src/makeStaticStyles.test.ts
@@ -28,6 +28,7 @@ describe('makeStaticStyles', () => {
     useStyles({ renderer });
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       body {
         background: blue;
         transition: all 4s ease;
@@ -58,6 +59,7 @@ describe('makeStaticStyles', () => {
     useStyles({ renderer });
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       @font-face {
         font-family: Open Sans;
         src: url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
@@ -75,6 +77,7 @@ describe('makeStaticStyles', () => {
     useStyles({ renderer });
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       body {
         background: red;
       }
@@ -102,6 +105,7 @@ describe('makeStaticStyles', () => {
     useStyles2({ renderer });
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       body {
         background: blue;
       }
@@ -124,6 +128,7 @@ describe('makeStaticStyles', () => {
     expect(useStyles({ dir: 'ltr', renderer }).root).toBe('___23yvam0_0000000 fy9yzz7 f4ybsrx');
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       @font-face {
         font-family: Open Sans;
         src: url("/fonts/OpenSans-Regular-webfont.woff") format("woff");

--- a/packages/core/src/makeStyles.test.ts
+++ b/packages/core/src/makeStyles.test.ts
@@ -33,6 +33,7 @@ describe('makeStyles', () => {
     expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('___afhpfp0 fe3e8s9');
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       .fe3e8s9 {
         color: red;
       }
@@ -44,16 +45,22 @@ describe('makeStyles', () => {
       root: {
         color: 'red',
         position: 'absolute',
+        ':hover': { color: 'blue' },
       },
     });
-    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('___1jgns8t fe3e8s9 f1euv43f');
 
+    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('___20fshm0 fe3e8s9 f1euv43f f10q6zxg');
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       .fe3e8s9 {
         color: red;
       }
       .f1euv43f {
         position: absolute;
+      }
+      /** bucket "h" **/
+      .f10q6zxg:hover {
+        color: blue;
       }
     `);
   });
@@ -73,6 +80,7 @@ describe('makeStyles', () => {
     expect(rtlClasses).toEqual('___7x57i00 f81rol6 f19krssl');
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       .frdkuqy {
         padding-left: 10px;
       }
@@ -106,6 +114,7 @@ describe('makeStyles', () => {
     expect(computeClasses({ dir: 'rtl', renderer }).root).toBe('___3kh5ri0 f1fp4ujf f1cpbl36 f1t9cprh');
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "k" **/
       @keyframes f1q8eu9e {
         from {
           transform: rotate(0deg);
@@ -122,6 +131,7 @@ describe('makeStyles', () => {
           transform: rotate(-360deg);
         }
       }
+      /** bucket "d" **/
       .f1g6ul6r {
         animation-name: f1q8eu9e;
       }
@@ -154,6 +164,7 @@ describe('makeStyles', () => {
     expect(rendererA.stylesheets.d).not.toBe(rendererB.stylesheets.d);
 
     expect(rendererA).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       .f22iagw {
         display: flex;
       }
@@ -165,6 +176,7 @@ describe('makeStyles', () => {
       }
     `);
     expect(rendererB).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       .f22iagw {
         display: flex;
       }
@@ -210,6 +222,7 @@ describe('makeStyles', () => {
     expect(computeClasses({ dir: 'ltr', renderer })[42]).toEqual('___afhpfp0 fe3e8s9');
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       .fe3e8s9 {
         color: red;
       }

--- a/packages/core/src/renderer/createDOMRenderer.test.ts
+++ b/packages/core/src/renderer/createDOMRenderer.test.ts
@@ -23,6 +23,7 @@ describe('createDOMRenderer', () => {
     renderer.insertCSSRules(cssRules);
 
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "d" **/
       .foo {
         background-color: red;
       }
@@ -44,6 +45,7 @@ describe('createDOMRenderer', () => {
 
     renderer.insertCSSRules(cssRules);
     expect(renderer).toMatchInlineSnapshot(`
+      /** bucket "t" **/
       .foo {
         background-color: red;
       }

--- a/packages/core/src/runtime/resolveResetStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.test.ts
@@ -11,6 +11,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       .r11y0rml {
         color: red;
         overflow-x: hidden;
@@ -22,6 +23,7 @@ describe('resolveResetStyleRules', () => {
     const result = resolveResetStyleRules({ marginLeft: '15px' });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       .rovwgyn {
         margin-left: 15px;
       }
@@ -37,6 +39,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       .rj1urkn {
         color: red;
         color: blue;
@@ -51,6 +54,7 @@ describe('resolveResetStyleRules', () => {
         ':global(body)': { color: 'magenta' },
       }),
     ).toMatchInlineSnapshot(`
+      /** bucket "r" */
       .rzlpwqs {
         color: red;
       }
@@ -67,6 +71,7 @@ describe('resolveResetStyleRules', () => {
         },
       }),
     ).toMatchInlineSnapshot(`
+      /** bucket "r" */
       body .r1i1zh9k {
         color: magenta;
       }
@@ -82,6 +87,7 @@ describe('resolveResetStyleRules', () => {
         },
       }),
     ).toMatchInlineSnapshot(`
+      /** bucket "r" */
       .fui-FluentProvider .rmi35r5 .foo {
         color: orange;
       }
@@ -96,6 +102,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       @container foo (max-width: 1px) {
         .rmph5rz {
           color: orange;
@@ -112,6 +119,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       @container (max-width: 1px) {
         .r1ph1abo {
           color: orange;
@@ -132,6 +140,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       .rpycl1b {
         color: red;
       }
@@ -157,6 +166,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       @layer utilities {
         .rvhnavh {
           color: orange;
@@ -179,6 +189,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       @supports (display: flex) {
         .rxf8lon {
           color: orange;
@@ -202,6 +213,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       @supports (display: flex) {
         .rhd25ja {
           color: pink;
@@ -223,6 +235,7 @@ describe('resolveResetStyleRules', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
+      /** bucket "r" */
       .r1s1f2pl:hover {
         color: red;
       }
@@ -242,6 +255,7 @@ describe('resolveResetStyleRules', () => {
       });
 
       expect(result).toMatchInlineSnapshot(`
+        /** bucket "r" */
         .reh730q {
           animation-name: foo;
         }
@@ -257,6 +271,7 @@ describe('resolveResetStyleRules', () => {
       });
 
       expect(result).toMatchInlineSnapshot(`
+        /** bucket "r" */
         .rgmpmil {
           animation-name: r1kgwxhb;
         }
@@ -289,6 +304,7 @@ describe('resolveResetStyleRules', () => {
       });
 
       expect(result).toMatchInlineSnapshot(`
+        /** bucket "r" */
         .rw8vs22 {
           animation-name: r1sekkel, r5j8bii;
         }


### PR DESCRIPTION
This PR modifies existing snapshot serializers to emit bucket names in formatted CSS to make clearer what is generated.