### PR TITLE
chore(core): move prefixer to stylis directory

### DIFF
--- a/change/@griffel-core-bfc4fd85-b03a-4200-88cc-14704f59ac47.json
+++ b/change/@griffel-core-bfc4fd85-b03a-4200-88cc-14704f59ac47.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(core): move prefixer to stylis directory",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/core/src/runtime/compileCSSRules.ts
+++ b/packages/core/src/runtime/compileCSSRules.ts
@@ -1,8 +1,8 @@
 import { compile, middleware, rulesheet, serialize, stringify } from 'stylis';
 
 import { globalPlugin } from './stylis/globalPlugin';
+import { prefixerPlugin } from './stylis/prefixerPlugin';
 import { sortClassesInAtRulesPlugin } from './stylis/sortClassesInAtRulesPlugin';
-import { prefixer } from './prefixer';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop() {}
@@ -15,8 +15,7 @@ export function compileCSSRules(cssRules: string, sortClassesInAtRules: boolean)
     middleware([
       globalPlugin,
       sortClassesInAtRules ? sortClassesInAtRulesPlugin : noop,
-      // prefixer,
-      prefixer,
+      prefixerPlugin,
       stringify,
 
       // 💡 we are using `.insertRule()` API for DOM operations, which does not support

--- a/packages/core/src/runtime/compileKeyframeCSS.ts
+++ b/packages/core/src/runtime/compileKeyframeCSS.ts
@@ -1,6 +1,7 @@
 import type { GriffelAnimation } from '@griffel/style-types';
 import { compile, middleware, serialize, rulesheet, stringify } from 'stylis';
-import { prefixer } from './prefixer';
+
+import { prefixerPlugin } from './stylis/prefixerPlugin';
 import { cssifyObject } from './utils/cssifyObject';
 
 export function compileKeyframeRule(keyframeObject: GriffelAnimation): string {
@@ -25,7 +26,7 @@ export function compileKeyframesCSS(keyframeName: string, keyframeCSS: string): 
     compile(cssRule),
     middleware([
       stringify,
-      prefixer,
+      prefixerPlugin,
       // 💡 we are using `.insertRule()` API for DOM operations, which does not support
       // insertion of multiple CSS rules in a single call. `rulesheet` plugin extracts
       // individual rules to be used with this API

--- a/packages/core/src/runtime/stylis/prefixerPlugin.test.ts
+++ b/packages/core/src/runtime/stylis/prefixerPlugin.test.ts
@@ -1,4 +1,4 @@
-import { prefix } from './prefixer';
+import { prefix } from './prefixerPlugin';
 
 const globalCssValues = ['inherit', 'initial', 'unset', 'revert', 'revert-layer'];
 

--- a/packages/core/src/runtime/stylis/prefixerPlugin.ts
+++ b/packages/core/src/runtime/stylis/prefixerPlugin.ts
@@ -9,14 +9,13 @@ import {
   MS,
   MOZ,
   WEBKIT,
-  Element,
   copy,
   serialize,
   DECLARATION,
   RULESET,
   combine,
-  Middleware,
 } from 'stylis';
+import type { Element, Middleware } from 'stylis';
 
 export function prefix(value: string, length: number, children?: Element[]): string {
   switch (hash(value, length)) {
@@ -110,7 +109,7 @@ export function prefix(value: string, length: number, children?: Element[]): str
  * @param {object[]} children
  * @param {function} callback
  */
-export function prefixer(
+export function prefixerPlugin(
   element: Element,
   index: number,
   children: Element[],


### PR DESCRIPTION
Moves `prefixerPlugin` to `/runtime/stylis` directory where all `stylis` related things live.