### PR TITLE
Stop inlining the CSS in the virtual CSS module request

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-2722342d-e7ad-42c7-b370-cc43d50217de.json
+++ b/change/@griffel-webpack-extraction-plugin-2722342d-e7ad-42c7-b370-cc43d50217de.json
@@ -1,6 +1,6 @@
 {
-  "type": "minor",
-  "comment": "Stop inlining the styles in the virtual CSS module request",
+  "type": "patch",
+  "comment": "chore: stop inlining the styles in the virtual CSS module request",
   "packageName": "@griffel/webpack-extraction-plugin",
   "email": "miclo@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@griffel-webpack-extraction-plugin-2722342d-e7ad-42c7-b370-cc43d50217de.json
+++ b/change/@griffel-webpack-extraction-plugin-2722342d-e7ad-42c7-b370-cc43d50217de.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Stop inlining the styles in the virtual CSS module request",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-flip/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-flip/output.ts
@@ -6,4 +6,4 @@ export const useStyles = _css({
   },
 });
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.ftcbn0w%7Bbackground-image%3Aurl(.%2Fleft.jpg)%2Curl(.%2Fright.jpg)%3B%7D.f37sp7w%7Bbackground-image%3Aurl(.%2Fright.jpg)%2Curl(.%2Fleft.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets-multiple/output.ts
@@ -6,4 +6,4 @@ export const useStyles = _css({
   },
 });
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fp00rh9%7Bbackground-image%3Aurl(.%2Fblank.jpg)%2Curl(.%2Fempty.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/assets/output.ts
@@ -6,4 +6,4 @@ export const useStyles = _css({
   },
 });
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fnwsaxv%7Bbackground-image%3Aurl(.%2Fblank.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/basic-rules/output.ts
@@ -11,4 +11,4 @@ export const styles = _css({
   },
 });
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D.fycuoez%7Bpadding-left%3A4px%3B%7D.f8wuabp%7Bpadding-right%3A4px%3B%7D.fcnqdeg%7Bbackground-color%3Agreen%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/mixed/output.ts
@@ -8,4 +8,4 @@ export const useClasses = _css({
 });
 export const useClassName = _resetCSS('rjefjbm', 'r7z97ji');
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/multiple/output.ts
@@ -11,4 +11,4 @@ export const stylesB = _css({
   },
 });
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fcnqdeg%7Bbackground-color%3Agreen%3B%7D.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset-assets/output.ts
@@ -2,4 +2,4 @@ import { __resetCSS as _resetCSS } from '@griffel/react';
 import { __resetStyles } from '@griffel/react';
 export const useClassName = _resetCSS('ra9m047', null);
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.ra9m047%7Bbackground-image%3Aurl(.%2Fblank.jpg)%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/reset/output.ts
@@ -2,4 +2,4 @@ import { __resetCSS as _resetCSS } from '@griffel/react';
 import { __resetStyles } from '@griffel/react';
 export const useClassName = _resetCSS('rjefjbm', 'r7z97ji');
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-attach-to-main/output.ts
@@ -10,4 +10,4 @@ export const useClasses = __styles(
   },
 );
 
-require('./code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts');
+require('./code.griffel.css!=!../../../virtual-loader/index.js!./code.ts');

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/unstable-keep-original-code/output.ts
@@ -16,4 +16,4 @@ export const useClassName = __resetStyles('rjefjbm', 'r7z97ji', [
   '.r7z97ji{color:red;padding-right:4px;}',
 ]);
 
-import './code.griffel.css!=!../../../virtual-loader/index.js?style=%2F**%20%40griffel%3Acss-start%20%5Br%5D%20**%2F%0A.rjefjbm%7Bcolor%3Ared%3Bpadding-left%3A4px%3B%7D.r7z97ji%7Bcolor%3Ared%3Bpadding-right%3A4px%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A%2F**%20%40griffel%3Acss-start%20%5Bd%5D%20**%2F%0A.fe3e8s9%7Bcolor%3Ared%3B%7D%0A%2F**%20%40griffel%3Acss-end%20**%2F%0A!./code.ts';
+import './code.griffel.css!=!../../../virtual-loader/index.js!./code.ts';

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -4,7 +4,7 @@ import type { Chunk, Compiler, Module, sources } from 'webpack';
 
 import { parseCSSRules } from './parseCSSRules';
 import { sortCSSRules } from './sortCSSRules';
-import { PLUGIN_NAME, GriffelCssLoaderContextKey, type SupplementedLoaderCotext } from './constants';
+import { PLUGIN_NAME, GriffelCssLoaderContextKey, type SupplementedLoaderContext } from './constants';
 
 // Webpack does not export these constants
 // https://github.com/webpack/webpack/blob/b67626c7b4ffed8737d195b27c8cea1e68d58134/lib/OptimizationStages.js#L8
@@ -185,7 +185,7 @@ export class GriffelCSSExtractionPlugin {
       NormalModule.getCompilationHooks(compilation).loader.tap(PLUGIN_NAME, (loaderContext, module) => {
         const resourcePath = module.resource;
 
-        (loaderContext as SupplementedLoaderCotext)[GriffelCssLoaderContextKey] = {
+        (loaderContext as SupplementedLoaderContext)[GriffelCssLoaderContextKey] = {
           registerExtractedCss(css: string) {
             cssByModuleMap.set(resourcePath, css);
           },

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -4,13 +4,7 @@ import type { Chunk, Compiler, Module, sources } from 'webpack';
 
 import { parseCSSRules } from './parseCSSRules';
 import { sortCSSRules } from './sortCSSRules';
-import {
-  GriffelCssModule,
-  GriffelCssModuleKey,
-  PLUGIN_NAME,
-  RegisterMappingsLoaderContextKey,
-  type SupplementedLoaderCotext,
-} from './constants';
+import { PLUGIN_NAME, GriffelCssLoaderContextKey, type SupplementedLoaderCotext } from './constants';
 
 // Webpack does not export these constants
 // https://github.com/webpack/webpack/blob/b67626c7b4ffed8737d195b27c8cea1e68d58134/lib/OptimizationStages.js#L8
@@ -188,7 +182,7 @@ export class GriffelCSSExtractionPlugin {
       //   Allows us to register the CSS extracted from Griffel calls to then process in a CSS module
       const cssByModuleMap: Record<string, string> = {};
       NormalModule.getCompilationHooks(compilation).loader.tap(PLUGIN_NAME, (loaderContext, module) => {
-        (loaderContext as SupplementedLoaderCotext)[RegisterMappingsLoaderContextKey] = {
+        (loaderContext as SupplementedLoaderCotext)[GriffelCssLoaderContextKey] = {
           registerExtractedCss(css: string) {
             cssByModuleMap[module.resource] = css;
           },

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -180,14 +180,20 @@ export class GriffelCSSExtractionPlugin {
       //   Adds a callback to the loader context
       // WHY?
       //   Allows us to register the CSS extracted from Griffel calls to then process in a CSS module
-      const cssByModuleMap: Record<string, string> = {};
+      const cssByModuleMap = new Map<string, string>();
+
       NormalModule.getCompilationHooks(compilation).loader.tap(PLUGIN_NAME, (loaderContext, module) => {
+        const resourcePath = module.resource;
+
         (loaderContext as SupplementedLoaderCotext)[GriffelCssLoaderContextKey] = {
           registerExtractedCss(css: string) {
-            cssByModuleMap[module.resource] = css;
+            cssByModuleMap.set(resourcePath, css);
           },
           getExtractedCss() {
-            return cssByModuleMap[module.resource] ?? '';
+            const css = cssByModuleMap.get(resourcePath) ?? '';
+            cssByModuleMap.delete(resourcePath);
+
+            return css;
           },
         };
       });

--- a/packages/webpack-extraction-plugin/src/constants.ts
+++ b/packages/webpack-extraction-plugin/src/constants.ts
@@ -1,0 +1,18 @@
+import type { LoaderContext, NormalModule } from 'webpack';
+
+export const PLUGIN_NAME = 'GriffelExtractPlugin';
+export const RegisterMappingsLoaderContextKey = Symbol(`${PLUGIN_NAME}/RegisterMappingsLoaderContextKey`);
+export const GriffelCssModuleKey = Symbol(`${PLUGIN_NAME}/extracted-css`);
+
+export interface GriffelLoaderContextSupplement {
+  registerExtractedCss(css: string): void;
+  getExtractedCss(): string;
+}
+
+export type SupplementedLoaderCotext<Options = unknown> = LoaderContext<Options> & {
+  [RegisterMappingsLoaderContextKey]?: GriffelLoaderContextSupplement;
+};
+
+export type GriffelCssModule = NormalModule & {
+  [GriffelCssModuleKey]: string;
+};

--- a/packages/webpack-extraction-plugin/src/constants.ts
+++ b/packages/webpack-extraction-plugin/src/constants.ts
@@ -1,8 +1,7 @@
-import type { LoaderContext, NormalModule } from 'webpack';
+import type { LoaderContext } from 'webpack';
 
 export const PLUGIN_NAME = 'GriffelExtractPlugin';
-export const RegisterMappingsLoaderContextKey = Symbol(`${PLUGIN_NAME}/RegisterMappingsLoaderContextKey`);
-export const GriffelCssModuleKey = Symbol(`${PLUGIN_NAME}/extracted-css`);
+export const GriffelCssLoaderContextKey = Symbol(`${PLUGIN_NAME}/GriffelCssLoaderContextKey`);
 
 export interface GriffelLoaderContextSupplement {
   registerExtractedCss(css: string): void;
@@ -10,9 +9,5 @@ export interface GriffelLoaderContextSupplement {
 }
 
 export type SupplementedLoaderCotext<Options = unknown> = LoaderContext<Options> & {
-  [RegisterMappingsLoaderContextKey]?: GriffelLoaderContextSupplement;
-};
-
-export type GriffelCssModule = NormalModule & {
-  [GriffelCssModuleKey]: string;
+  [GriffelCssLoaderContextKey]?: GriffelLoaderContextSupplement;
 };

--- a/packages/webpack-extraction-plugin/src/constants.ts
+++ b/packages/webpack-extraction-plugin/src/constants.ts
@@ -8,6 +8,6 @@ export interface GriffelLoaderContextSupplement {
   getExtractedCss(): string;
 }
 
-export type SupplementedLoaderCotext<Options = unknown> = LoaderContext<Options> & {
+export type SupplementedLoaderContext<Options = unknown> = LoaderContext<Options> & {
   [GriffelCssLoaderContextKey]?: GriffelLoaderContextSupplement;
 };

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
-import { RegisterMappingsLoaderContextKey, SupplementedLoaderCotext } from './constants';
+import { GriffelCssLoaderContextKey, SupplementedLoaderCotext } from './constants';
 
 export type WebpackLoaderOptions = {
   /**
@@ -106,7 +106,7 @@ function webpackLoader(
 
       const outputFileName = this.resourcePath.replace(/\.[^.]+$/, '.griffel.css');
 
-      this[RegisterMappingsLoaderContextKey]?.registerExtractedCss(css);
+      this[GriffelCssLoaderContextKey]?.registerExtractedCss(css);
       const request = `${outputFileName}!=!${virtualLoaderPath}!${this.resourcePath}`;
       const stringifiedRequest = JSON.stringify(this.utils.contextify(this.context || this.rootContext, request));
 

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
+import { RegisterMappingsLoaderContextKey, SupplementedLoaderCotext } from './constants';
 
 export type WebpackLoaderOptions = {
   /**
@@ -14,10 +15,6 @@ export type WebpackLoaderOptions = {
 type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLoaderOptions>>;
 
 const virtualLoaderPath = path.resolve(__dirname, '..', 'virtual-loader', 'index.js');
-
-function toURIComponent(rule: string): string {
-  return encodeURIComponent(rule).replace(/!/g, '%21');
-}
 
 /**
  * Webpack can also pass sourcemaps as a string, Babel accepts only objects.
@@ -36,7 +33,7 @@ function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOption
 }
 
 function webpackLoader(
-  this: webpack.LoaderContext<WebpackLoaderOptions>,
+  this: SupplementedLoaderCotext<WebpackLoaderOptions>,
   sourceCode: WebpackLoaderParams[0],
   inputSourceMap: WebpackLoaderParams[1],
 ) {
@@ -59,7 +56,6 @@ function webpackLoader(
   try {
     result = transformSync(sourceCode, {
       filename: path.relative(process.cwd(), this.resourcePath),
-
       enableSourceMaps: this.sourceMap || false,
       inputSourceMap: parseSourceMap(inputSourceMap),
     });
@@ -70,9 +66,10 @@ function webpackLoader(
   if (result) {
     const resultCode = unstable_keepOriginalCode ? sourceCode : result.code;
     const resultSourceMap = unstable_keepOriginalCode ? inputSourceMap : result.sourceMap;
+    const { cssRulesByBucket } = result;
 
-    if (result.cssRulesByBucket) {
-      const entries = Object.entries(result.cssRulesByBucket);
+    if (cssRulesByBucket) {
+      const entries = Object.entries(cssRulesByBucket);
 
       if (entries.length === 0) {
         this.callback(null, resultCode, resultSourceMap);
@@ -109,7 +106,8 @@ function webpackLoader(
 
       const outputFileName = this.resourcePath.replace(/\.[^.]+$/, '.griffel.css');
 
-      const request = `${outputFileName}!=!${virtualLoaderPath}?style=${toURIComponent(css)}!${this.resourcePath}`;
+      this[RegisterMappingsLoaderContextKey]?.registerExtractedCss(css);
+      const request = `${outputFileName}!=!${virtualLoaderPath}!${this.resourcePath}`;
       const stringifiedRequest = JSON.stringify(this.utils.contextify(this.context || this.rootContext, request));
 
       this.callback(null, `${resultCode}\n\nimport ${stringifiedRequest};`, resultSourceMap);

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as webpack from 'webpack';
 
 import { transformSync, TransformResult, TransformOptions } from './transformSync';
-import { GriffelCssLoaderContextKey, SupplementedLoaderCotext } from './constants';
+import { GriffelCssLoaderContextKey, SupplementedLoaderContext } from './constants';
 
 export type WebpackLoaderOptions = {
   /**
@@ -33,7 +33,7 @@ function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOption
 }
 
 function webpackLoader(
-  this: SupplementedLoaderCotext<WebpackLoaderOptions>,
+  this: SupplementedLoaderContext<WebpackLoaderOptions>,
   sourceCode: WebpackLoaderParams[0],
   inputSourceMap: WebpackLoaderParams[1],
 ) {

--- a/packages/webpack-extraction-plugin/virtual-loader/index.js
+++ b/packages/webpack-extraction-plugin/virtual-loader/index.js
@@ -1,11 +1,11 @@
+const { RegisterMappingsLoaderContextKey } = require('../src/constants');
+
 /**
- * @this {import('webpack').LoaderContext<{ style?: string }>}
+ * @this {import("../src/constants").SupplementedLoaderCotext}
  * @return {String}
  */
 function virtualLoader() {
-  const { style = '' } = this.getOptions();
-
-  return style;
+  return this[RegisterMappingsLoaderContextKey]?.getExtractedCss() ?? '';
 }
 
 module.exports = virtualLoader;

--- a/packages/webpack-extraction-plugin/virtual-loader/index.js
+++ b/packages/webpack-extraction-plugin/virtual-loader/index.js
@@ -1,7 +1,7 @@
 const { GriffelCssLoaderContextKey } = require('../src/constants');
 
 /**
- * @this {import("../src/constants").SupplementedLoaderCotext}
+ * @this {import("../src/constants").SupplementedLoaderContext}
  * @return {String}
  */
 function virtualLoader() {

--- a/packages/webpack-extraction-plugin/virtual-loader/index.js
+++ b/packages/webpack-extraction-plugin/virtual-loader/index.js
@@ -1,11 +1,11 @@
-const { RegisterMappingsLoaderContextKey } = require('../src/constants');
+const { GriffelCssLoaderContextKey } = require('../src/constants');
 
 /**
  * @this {import("../src/constants").SupplementedLoaderCotext}
  * @return {String}
  */
 function virtualLoader() {
-  return this[RegisterMappingsLoaderContextKey]?.getExtractedCss() ?? '';
+  return this[GriffelCssLoaderContextKey]?.getExtractedCss() ?? '';
 }
 
 module.exports = virtualLoader;


### PR DESCRIPTION
This change should have no impact on production build output. However, one issue I've noticed hen trying to migrate Outlook to use this is that our bundle-diff tool gets unwieldy with the massive module requests that embed the entire extracted CSS into the request.

Instead, this change stores the extracted CSS in a map in the plugin, and uses an enhancement to the loader context to read and write the CSS in the map. As a result, we can eliminate the `?styles=<css>` part of the module request.