### PR TITLE
Optimize the size of JS generated by @griffel/webpack-extraction-plugin

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -28,6 +28,9 @@ export const DEFINITION_LOOKUP_TABLE = getGlobalVar<Record<SequenceHash, LookupI
 /** @internal */
 export const LTR_TO_RTL_LOOKUP = getGlobalVar<Record<string, string>>('LTR_TO_RTL_LOOKUP', {});
 
+/** @internal */
+export const CLASS_PROP_LOOKUP = getGlobalVar<Record<string, string>>('CLASS_PROP_LOOKUP', {});
+
 // ----
 
 /** @internal */

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -25,6 +25,9 @@ export const DEBUG_RESET_CLASSES = getGlobalVar<Record<string, 1>>('DEBUG_RESET_
 /** @internal */
 export const DEFINITION_LOOKUP_TABLE = getGlobalVar<Record<SequenceHash, LookupItem>>('DEFINITION_LOOKUP_TABLE', {});
 
+/** @internal */
+export const LTR_TO_RTL_LOOKUP = getGlobalVar<Record<string, string>>('LTR_TO_RTL_LOOKUP', {});
+
 // ----
 
 /** @internal */

--- a/packages/core/src/runtime/reduceToClassNameForSlots.ts
+++ b/packages/core/src/runtime/reduceToClassNameForSlots.ts
@@ -1,4 +1,4 @@
-import { DEFINITION_LOOKUP_TABLE } from '../constants';
+import { DEFINITION_LOOKUP_TABLE, LTR_TO_RTL_LOOKUP } from '../constants';
 import { hashSequence } from './utils/hashSequence';
 import { CSSClassesMapBySlot, CSSClassesMap, CSSClasses } from '../types';
 
@@ -18,7 +18,15 @@ export function reduceToClassName(classMap: CSSClassesMap, dir: 'ltr' | 'rtl'): 
       const hasRTLClassName = Array.isArray(classNameMapping);
 
       if (dir === 'rtl') {
-        className += (hasRTLClassName ? classNameMapping[1] : classNameMapping) + ' ';
+        className +=
+          (hasRTLClassName
+            ? classNameMapping[1]
+            : // WHAT?
+              //   Check the global mapping of LTR class->RTL class when given a single CSS class
+              // WHY?
+              //   In order to optimize bundle size and reduce duplication, the webpack extraction plugin
+              //   generates a runtime module that boostraps LTR_TO_RTL_LOOKUP with the mapping of all LTR->RTL classes
+              LTR_TO_RTL_LOOKUP[classNameMapping] ?? classNameMapping) + ' ';
       } else {
         className += (hasRTLClassName ? classNameMapping[0] : classNameMapping) + ' ';
       }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -57,6 +57,7 @@ export type CSSClasses = /* ltrClassName */ string | [/* ltrClassName */ string,
 
 export type CSSClassesMap = Record<PropertyHash, CSSClasses>;
 export type CSSClassesMapBySlot<Slots extends string | number> = Record<Slots, CSSClassesMap>;
+export type EllidedCSSClassesMapBySlot<Slots extends string | number> = Record<Slots, string[]>;
 
 export type CSSRulesByBucket = {
   // reset


### PR DESCRIPTION
This change aims to optimize the size of generated JS from `@griffel/webpack-extraction-plugin` by centralizing both 
1. the mapping of LTR->RTL pairs, and
2. the mapping of class names -> CSS properties
to a central runtime module, thus removing a significant source of duplication.

Tasks:
[ ] Generate centralized maps in `@griffel/webpack-extraction-plugin` in a new runtime module.
[x] Consume centralized maps inside of `@griffel/core`
[ ] Tests
[ ] Documentation