### PR TITLE
eslint-plugin: enforce pseudo element naming with :: over :

### DIFF
--- a/change/@griffel-eslint-plugin-de59e2ef-e29f-4852-bc03-5bf3b563f991.json
+++ b/change/@griffel-eslint-plugin-de59e2ef-e29f-4852-bc03-5bf3b563f991.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(eslint): pseudo element naming rule",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "levin@uncu.de",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-eslint-plugin-de59e2ef-e29f-4852-bc03-5bf3b563f991.json
+++ b/change/@griffel-eslint-plugin-de59e2ef-e29f-4852-bc03-5bf3b563f991.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat(eslint): pseudo element naming rule",
+  "comment": "feat: add pseudo element naming rule",
   "packageName": "@griffel/eslint-plugin",
   "email": "levin@uncu.de",
   "dependentChangeType": "patch"

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -30,7 +30,8 @@ This plugin exports recommended configuration that enforce good practices, but y
   "plugins": ["@griffel"],
   "rules": {
     "@griffel/hook-naming": "error",
-    "@griffel/no-shorthands": "warn"
+    "@griffel/no-shorthands": "error",
+    "@griffel/pseudo-element-naming": "error"
   }
 }
 ```
@@ -41,7 +42,10 @@ You can find more info about enabled rules in the [Supported Rules section](#sup
 
 **Key**: 🔧 = fixable
 
-| Name                                                     | Description                                                                | 🔧  |
-| -------------------------------------------------------- | -------------------------------------------------------------------------- | --- |
-| [`@griffel/hook-naming`](./src/rules/hook-naming.md)     | Ensure that hooks returned by the `makeStyles()` function start with "use" |     |
-| [`@griffel/no-shorthands`](./src/rules/no-shorthands.md) | Enforce usage of CSS longhands                                             |     |
+| Name                                                                     | Description                                                                                                     | 🔧  |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | --- |
+| [`@griffel/hook-naming`](./src/rules/hook-naming.md)                     | Ensure that hooks returned by the `makeStyles()` function start with "use"                                      | ❌  |
+| [`@griffel/no-shorthands`](./src/rules/no-shorthands.md)                 | Enforce usage of CSS longhands                                                                                  | ❌  |
+| [`@griffel/styles-file`](./src/rules/styles-file.md)                     | Ensures that all `makeStyles()` and `makeResetStyles()` calls are placed in a `.styles.js` or `.styles.ts` file | ❌  |
+| [`@griffel/pseudo-element-naming`](./src/rules/pseudo-element-naming.md) | Ensures that all Pseudo Elements start with two colons                                                          | ✅  |
+|                                                                          |

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -48,4 +48,3 @@ You can find more info about enabled rules in the [Supported Rules section](#sup
 | [`@griffel/no-shorthands`](./src/rules/no-shorthands.md)                 | Enforce usage of CSS longhands                                                                                  | ❌  |
 | [`@griffel/styles-file`](./src/rules/styles-file.md)                     | Ensures that all `makeStyles()` and `makeResetStyles()` calls are placed in a `.styles.js` or `.styles.ts` file | ❌  |
 | [`@griffel/pseudo-element-naming`](./src/rules/pseudo-element-naming.md) | Ensures that all Pseudo Elements start with two colons                                                          | ✅  |
-|                                                                          |

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -3,5 +3,6 @@ export const recommendedConfig = {
   rules: {
     '@griffel/hook-naming': 'error',
     '@griffel/no-shorthands': 'error',
+    '@griffel/pseudo-element-naming': 'error',
   },
 };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import { recommendedConfig } from './configs/recommended';
 import { hookNamingRule } from './rules/hook-naming';
 import { noShorthandsRule } from './rules/no-shorthands';
+import { pseudoElementNamingRule } from './rules/pseudo-element-naming';
 import { stylesFileRule } from './rules/styles-file';
 
 export = {
@@ -11,5 +12,6 @@ export = {
     'hook-naming': hookNamingRule,
     'no-shorthands': noShorthandsRule,
     'styles-file': stylesFileRule,
+    'pseudo-element-naming': pseudoElementNamingRule,
   },
 };

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.md
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.md
@@ -11,7 +11,7 @@ Examples of **incorrect** code for this rule:
 ```js
 import { makeStyles } from '@griffel/react';
 
-export const makeStyles({
+export const useClasses = makeStyles({
   root: {
     ':before': {},
     ':after': {},

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.md
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.md
@@ -1,0 +1,33 @@
+# Enforce that Pseudo elements start with two colons
+
+Ensures that all Pseudo Elements start with two colons (::before) instead of one colon (:before).
+
+## Rule Details
+
+Pseudo **Elements** should always start with two colons while Pseudeo **Selectors** should always start with one colon.
+
+Examples of **incorrect** code for this rule:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+export const makeStyles({
+  root: {
+    ':before': {},
+    ':after': {},
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+export const makeStyles({
+  root: {
+    '::before': {},
+    '::after': {},
+  },
+});
+```

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.md
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.md
@@ -24,7 +24,7 @@ Examples of **correct** code for this rule:
 ```js
 import { makeStyles } from '@griffel/react';
 
-export const makeStyles({
+export const useClasses = makeStyles({
   root: {
     '::before': {},
     '::after': {},

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.md
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.md
@@ -1,6 +1,6 @@
 # Enforce that Pseudo elements start with two colons
 
-Ensures that all Pseudo Elements start with two colons (::before) instead of one colon (:before).
+Ensures that all Pseudo Elements start with two colons (`::before`) instead of one colon (`:before`).
 
 ## Rule Details
 

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.test.ts
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.test.ts
@@ -1,0 +1,86 @@
+import { TSESLint } from '@typescript-eslint/utils';
+import * as path from 'path';
+
+import { pseudoElementNamingRule, RULE_NAME } from './pseudo-element-naming';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: path.resolve('./node_modules/@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run(RULE_NAME, pseudoElementNamingRule, {
+  valid: [
+    {
+      name: 'without Pseudo Element',
+      code: `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { backgroundColor: 'red' },
+});
+`,
+    },
+    {
+      name: 'with Valid Pseudo Element',
+      code: `
+    import { makeStyles } from '@griffel/react';
+
+    export const useStyles = makeStyles({
+      root: { '::before': { backgroundColor: 'red' } },
+    });
+    `,
+    },
+    {
+      name: 'Invalid Pseudo Elements can be used as slot names',
+      code: `
+    import { makeStyles } from '@griffel/react';
+
+    export const useStyles = makeStyles({
+      ':before': { backgroundColor: 'red' },
+    });
+    `,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'Invalid Pseudo Element',
+      code: `
+    import { makeStyles } from '@griffel/react';
+    export const useStyles = makeStyles({
+      root: { ':before': { backgroundColor: 'red' } },
+    });
+    `,
+      output: `
+    import { makeStyles } from '@griffel/react';
+    export const useStyles = makeStyles({
+      root: { '::before': { backgroundColor: 'red' } },
+    });
+    `,
+      errors: [{ messageId: 'invalidPseudoElementNameFound' }],
+    },
+    {
+      name: 'Invalid Pseudo Element in a selector',
+      code: `
+    import { makeStyles } from '@griffel/react';
+    export const useStyles = makeStyles({
+      root: {
+        ':hover': { ':before': { backgroundColor: 'red' } }
+      },
+    });
+    `,
+      output: `
+    import { makeStyles } from '@griffel/react';
+    export const useStyles = makeStyles({
+      root: {
+        ':hover': { '::before': { backgroundColor: 'red' } }
+      },
+    });
+    `,
+      errors: [{ messageId: 'invalidPseudoElementNameFound' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
@@ -10,7 +10,7 @@ const UNSUPPORTED_PSEUDO_ELEMENTS: Record<string, true> = {
   ':after': true,
 };
 
-function findPseudoElementProperties(
+function findInvalidPseudoElementProperties(
   node: TSESTree.ObjectExpression,
   isRoot = false,
   result: TSESTree.StringLiteral[] = [],
@@ -24,7 +24,7 @@ function findPseudoElementProperties(
       }
 
       if (isObjectExpression(propertyNode.value)) {
-        findPseudoElementProperties(propertyNode.value, false, result);
+        findInvalidPseudoElementProperties(propertyNode.value, false, result);
       }
     }
   }
@@ -59,15 +59,15 @@ export const pseudoElementNamingRule: ReturnType<ReturnType<typeof ESLintUtils.R
           const argument = node.arguments[0];
 
           if (isObjectExpression(argument)) {
-            const pseudoElementProperties = findPseudoElementProperties(argument, true);
+            const invalidPseudoElementProperties = findInvalidPseudoElementProperties(argument, true);
 
-            pseudoElementProperties.forEach(pseudoElementProperty => {
+            invalidPseudoElementProperties.forEach(invalidPseudoElementProperty => {
               context.report({
-                node: pseudoElementProperty,
+                node: invalidPseudoElementProperty,
                 messageId: 'invalidPseudoElementNameFound',
                 fix: function (fixer) {
-                  const start = pseudoElementProperty.range[0] + 1;
-                  const end = pseudoElementProperty.range[1];
+                  const start = invalidPseudoElementProperty.range[0] + 1;
+                  const end = invalidPseudoElementProperty.range[1];
                   return fixer.insertTextBeforeRange([start, end], ':');
                 },
               });

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
@@ -1,0 +1,80 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+import { createRule } from '../utils/createRule';
+import { isStringLiteral, isMakeStylesIdentifier, isObjectExpression, isProperty } from '../utils/helpers';
+
+export const RULE_NAME = 'pseudo-element-naming';
+
+const UNSUPPORTED_PSEUDO_ELEMENTS: Record<string, true> = {
+  ':before': true,
+  ':after': true,
+};
+
+function findPseudoElementProperties(
+  node: TSESTree.ObjectExpression,
+  isRoot = false,
+  result: TSESTree.StringLiteral[] = [],
+): TSESTree.StringLiteral[] {
+  for (const propertyNode of node.properties) {
+    if (isProperty(propertyNode)) {
+      if (isStringLiteral(propertyNode.key) && !isRoot) {
+        if (Object.prototype.hasOwnProperty.call(UNSUPPORTED_PSEUDO_ELEMENTS, propertyNode.key.value)) {
+          result.push(propertyNode.key);
+        }
+      }
+
+      if (isObjectExpression(propertyNode.value)) {
+        findPseudoElementProperties(propertyNode.value, false, result);
+      }
+    }
+  }
+
+  return result;
+}
+
+export const pseudoElementNamingRule: ReturnType<ReturnType<typeof ESLintUtils.RuleCreator>> = createRule({
+  name: RULE_NAME,
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      description: 'Enforce that Pseudo elements start with two colons (::) instead of one colon (:)',
+      recommended: 'error',
+    },
+    messages: {
+      invalidPseudoElementNameFound: 'Pseudo elements must start with two colons (::)',
+    },
+    schema: [
+      {
+        type: 'string',
+      },
+    ],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isMakeStylesIdentifier(node.callee)) {
+          const argument = node.arguments[0];
+
+          if (isObjectExpression(argument)) {
+            const pseudoElementProperties = findPseudoElementProperties(argument, true);
+
+            pseudoElementProperties.forEach(pseudoElementProperty => {
+              context.report({
+                node: pseudoElementProperty,
+                messageId: 'invalidPseudoElementNameFound',
+                fix: function (fixer) {
+                  const start = pseudoElementProperty.range[0] + 1;
+                  const end = pseudoElementProperty.range[1];
+                  return fixer.insertTextBeforeRange([start, end], ':');
+                },
+              });
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
@@ -5,7 +5,7 @@ import { isStringLiteral, isMakeStylesIdentifier, isObjectExpression, isProperty
 
 export const RULE_NAME = 'pseudo-element-naming';
 
-const UNSUPPORTED_PSEUDO_ELEMENTS: Record<string, true> = {
+const PSEUDO_ELEMENTS = [':before', ':after']
   ':before': true,
   ':after': true,
 };

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
@@ -5,10 +5,7 @@ import { isStringLiteral, isMakeStylesIdentifier, isObjectExpression, isProperty
 
 export const RULE_NAME = 'pseudo-element-naming';
 
-const PSEUDO_ELEMENTS = [':before', ':after']
-  ':before': true,
-  ':after': true,
-};
+const PSEUDO_ELEMENTS = [':before', ':after'];
 
 function findInvalidPseudoElementProperties(
   node: TSESTree.ObjectExpression,
@@ -18,7 +15,7 @@ function findInvalidPseudoElementProperties(
   for (const propertyNode of node.properties) {
     if (isProperty(propertyNode)) {
       if (isStringLiteral(propertyNode.key) && !isRoot) {
-        if (Object.prototype.hasOwnProperty.call(UNSUPPORTED_PSEUDO_ELEMENTS, propertyNode.key.value)) {
+        if (PSEUDO_ELEMENTS.includes(propertyNode.key.value)) {
           result.push(propertyNode.key);
         }
       }
@@ -68,6 +65,7 @@ export const pseudoElementNamingRule: ReturnType<ReturnType<typeof ESLintUtils.R
                 fix: function (fixer) {
                   const start = invalidPseudoElementProperty.range[0] + 1;
                   const end = invalidPseudoElementProperty.range[1];
+
                   return fixer.insertTextBeforeRange([start, end], ':');
                 },
               });

--- a/packages/eslint-plugin/src/utils/helpers.ts
+++ b/packages/eslint-plugin/src/utils/helpers.ts
@@ -4,6 +4,7 @@ type IsHelper<NodeType extends AST_NODE_TYPES> = (node: TSESTree.Node | null | u
   type: NodeType;
 };
 
+const isLiteral: IsHelper<AST_NODE_TYPES.Literal> = ASTUtils.isNodeOfType(AST_NODE_TYPES.Literal);
 export const isIdentifier: IsHelper<AST_NODE_TYPES.Identifier> = ASTUtils.isIdentifier;
 export const isObjectExpression: IsHelper<AST_NODE_TYPES.ObjectExpression> = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.ObjectExpression,
@@ -12,4 +13,7 @@ export const isProperty: IsHelper<AST_NODE_TYPES.Property> = ASTUtils.isNodeOfTy
 
 export function isMakeStylesIdentifier(node: TSESTree.Node | null | undefined): node is TSESTree.Identifier {
   return isIdentifier(node) && node.name === 'makeStyles';
+}
+export function isStringLiteral(node: TSESTree.Node | null | undefined): node is TSESTree.StringLiteral {
+  return isLiteral(node) && typeof node.value === 'string';
 }


### PR DESCRIPTION
This fixes #304.

It is basically the same rule as for `no-shorthands`, but instead of checking
whether the property is an `Identifier`, we check for `StringLiteral`.

Invalid Pseudo Element Names are:
`:before` and `:after`

Autofix works as intended:
```js
...
':before': {},
...
```
will fix to
```js
...
'::before': {},
...
```

Note: I am not the best programmer, so if you find something that should be changed or is not working as intended, let me know and I will try to fix it.
