### PR TITLE
fix(style-types): fix types for "animationName"

### DIFF
--- a/change/@griffel-style-types-b862f87c-02b5-4bac-9b0b-01ba4a0c4e63.json
+++ b/change/@griffel-style-types-b862f87c-02b5-4bac-9b0b-01ba4a0c4e63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update types for \"animationName\"",
+  "packageName": "@griffel/style-types",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/e2e/typescript/src/assets/fixture-reset.ts
+++ b/e2e/typescript/src/assets/fixture-reset.ts
@@ -6,6 +6,31 @@ function assertType(style: GriffelResetStyle): GriffelResetStyle {
 
 // Animation
 assertType({ animationName: 'foo' });
+assertType({
+  animationName: {
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+  },
+});
+assertType({
+  animationName: [
+    {
+      from: { opacity: 0 },
+      to: { opacity: 0 },
+    },
+    {
+      from: { height: 0 },
+      to: { height: '200px' },
+    },
+  ],
+});
+
+assertType({
+  // @ts-expect-error "200" is not a valid CSS value for "height"
+  animationName: {
+    to: { height: 200 },
+  },
+});
 
 // Basic styles
 //

--- a/e2e/typescript/src/assets/fixture.ts
+++ b/e2e/typescript/src/assets/fixture.ts
@@ -6,6 +6,31 @@ function assertType(style: GriffelStyle): GriffelStyle {
 
 // Animation
 assertType({ animationName: 'foo' });
+assertType({
+  animationName: {
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+  },
+});
+assertType({
+  animationName: [
+    {
+      from: { opacity: 0 },
+      to: { opacity: 0 },
+    },
+    {
+      from: { height: 0 },
+      to: { height: '200px' },
+    },
+  ],
+});
+
+assertType({
+  // @ts-expect-error "200" is not a valid CSS value for "height"
+  animationName: {
+    to: { height: 200 },
+  },
+});
 
 // Basic styles
 //

--- a/packages/style-types/src/makeResetStyles.ts
+++ b/packages/style-types/src/makeResetStyles.ts
@@ -23,5 +23,5 @@ type GriffelCSSPseudos = {
   [Property in CSS.Pseudos]?: GriffelResetStylesStrictCSSObject | GriffelCSSObjectCustom;
 };
 
-export type GriffelResetAnimation = Record<'from' | 'to' | string, GriffelCSSObjectCustom>;
+export type GriffelResetAnimation = Record<'from' | 'to' | string, GriffelResetStylesCSSProperties>;
 export type GriffelResetStyle = GriffelResetStylesStrictCSSObject | GriffelCSSObjectCustom;

--- a/packages/style-types/src/makeStyles.ts
+++ b/packages/style-types/src/makeStyles.ts
@@ -12,9 +12,12 @@ type GriffelStylesCSSProperties = Omit<
   CSS.PropertiesFallback<GriffelStylesCSSValue>,
   // We have custom definition for "animationName"
   'animationName'
-> & { animationName?: GriffelAnimation | GriffelAnimation[] | string } & Partial<GriffelStylesUnsupportedCSSProperties>;
+> &
+  Partial<GriffelStylesUnsupportedCSSProperties>;
 
-export type GriffelStylesStrictCSSObject = GriffelStylesCSSProperties & GriffelCSSPseudos;
+export type GriffelStylesStrictCSSObject = GriffelStylesCSSProperties & {
+  animationName?: GriffelAnimation | GriffelAnimation[] | string;
+} & GriffelCSSPseudos;
 
 type GriffelCSSObjectCustom = {
   [Property: string]: GriffelStyle | GriffelStylesCSSValue;
@@ -24,5 +27,5 @@ type GriffelCSSPseudos = {
   [Property in CSS.Pseudos]?: GriffelStylesStrictCSSObject | GriffelCSSObjectCustom;
 };
 
-export type GriffelAnimation = Record<'from' | 'to' | string, GriffelCSSObjectCustom>;
+export type GriffelAnimation = Record<'from' | 'to' | string, GriffelStylesCSSProperties>;
 export type GriffelStyle = GriffelStylesStrictCSSObject | GriffelCSSObjectCustom;


### PR DESCRIPTION
Currently following snippet produces an error:

```ts
assertType({
  animationName: {
    from: { opacity: 0 },
    to: { opacity: 1 },
  },
});
```

This is not expected, this PR fixes it and adds new fixtures.