### PR TITLE
Inherit more webpack resolve options

### DIFF
--- a/change/@griffel-webpack-loader-b9e23b96-1848-4762-8b00-bb466cbbe407.json
+++ b/change/@griffel-webpack-loader-b9e23b96-1848-4762-8b00-bb466cbbe407.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Inherit more resolve options from webpack config",
+  "comment": "feat: Add 'inheritResolveOptions' to configure resolve options in Webpack",
   "packageName": "@griffel/webpack-loader",
   "email": "miclo@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@griffel-webpack-loader-b9e23b96-1848-4762-8b00-bb466cbbe407.json
+++ b/change/@griffel-webpack-loader-b9e23b96-1848-4762-8b00-bb466cbbe407.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Inherit more resolve options from webpack config",
+  "packageName": "@griffel/webpack-loader",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-loader/README.md
+++ b/packages/webpack-loader/README.md
@@ -159,7 +159,9 @@ module.exports = {
 ```
 
 ### Configuring webpack resolve options
-If your `@griffel/react` modules import other files (eg., a set of common mixins or colors for your app), the loader resolves these using `enhanced-resolve`. By default, it inherits the settings `resolve.alias`, `resolve.modules`, and `resolve.modules` from youe webpack config, while using its own default values for `resolve.extensions` and `resolve.conditionNames`. If you want to change this behavior, you can choose which `resolve` options are inherited from your webpack config.
+If your `@griffel/react` modules import other files (eg., a set of common mixins or colors for your app), the loader resolves these using `enhanced-resolve`. By default, it inherits the settings `resolve.alias`, `resolve.modules`, and `resolve.modules` from your Webpack config, while using its own default values for `resolve.extensions` and `resolve.conditionNames`.
+
+If you want to change this behavior, you can choose which [`resolve` options](https://webpack.js.org/configuration/resolve/) are inherited from your Webpack config.
 ```js
 module.exports = {
   module: {

--- a/packages/webpack-loader/README.md
+++ b/packages/webpack-loader/README.md
@@ -10,6 +10,7 @@ A loader for Webpack 5 that performs build time transforms for [`@griffel/react`
 - [Usage](#usage)
   - [Handling Griffel re-exports](#handling-griffel-re-exports)
   - [Configuring Babel settings](#configuring-babel-settings)
+  - [Configuring webpack resolve options](#configuring-webpack-resolve-options)
   - [Configuring module evaluation](#configuring-module-evaluation)
 - [Troubleshooting](#troubleshooting)
 
@@ -149,6 +150,27 @@ module.exports = {
               // If your project uses TypeScript
               presets: ['@babel/preset-typescript'],
             },
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+### Configuring webpack resolve options
+If your `@griffel/react` modules import other files (eg., a set of common mixins or colors for your app), the loader resolves these using `enhanced-resolve`. By default, it inherits the settings `resolve.alias`, `resolve.modules`, and `resolve.modules` from youe webpack config, while using its own default values for `resolve.extensions` and `resolve.conditionNames`. If you want to change this behavior, you can choose which `resolve` options are inherited from your webpack config.
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: '@griffel/webpack-loader',
+          options: {
+            inheritResolveOptions: ['alias', 'modules', 'plugins', 'conditionNames'],
           },
         },
       },

--- a/packages/webpack-loader/__fixtures__/webpack-resolve-options/code.ts
+++ b/packages/webpack-loader/__fixtures__/webpack-resolve-options/code.ts
@@ -1,0 +1,8 @@
+import { makeStyles } from '@griffel/react';
+import color from './color';
+
+export const styles = makeStyles({
+  root: {
+    backgroundColor: color,
+  },
+});

--- a/packages/webpack-loader/__fixtures__/webpack-resolve-options/color.jsx
+++ b/packages/webpack-loader/__fixtures__/webpack-resolve-options/color.jsx
@@ -1,0 +1,3 @@
+const color = 'blue';
+
+export default color;

--- a/packages/webpack-loader/__fixtures__/webpack-resolve-options/output.ts
+++ b/packages/webpack-loader/__fixtures__/webpack-resolve-options/output.ts
@@ -1,0 +1,12 @@
+import { __styles } from '@griffel/react';
+import color from './color';
+export const styles = __styles(
+  {
+    root: {
+      De3pzq: 'f1bh81bl',
+    },
+  },
+  {
+    d: ['.f1bh81bl{background-color:blue;}'],
+  },
+);

--- a/packages/webpack-loader/src/schema.ts
+++ b/packages/webpack-loader/src/schema.ts
@@ -1,0 +1,10 @@
+export const optionsSchema: JSONSchema7 = {
+  ...configSchema,
+  properties: {
+    ...configSchema.properties,
+    inheritResolveOptions: {
+      type: 'array',
+      items: { type: 'string', enum: ['alias', 'modules', 'plugins', 'conditionNames', 'extensions'] },
+    },
+  },
+};

--- a/packages/webpack-loader/src/schema.ts
+++ b/packages/webpack-loader/src/schema.ts
@@ -1,3 +1,6 @@
+import type { JSONSchema7 } from 'json-schema';
+import { configSchema } from '@griffel/babel-preset';
+
 export const optionsSchema: JSONSchema7 = {
   ...configSchema,
   properties: {

--- a/packages/webpack-loader/src/webpackLoader.test.ts
+++ b/packages/webpack-loader/src/webpackLoader.test.ts
@@ -257,6 +257,18 @@ describe('webpackLoader', () => {
     },
   });
 
+  // Asserts that "inheritResolveOptions" are handled properly
+  testFixture('webpack-resolve-options', {
+    loaderOptions: {
+      inheritResolveOptions: ['extensions'],
+    },
+    webpackConfig: {
+      resolve: {
+        extensions: ['.ts', '.jsx'],
+      },
+    },
+  });
+
   // Asserts that aliases are resolved properly in Babel plugin with resolve plugins
   testFixture('webpack-resolve-plugins', {
     webpackConfig: {

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -56,10 +56,6 @@ export function webpackLoader(
 
   EvalCache.clearForFile(this.resourcePath);
 
-  const resolveOptionsDefaults: webpack.ResolveOptions = {
-    conditionNames: ['require'],
-    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
-  };
   // ⚠ "this._compilation" limits loaders compatibility, however there seems to be no other way to access Webpack's
   // resolver.
   // There is this.resolve(), but it's asynchronous. Another option is to read the webpack.config.js, but it won't work
@@ -67,10 +63,11 @@ export function webpackLoader(
   const resolveOptionsFromWebpackConfig: webpack.ResolveOptions = this._compilation?.options.resolve || {};
 
   const resolveSync = enhancedResolve.create.sync({
-    ...resolveOptionsDefaults,
     alias: resolveOptionsFromWebpackConfig.alias,
     modules: resolveOptionsFromWebpackConfig.modules,
     plugins: resolveOptionsFromWebpackConfig.plugins,
+    conditionNames: [...(resolveOptionsFromWebpackConfig.conditionNames ?? []), 'require'],
+    extensions: resolveOptionsFromWebpackConfig.extensions ?? ['.js', '.jsx', '.ts', '.tsx', '.json'],
   });
 
   const originalResolveFilename = Module._resolveFilename;

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
+import { optionsSchema } from './schema';
 import type { JSONSchema7 } from 'json-schema';
 
 export type WebpackLoaderOptions = BabelPluginOptions & {
@@ -11,17 +12,6 @@ export type WebpackLoaderOptions = BabelPluginOptions & {
 };
 
 type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLoaderOptions>>;
-
-const optionsSchema: JSONSchema7 = {
-  ...configSchema,
-  properties: {
-    ...configSchema.properties,
-    inheritResolveOptions: {
-      type: 'array',
-      items: { type: 'string', enum: ['alias', 'modules', 'plugins', 'conditionNames', 'extensions'] },
-    },
-  },
-};
 
 export function shouldTransformSourceCode(
   sourceCode: string,

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
-import type { JSONSchema7 } from '@typescript-eslint/utils/dist/json-schema';
+import type { JSONSchema7 } from 'json-schema';
 
 export type WebpackLoaderOptions = BabelPluginOptions & {
   inheritResolveOptions?: ('alias' | 'modules' | 'plugins' | 'conditionNames' | 'extensions')[];

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -1,11 +1,10 @@
-import { configSchema, BabelPluginOptions, EvalCache, Module } from '@griffel/babel-preset';
+import { BabelPluginOptions, EvalCache, Module } from '@griffel/babel-preset';
 import * as enhancedResolve from 'enhanced-resolve';
 import * as path from 'path';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
 import { optionsSchema } from './schema';
-import type { JSONSchema7 } from 'json-schema';
 
 export type WebpackLoaderOptions = BabelPluginOptions & {
   inheritResolveOptions?: ('alias' | 'modules' | 'plugins' | 'conditionNames' | 'extensions')[];


### PR DESCRIPTION
The Outlook project has `webpack` build directly from Typescript source using `esbuild-loader`; to accomplish this, we define a `"source"` condition on all of our various package `"exports"` and specify it in `resolve.conditionNames` in `webpack.config.js`. The current behavior to lock this option to simply `["require"]` is a blocker to integrating the loader into our config.