### PR TITLE
feat: Add metadata generation to babel preset

### DIFF
--- a/change/@griffel-babel-preset-84c90e38-9d5d-40cf-9ef9-ef07ef7886b5.json
+++ b/change/@griffel-babel-preset-84c90e38-9d5d-40cf-9ef9-ef07ef7886b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add metadata generation to babel preset",
+  "packageName": "@griffel/babel-preset",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -13,7 +13,7 @@ A Babel preset that performs build time transforms for [`@griffel/react`](../rea
   - [Configuring module evaluation](#configuring-module-evaluation)
 - [Transforms](#transforms)
 - [Example](#example)
-- [CSS metadata](#css-metadata)
+- [Access CSS output from code](#access-css-output-from-code)
 - [Troubleshooting](#troubleshooting)
   - [Module evaluation](#module-evaluation)
 
@@ -162,9 +162,9 @@ import { __styles } from '@griffel/react';
 const useStyles = __styles(/* resolved styles */);
 ```
 
-## CSS metadata
+## Access CSS output from code
 
-It's possible to configure the preset to return metadata of all the evaluated styles of a file. This
+It's possible to configure the preset to return all the evaluated styles of a file. This
 metadata looks something like below:
 
 ```ts

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -194,20 +194,23 @@ This is intended for programmatic transforms in code so that they can be reused 
 the output styles
 
 ```ts
-  const babelFileResult = Babel.transformFromAstSync(babelAST, sourceCode, {
-    babelrc: false,
-    configFile: false,
-    presets: [[griffelPreset, { generateMetadata: true }]],
+import { griffelPreset, BabelPluginMetadata } from '@griffel/babel-preset';
 
-    filename: options.filename,
 
-    sourceMaps: options.enableSourceMaps,
-    sourceFileName: options.filename,
-    inputSourceMap: options.inputSourceMap,
-  });
+const babelFileResult = Babel.transformFromAstSync(babelAST, sourceCode, {
+  babelrc: false,
+  configFile: false,
+  presets: [[griffelPreset, { generateMetadata: true }]],
 
-  // metadata
-  console.log(babelFileResult.metadata);
+  filename: options.filename,
+
+  sourceMaps: options.enableSourceMaps,
+  sourceFileName: options.filename,
+  inputSourceMap: options.inputSourceMap,
+});
+
+// metadata
+console.log(babelFileResult.metadata as unknown as BabelPluginMetadata);
 ```
 
 ## Troubleshooting

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -168,26 +168,25 @@ It's possible to configure the preset to return all the evaluated styles of a fi
 metadata looks something like below:
 
 ```ts
-{
+const output = {
   // makeStyles
   cssEntries: {
     // by each hook
     useStyles1: {
       // by each slot
-      root:  [ .fxxxxx { color: 'red' } ],
-    }
+      root: [".fxxxxx { color: 'red' }"],
+    },
     useStyles2: {
-      root:  [ .fxxxxx { color: 'red' } ],
+      root: [".fxxxxx { color: 'red' }"],
     },
   },
-
   // makeResetStyles
   cssResetEntries: {
     // by each hook
-    useResetStyles1: [ .fxxxxx { color: 'red' } ],
-    useResetStyles2: [ .fxxxxx { color: 'red' } ],
-  }
-}
+    useResetStyles1: [".fxxxxx { color: 'red' }"],
+    useResetStyles2: [".fxxxxx { color: 'red' }"],
+  },
+};
 ```
 
 This is intended for programmatic transforms in code so that they can be reused by other tooling without extra steps to determine
@@ -195,7 +194,6 @@ the output styles
 
 ```ts
 import { griffelPreset, BabelPluginMetadata } from '@griffel/babel-preset';
-
 
 const babelFileResult = Babel.transformFromAstSync(babelAST, sourceCode, {
   babelrc: false,

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -13,6 +13,7 @@ A Babel preset that performs build time transforms for [`@griffel/react`](../rea
   - [Configuring module evaluation](#configuring-module-evaluation)
 - [Transforms](#transforms)
 - [Example](#example)
+- [CSS metadata](#css-metadata)
 - [Troubleshooting](#troubleshooting)
   - [Module evaluation](#module-evaluation)
 
@@ -159,6 +160,54 @@ roughly to
 import { __styles } from '@griffel/react';
 
 const useStyles = __styles(/* resolved styles */);
+```
+
+## CSS metadata
+
+It's possible to configure the preset to return metadata of all the evaluated styles of a file. This
+metadata looks something like below:
+
+```ts
+{
+  // makeStyles
+  cssEntries: {
+    // by each hook
+    useStyles1: {
+      // by each slot
+      root:  [ .fxxxxx { color: 'red' } ],
+    }
+    useStyles2: {
+      root:  [ .fxxxxx { color: 'red' } ],
+    },
+  },
+
+  // makeResetStyles
+  cssResetEntries: {
+    // by each hook
+    useResetStyles1: [ .fxxxxx { color: 'red' } ],
+    useResetStyles2: [ .fxxxxx { color: 'red' } ],
+  }
+}
+```
+
+This is intended for programmatic transforms in code so that they can be reused by other tooling without extra steps to determine
+the output styles
+
+```ts
+  const babelFileResult = Babel.transformFromAstSync(babelAST, sourceCode, {
+    babelrc: false,
+    configFile: false,
+    presets: [[griffelPreset, { generateMetadata: true }]],
+
+    filename: options.filename,
+
+    sourceMaps: options.enableSourceMaps,
+    sourceFileName: options.filename,
+    inputSourceMap: options.inputSourceMap,
+  });
+
+  // metadata
+  console.log(babelFileResult.metadata);
 ```
 
 ## Troubleshooting

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -1,14 +1,14 @@
 import { transformPlugin } from './transformPlugin';
 
 import type { ConfigAPI } from '@babel/core';
-import type { BabelPluginOptions } from './types';
+import type { BabelPluginOptions, GriffelHookEntries, GriffelResetHookEntries, BabelPluginMetadata } from './types';
 
 export { default as shakerEvaluator } from '@linaria/shaker';
 export { EvalCache, Module } from '@linaria/babel-preset';
 export { configSchema } from './schema';
 
 export type { Evaluator, EvalRule } from '@linaria/babel-preset';
-export type { BabelPluginOptions };
+export type { BabelPluginOptions, GriffelHookEntries, GriffelResetHookEntries, BabelPluginMetadata };
 
 export default function griffelPreset(babel: ConfigAPI, options: BabelPluginOptions) {
   return {

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -1,14 +1,14 @@
 import { transformPlugin } from './transformPlugin';
 
 import type { ConfigAPI } from '@babel/core';
-import type { BabelPluginOptions, GriffelHookEntries, GriffelResetHookEntries, BabelPluginMetadata } from './types';
+import type { BabelPluginOptions, BabelPluginMetadata } from './types';
 
 export { default as shakerEvaluator } from '@linaria/shaker';
 export { EvalCache, Module } from '@linaria/babel-preset';
 export { configSchema } from './schema';
 
 export type { Evaluator, EvalRule } from '@linaria/babel-preset';
-export type { BabelPluginOptions, GriffelHookEntries, GriffelResetHookEntries, BabelPluginMetadata };
+export type { BabelPluginOptions, BabelPluginMetadata };
 
 export default function griffelPreset(babel: ConfigAPI, options: BabelPluginOptions) {
   return {

--- a/packages/babel-preset/src/schema.ts
+++ b/packages/babel-preset/src/schema.ts
@@ -6,6 +6,9 @@ export const configSchema: JSONSchema7 = {
 
   type: 'object',
   properties: {
+    generateMetadata: {
+      type: 'boolean',
+    },
     modules: {
       type: 'array',
       items: {

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -286,7 +286,7 @@ describe('babel preset', () => {
     expect(babelFileResult?.metadata).toMatchInlineSnapshot(`Object {}`);
   });
 
-  it.only('should generate metadata for makeStyles when configured', () => {
+  it('should generate metadata for makeStyles when configured', () => {
     const fixture = path.resolve(fixturesDir, 'object', 'code.ts');
     const code = fs.readFileSync(fixture).toString();
 

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -1,3 +1,4 @@
+import * as Babel from '@babel/core';
 import pluginTester, { prettierFormatter } from 'babel-plugin-tester';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -265,4 +266,79 @@ pluginTester({
 
   plugin: transformPlugin,
   pluginName: '@griffel/babel-plugin-transform',
+});
+
+// TODO use the plugin tester and all existing fixtures once there is support for that
+// https://github.com/babel-utils/babel-plugin-tester/issues/186
+describe('babel preset', () => {
+  it('should not generate metadata when not configured', () => {
+    const fixture = path.resolve(fixturesDir, 'object', 'code.ts');
+    const code = fs.readFileSync(fixture).toString();
+
+    const babelFileResult = Babel.transformSync(code, {
+      babelrc: false,
+      configFile: false,
+      plugins: [[transformPlugin]],
+      filename: fixture,
+      presets: ['@babel/typescript'],
+    });
+
+    expect(babelFileResult?.metadata).toMatchInlineSnapshot(`Object {}`);
+  });
+
+  it('should generate metadata for makeStyles when configured', () => {
+    const fixture = path.resolve(fixturesDir, 'object', 'code.ts');
+    const code = fs.readFileSync(fixture).toString();
+
+    const babelFileResult = Babel.transformSync(code, {
+      babelrc: false,
+      configFile: false,
+      plugins: [[transformPlugin, { generateMetadata: true }]],
+      filename: fixture,
+      presets: ['@babel/typescript'],
+    });
+
+    expect(babelFileResult?.metadata).toMatchInlineSnapshot(`
+      Object {
+        cssEntries: Object {
+          useStyles: Object {
+            icon: Array [
+              .fjf1xye{margin-left:4px;},
+              .f8zmjen{margin-right:4px;},
+            ],
+            root: Array [
+              .fycuoez{padding-left:4px;},
+              .f8wuabp{padding-right:4px;},
+            ],
+          },
+        },
+        cssResetEntries: Object {},
+      }
+    `);
+  });
+
+  it('should generate metadata for makeResetStyles when configured', () => {
+    const fixture = path.resolve(fixturesDir, 'reset-styles', 'code.ts');
+    const code = fs.readFileSync(fixture).toString();
+
+    const babelFileResult = Babel.transformSync(code, {
+      babelrc: false,
+      configFile: false,
+      plugins: [[transformPlugin, { generateMetadata: true }]],
+      filename: fixture,
+      presets: ['@babel/typescript'],
+    });
+
+    expect(babelFileResult?.metadata).toMatchInlineSnapshot(`
+      Object {
+        cssEntries: Object {},
+        cssResetEntries: Object {
+          useStyles: Array [
+            .rjefjbm{color:red;padding-left:4px;},
+            .r7z97ji{color:red;padding-right:4px;},
+          ],
+        },
+      }
+    `);
+  });
 });

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -286,7 +286,7 @@ describe('babel preset', () => {
     expect(babelFileResult?.metadata).toMatchInlineSnapshot(`Object {}`);
   });
 
-  it('should generate metadata for makeStyles when configured', () => {
+  it.only('should generate metadata for makeStyles when configured', () => {
     const fixture = path.resolve(fixturesDir, 'object', 'code.ts');
     const code = fs.readFileSync(fixture).toString();
 
@@ -303,10 +303,12 @@ describe('babel preset', () => {
         cssEntries: Object {
           useStyles: Object {
             icon: Array [
+              .fcnqdeg{background-color:green;},
               .fjf1xye{margin-left:4px;},
               .f8zmjen{margin-right:4px;},
             ],
             root: Array [
+              .fe3e8s9{color:red;},
               .fycuoez{padding-left:4px;},
               .f8wuabp{padding-right:4px;},
             ],

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -134,12 +134,14 @@ function buildCSSEntriesMetadata(
       ];
     }),
   );
+
   const cssRules: string[] = Object.values(cssRulesByBucket).flatMap(cssRulesByBucket => {
     return cssRulesByBucket.map(bucketEntry => {
       const [cssRule] = normalizeCSSBucketEntry(bucketEntry);
       return cssRule;
     });
   });
+
   state.cssEntries[hookName] = Object.fromEntries(
     Object.entries(classesBySlot).map(([slot, cssClasses]) => {
       return [

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -105,6 +105,7 @@ function buildCSSResetEntriesMetadata(
   if (Array.isArray(cssRules)) {
     state.cssResetEntries[hookName] = cssRules;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const [_, bucketEntries] of Object.entries(cssRules)) {
       for (const bucketEntry of bucketEntries) {
         if (Array.isArray(bucketEntry)) {
@@ -128,12 +129,14 @@ function buildCSSEntriesMetadata(
 ) {
   const classesBySlot: Record<string, string[]> = {};
   for (const [slot, cssClassesMap] of Object.entries(classnamesMapping)) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const [_, cssClasses] of Object.entries(cssClassesMap)) {
       classesBySlot[slot] = Array.isArray(cssClasses) ? cssClasses : [cssClasses];
     }
   }
 
   const cssRules: string[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for (const [_, bucketEntries] of Object.entries(cssRulesByBucket)) {
     for (const bucketEntry of bucketEntries) {
       if (Array.isArray(bucketEntry)) {

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -16,7 +16,7 @@ import { normalizeStyleRules } from './assets/normalizeStyleRules';
 import { replaceAssetsWithImports } from './assets/replaceAssetsWithImports';
 import { dedupeCSSRules } from './utils/dedupeCSSRules';
 import { evaluatePaths } from './utils/evaluatePaths';
-import { BabelPluginOptions, GriffelHookEntries, GriffelResetHookEntries, BabelPluginMetadata } from './types';
+import { BabelPluginOptions, BabelPluginMetadata } from './types';
 import { validateOptions } from './validateOptions';
 
 type FunctionKinds = 'makeStyles' | 'makeResetStyles';
@@ -34,8 +34,8 @@ type BabelPluginState = PluginPass & {
     path: NodePath<t.Expression | t.SpreadElement>;
   }[];
   calleePaths?: NodePath<t.Identifier>[];
-  cssEntries?: GriffelHookEntries;
-  cssResetEntries?: GriffelResetHookEntries;
+  cssEntries?: BabelPluginMetadata['cssEntries'];
+  cssResetEntries?: BabelPluginMetadata['cssResetEntries'];
 };
 
 function getDefinitionPathFromCallExpression(
@@ -336,8 +336,10 @@ export const transformPlugin = declare<Partial<BabelPluginOptions>, PluginObj<Ba
             });
 
             if (pluginOptions.generateMetadata) {
-              (this.file.metadata as unknown as BabelPluginMetadata).cssResetEntries = state.cssResetEntries ?? {};
-              (this.file.metadata as unknown as BabelPluginMetadata).cssEntries = state.cssEntries ?? {};
+              Object.assign(this.file.metadata, {
+                cssResetEntries: state.cssResetEntries ?? {},
+                cssEntries: state.cssEntries ?? {},
+              } as BabelPluginMetadata);
             }
           }
 

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -131,7 +131,12 @@ function buildCSSEntriesMetadata(
   for (const [slot, cssClassesMap] of Object.entries(classnamesMapping)) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const [_, cssClasses] of Object.entries(cssClassesMap)) {
-      classesBySlot[slot] = Array.isArray(cssClasses) ? cssClasses : [cssClasses];
+      classesBySlot[slot] ??= [];
+      if (Array.isArray(cssClasses)) {
+        classesBySlot[slot].push(...cssClasses);
+      } else {
+        classesBySlot[slot].push(cssClasses);
+      }
     }
   }
 

--- a/packages/babel-preset/src/types.ts
+++ b/packages/babel-preset/src/types.ts
@@ -2,6 +2,11 @@ import type { TransformOptions } from '@babel/core';
 import type { EvalRule } from '@linaria/babel-preset';
 
 export type BabelPluginOptions = {
+  /**
+   * Returns the evaluated CSS rules in the file result metadata
+   * @default false
+   */
+  generateMetadata?: boolean;
   /** Defines set of modules and imports handled by a transformPlugin. */
   modules?: {
     moduleSource: string;
@@ -25,4 +30,14 @@ export type BabelPluginOptions = {
    * @default process.cwd()
    */
   projectRoot?: string;
+};
+
+type CSSRulesBySlot = Record<string, string[]>;
+
+export type GriffelHookEntries = Record<string, CSSRulesBySlot>;
+export type GriffelResetHookEntries = Record<string, string[]>;
+
+export type BabelPluginMetadata = {
+  cssEntries: GriffelHookEntries;
+  cssResetEntries: GriffelResetHookEntries;
 };

--- a/packages/babel-preset/src/types.ts
+++ b/packages/babel-preset/src/types.ts
@@ -32,12 +32,7 @@ export type BabelPluginOptions = {
   projectRoot?: string;
 };
 
-type CSSRulesBySlot = Record<string, string[]>;
-
-export type GriffelHookEntries = Record<string, CSSRulesBySlot>;
-export type GriffelResetHookEntries = Record<string, string[]>;
-
 export type BabelPluginMetadata = {
-  cssEntries: GriffelHookEntries;
-  cssResetEntries: GriffelResetHookEntries;
+  cssEntries: Record<string, Record<string, string[]>>;
+  cssResetEntries: Record<string, string[]>;
 };

--- a/packages/babel-preset/src/validateOptions.test.ts
+++ b/packages/babel-preset/src/validateOptions.test.ts
@@ -35,12 +35,21 @@ describe('validateOptions', () => {
       expect(() => validateOptions(pluginOptions)).not.toThrow();
     });
 
-    it('throws on wrong options', () => {
+    it('throws when babelOptions is not valid', () => {
       const pluginOptions = { babelOptions: [] };
 
       // @ts-expect-error Invalid options are passed for testing purposes
       expect(() => validateOptions(pluginOptions)).toThrowErrorMatchingInlineSnapshot(
         `"Validation failed for passed config: data/babelOptions must be object"`,
+      );
+    });
+
+    it('throws when generateMetadata is not valid', () => {
+      const pluginOptions = { generateMetadata: 3 };
+
+      // @ts-expect-error Invalid options are passed for testing purposes
+      expect(() => validateOptions(pluginOptions)).toThrowErrorMatchingInlineSnapshot(
+        `"Validation failed for passed config: data/generateMetadata must be boolean"`,
       );
     });
   });


### PR DESCRIPTION
Adds a new plugin option `generateMetadata`.

Once this option is set, the babel preset will return metadata on the evaluated file containing Griffel styles in the below schema:

```ts
{
  // makeStyles
  cssEntries: {
    // by each hook
    useStyles1: {
      // by each slot
      root:  [ .fxxxxx { color: 'red' } ],
    }
    useStyles2: {
      root:  [ .fxxxxx { color: 'red' } ],
    },
  },

  // makeResetStyles
  cssResetEntries: {
    // by each hook
    useResetStyles1: [ .fxxxxx { color: 'red' } ],
    useResetStyles2: [ .fxxxxx { color: 'red' } ],
  }
}
```

This metadata is intended for programmatic transforms in code that can be reused by other tooling:


```ts
  const babelFileResult = Babel.transformFromAstSync(babelAST, sourceCode, {
    babelrc: false,
    configFile: false,
    presets: [[griffelPreset, { generateMetadata: true }]],

    filename: options.filename,

    sourceMaps: options.enableSourceMaps,
    sourceFileName: options.filename,
    inputSourceMap: options.inputSourceMap,
  });

  // metadata
  console.log(babelFileResult.metadata);
```