### PR TITLE
fix(style-types): allow CSS variables in animationName

### DIFF
--- a/change/@griffel-style-types-ce9ebd17-8bff-4a8f-977b-21c6d5621021.json
+++ b/change/@griffel-style-types-ce9ebd17-8bff-4a8f-977b-21c6d5621021.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: allow CSS variables in animationName, stricter types for selectors",
+  "packageName": "@griffel/style-types",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/e2e/typescript/src/assets/fixture-reset.ts
+++ b/e2e/typescript/src/assets/fixture-reset.ts
@@ -24,11 +24,23 @@ assertType({
     },
   ],
 });
+assertType({
+  animationName: {
+    from: { '--opacity': '0' },
+    to: { '--opacity': '1' },
+  },
+});
 
 assertType({
   // @ts-expect-error "200" is not a valid CSS value for "height"
   animationName: {
     to: { height: 200 },
+  },
+});
+assertType({
+  // @ts-expect-error Only strings can be used as values for CSS variables
+  animationName: {
+    from: { '--opacity': 0 },
   },
 });
 
@@ -95,6 +107,11 @@ assertType({
 });
 assertType({
   ':hover': { animationName: { from: {}, to: {} } },
+});
+
+assertType({
+  // @ts-expect-error Values of selectors can be only objects
+  ':hover': 'red',
 });
 
 // Custom selectors

--- a/e2e/typescript/src/assets/fixture.ts
+++ b/e2e/typescript/src/assets/fixture.ts
@@ -24,11 +24,23 @@ assertType({
     },
   ],
 });
+assertType({
+  animationName: {
+    from: { '--opacity': '0' },
+    to: { '--opacity': '1' },
+  },
+});
 
 assertType({
   // @ts-expect-error "200" is not a valid CSS value for "height"
   animationName: {
     to: { height: 200 },
+  },
+});
+assertType({
+  // @ts-expect-error Only strings can be used as values for CSS variables
+  animationName: {
+    from: { '--opacity': 0 },
   },
 });
 
@@ -92,6 +104,11 @@ assertType({
 });
 assertType({
   ':hover': { animationName: { from: {}, to: {} } },
+});
+
+assertType({
+  // @ts-expect-error Values of selectors can be only objects
+  ':hover': 'red',
 });
 
 // Custom selectors

--- a/e2e/typescript/src/test.ts
+++ b/e2e/typescript/src/test.ts
@@ -76,7 +76,8 @@ async function performTest(tsVersion: string, options: { mode?: 'legacy' | 'mode
 
 (async () => {
   await performTest('3.9', { mode: 'legacy' });
-  await performTest('4.1');
+  await performTest('4.1', { mode: 'legacy' });
+  await performTest('4.3', { mode: 'legacy' });
   await performTest('4.4');
   await performTest('4.9');
   await performTest('5.0');

--- a/packages/style-types/package.json
+++ b/packages/style-types/package.json
@@ -12,7 +12,7 @@
     "csstype": "^3.1.2"
   },
   "typesVersions": {
-    "<4.1": {
+    "<4.4": {
       "src/index.d.ts": [
         "src/legacy/index.d.ts"
       ]

--- a/packages/style-types/src/makeResetStyles.ts
+++ b/packages/style-types/src/makeResetStyles.ts
@@ -23,5 +23,8 @@ type GriffelCSSPseudos = {
   [Property in CSS.Pseudos]?: GriffelResetStylesStrictCSSObject | GriffelCSSObjectCustom;
 };
 
-export type GriffelResetAnimation = Record<'from' | 'to' | string, GriffelResetStylesCSSProperties>;
+export type GriffelResetAnimation = Record<
+  'from' | 'to' | string,
+  GriffelResetStylesCSSProperties & { [Property in `--${string}`]: string }
+>;
 export type GriffelResetStyle = GriffelResetStylesStrictCSSObject | GriffelCSSObjectCustom;

--- a/packages/style-types/src/makeStyles.ts
+++ b/packages/style-types/src/makeStyles.ts
@@ -27,5 +27,8 @@ type GriffelCSSPseudos = {
   [Property in CSS.Pseudos]?: GriffelStylesStrictCSSObject | GriffelCSSObjectCustom;
 };
 
-export type GriffelAnimation = Record<'from' | 'to' | string, GriffelStylesCSSProperties>;
+export type GriffelAnimation = Record<
+  'from' | 'to' | string,
+  GriffelStylesCSSProperties & { [Property in `--${string}`]: string }
+>;
 export type GriffelStyle = GriffelStylesStrictCSSObject | GriffelCSSObjectCustom;


### PR DESCRIPTION
Fixes an issue with `animationName` (fixes #417) to allow usage of CSS variables in `animationName`. The fix is done for modern typings as legacy typings already allow it.

To make it strict, new syntax with template literals. Legacy types now used for TS 4.3 and earlier.