### PR TITLE
feat: Implment postcss custom syntax for Griffel

### DIFF
--- a/change/@griffel-postcss-syntax-d4ee585a-66da-45c9-91ac-92a8b8f828be.json
+++ b/change/@griffel-postcss-syntax-d4ee585a-66da-45c9-91ac-92a8b8f828be.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: Initial release",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "nano-staged": "0.5.0",
     "next": "12.2.4",
     "nx": "15.3.3",
+    "postcss": "^8.4.29",
     "prettier": "2.8.2",
     "prism-react-renderer": "1.2.1",
     "react": "18.2.0",

--- a/packages/postcss-syntax/.babelrc
+++ b/packages/postcss-syntax/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/postcss-syntax/.eslintrc.json
+++ b/packages/postcss-syntax/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/postcss-syntax/README.md
+++ b/packages/postcss-syntax/README.md
@@ -13,4 +13,21 @@ calls. The parsed postcss AST will include source locations back to the original
 The stringifier only works on a postcss AST that was parsed by this custom syntax since Griffel ahead of time
 compilation lacks the capability to map generated CSS back to the original javascript properties very accurately.
 
+## Configuring @griffel/babel-preset
+
+The preprocessor uses transforms in the `@griffel/babel-preset` package. In order to configure the babel transform
+that is used internally, we've created the a factory to return the custom syntax that uses the desired configuration.
+
+```ts
+import { createSyntax } from '@griffel/postcss-syntax';
+const syntax = createSyntax({
+  modules: [
+    { importSource: '@myScope/griffel', importName: 'createStyles' },
+  ]
+})
+```
+
+For more information about how to configure the babel Griffel preset 
+[you can check out the docs](https://github.com/microsoft/griffel/blob/main/packages/babel-preset/README.md#usage)
+
 

--- a/packages/postcss-syntax/README.md
+++ b/packages/postcss-syntax/README.md
@@ -22,7 +22,7 @@ that is used internally, we've created the a factory to return the custom syntax
 import { createSyntax } from '@griffel/postcss-syntax';
 const syntax = createSyntax({
   modules: [
-    { importSource: '@myScope/griffel', importName: 'createStyles' },
+    { moduleSource: '@myScope/griffel', importName: 'createStyles' },
   ]
 })
 ```

--- a/packages/postcss-syntax/README.md
+++ b/packages/postcss-syntax/README.md
@@ -1,0 +1,16 @@
+# Postcss syntax for Griffel
+
+A postcss [custom syntax](https://postcss.org/docs/how-to-write-custom-syntax) for Javascript files that contain
+Griffel CSS in JS code.
+
+## Parser
+
+The parser will parse a Javascript file and return the CSS output of any Griffel `makeStyle` or `makeResetStyle`
+calls. The parsed postcss AST will include source locations back to the original Javascript code.
+
+## Stringifier
+
+The stringifier only works on a postcss AST that was parsed by this custom syntax since Griffel ahead of time
+compilation lacks the capability to map generated CSS back to the original javascript properties very accurately.
+
+

--- a/packages/postcss-syntax/jest.config.ts
+++ b/packages/postcss-syntax/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'eslint-plugin',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  coverageDirectory: '../../coverage/packages/eslint-plugin',
+};

--- a/packages/postcss-syntax/package.json
+++ b/packages/postcss-syntax/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@griffel/postcss-syntax",
+  "version": "1.0.0",
+  "description": "postcss syntax for Griffel",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/griffel"
+  },
+  "dependencies": {
+    "@babel/core": "^7.12.13",
+    "@griffel/babel-preset": "^1.5.0",
+    "@babel/helper-plugin-utils": "^7.12.13",
+    "postcss": "^8.4.29"
+  },
+  "main": "index.js"
+}

--- a/packages/postcss-syntax/package.json
+++ b/packages/postcss-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@griffel/postcss-syntax",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "postcss syntax for Griffel",
   "license": "MIT",
   "repository": {

--- a/packages/postcss-syntax/project.json
+++ b/packages/postcss-syntax/project.json
@@ -1,0 +1,55 @@
+{
+  "name": "@griffel/postcss-syntax",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/postcss-syntax/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/postcss-syntax/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/packages/postcss-syntax"],
+      "options": {
+        "jestConfig": "packages/postcss-syntax/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/postcss-syntax",
+        "tsConfig": "packages/postcss-syntax/tsconfig.lib.json",
+        "packageJson": "packages/postcss-syntax/package.json",
+        "main": "packages/postcss-syntax/src/index.ts",
+        "updateBuildableProjectDepsInPackageJson": false,
+        "assets": [
+          "packages/postcss-syntax/README.md",
+          {
+            "glob": "LICENSE.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/babel-preset",
+        "commands": [
+          {
+            "command": "tsc -b --pretty"
+          }
+        ],
+        "outputPath": []
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/postcss-syntax/src/constants.ts
+++ b/packages/postcss-syntax/src/constants.ts
@@ -1,0 +1,3 @@
+export const GRIFFEL_SLOT_RAW = 'griffel-slot';
+export const GRIFFEL_SRC_RAW = 'griffel-src';
+export const GRIFFEL_DECLARATOR_RAW = 'griffel-declarator';

--- a/packages/postcss-syntax/src/createSyntax.ts
+++ b/packages/postcss-syntax/src/createSyntax.ts
@@ -1,0 +1,18 @@
+import * as postcss from 'postcss';
+import { parse } from './parse';
+import { stringify } from './stringify';
+import { BabelPluginOptions } from '@griffel/babel-preset';
+
+/**
+ * Creates a custom syntax with configured options for @griffel/babel-preset
+ * @param options - Options to configure @griffel/babel-preset
+ * @returns a postcss custom syntax
+ */
+export function createSyntax(options: BabelPluginOptions): postcss.Syntax {
+  const extendedParse: postcss.Parser = (css, opts) => parse(css, { ...opts, ...options });
+
+  return {
+    stringify,
+    parse: extendedParse,
+  };
+}

--- a/packages/postcss-syntax/src/index.ts
+++ b/packages/postcss-syntax/src/index.ts
@@ -2,6 +2,7 @@ import { parse } from './parse';
 import { stringify } from './stringify';
 
 export { parse, stringify };
+export { createSyntax } from './createSyntax';
 
 export default {
   parse,

--- a/packages/postcss-syntax/src/index.ts
+++ b/packages/postcss-syntax/src/index.ts
@@ -1,0 +1,9 @@
+import { parse } from './parse';
+import { stringify } from './stringify';
+
+export { parse, stringify };
+
+export default {
+  parse,
+  stringify,
+};

--- a/packages/postcss-syntax/src/location-preset.ts
+++ b/packages/postcss-syntax/src/location-preset.ts
@@ -1,5 +1,6 @@
-import { PluginObj, PluginPass, types as t } from '@babel/core';
+import { PluginObj, PluginPass, types as t, ConfigAPI } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
+import { BabelPluginOptions } from '@griffel/babel-preset';
 
 export interface LocationPluginState extends PluginPass {
   locations?: Record<string, Record<string, t.SourceLocation>>;
@@ -11,15 +12,29 @@ export interface LocationPluginMetadata {
   resetLocations: Record<string, t.SourceLocation>;
 }
 
-// TODO setup module source for babel so the import source can be configured
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface LocationPluginOptions {}
+export interface LocationPluginOptions extends Pick<BabelPluginOptions, 'modules'> {}
 
 /**
  * A plugin that parses Griffel code and returns code locations mapped to respective styles and slots
  */
-const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((api /** options */) => {
+const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((api, options) => {
   api.assertVersion(7);
+
+  const {
+    modules = [
+      { moduleSource: '@griffel/react', importName: 'makeStyles', resetImportName: 'makeResetStyles' },
+      { moduleSource: '@fluentui/react-components', importName: 'makeStyles', resetImportName: 'makeResetStyles' },
+    ],
+  } = options;
+
+  const functionKinds = modules.map(moduleEntry => {
+    return moduleEntry.importName ?? 'makeStyles';
+  });
+
+  const resetFunctionKinds = modules.map(moduleEntry => {
+    return moduleEntry.resetImportName ?? 'makeResetStyles';
+  });
 
   return {
     name: '@griffel/slot-location-plugin',
@@ -54,7 +69,10 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
           return;
         }
 
-        if (callee.node.name === 'makeStyles') {
+        // Technically we should check if these function kinds are from Griffel
+        // but since we only collect locations, the plugin is idempotent and we
+        // it's safe enough to avoid doing that check
+        if (functionKinds.includes(callee.node.name)) {
           const locations = path.get('arguments')[0];
           if (!locations.isObjectExpression()) {
             return;
@@ -86,7 +104,7 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
           });
         }
 
-        if (callee.node.name === 'makeResetStyles') {
+        if (resetFunctionKinds.includes(callee.node.name)) {
           state.resetLocations ??= {};
           const resetStyles = path.get('arguments')[0];
           if (!resetStyles.isObjectExpression()) {
@@ -104,4 +122,8 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
   };
 });
 
-export default () => ({ plugins: [plugin] });
+export default (babel: ConfigAPI, options: LocationPluginOptions) => {
+  return {
+    plugins: [[plugin, options]],
+  };
+};

--- a/packages/postcss-syntax/src/location-preset.ts
+++ b/packages/postcss-syntax/src/location-preset.ts
@@ -1,0 +1,107 @@
+import { PluginObj, PluginPass, types as t } from '@babel/core';
+import { declare } from '@babel/helper-plugin-utils';
+
+export interface LocationPluginState extends PluginPass {
+  locations?: Record<string, Record<string, t.SourceLocation>>;
+  resetLocations?: Record<string, t.SourceLocation>;
+}
+
+export interface LocationPluginMetadata {
+  locations: Record<string, Record<string, t.SourceLocation>>;
+  resetLocations: Record<string, t.SourceLocation>;
+}
+
+// TODO setup module source for babel so the import source can be configured
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface LocationPluginOptions {}
+
+/**
+ * A plugin that parses Griffel code and returns code locations mapped to respective styles and slots
+ */
+const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((api /** options */) => {
+  api.assertVersion(7);
+
+  return {
+    name: '@griffel/slot-location-plugin',
+
+    pre() {
+      this.locations = {};
+      this.resetLocations = {};
+    },
+
+    visitor: {
+      Program: {
+        exit() {
+          Object.assign(this.file.metadata, {
+            locations: this.locations,
+            resetLocations: this.resetLocations,
+          } as LocationPluginMetadata);
+        },
+      },
+
+      CallExpression(path, state) {
+        const callee = path.get('callee');
+        const declarator = path.findParent(p => p.isVariableDeclarator());
+
+        if (!declarator?.isVariableDeclarator()) {
+          return;
+        }
+
+        const id = declarator.get('id');
+        const declaratorId = id.isIdentifier() ? id.node.name : 'unknown';
+
+        if (!callee.isIdentifier()) {
+          return;
+        }
+
+        if (callee.node.name === 'makeStyles') {
+          const locations = path.get('arguments')[0];
+          if (!locations.isObjectExpression()) {
+            return;
+          }
+
+          const properties = locations.get('properties');
+          properties.forEach(property => {
+            if (!property.isObjectProperty()) {
+              return;
+            }
+
+            const key = property.get('key');
+            if (!key.isIdentifier()) {
+              return;
+            }
+
+            if (!property.node.loc) {
+              return;
+            }
+
+            state.locations ??= {};
+            state.locations[declaratorId] ??= {};
+            state.locations[declaratorId][key.node.name] = {
+              ...property.node.loc,
+            };
+            state.locations[declaratorId][key.node.name] = {
+              ...property.node.loc,
+            };
+          });
+        }
+
+        if (callee.node.name === 'makeResetStyles') {
+          state.resetLocations ??= {};
+          const resetStyles = path.get('arguments')[0];
+          if (!resetStyles.isObjectExpression()) {
+            return;
+          }
+
+          if (!resetStyles.node.loc) {
+            return;
+          }
+
+          state.resetLocations[declaratorId] = resetStyles.node.loc;
+        }
+      },
+    },
+  };
+});
+
+export default () => ({ plugins: [plugin] });

--- a/packages/postcss-syntax/src/parse.test.ts
+++ b/packages/postcss-syntax/src/parse.test.ts
@@ -1,0 +1,220 @@
+import { GRIFFEL_DECLARATOR_RAW, GRIFFEL_SLOT_RAW, GRIFFEL_SRC_RAW } from './constants';
+import { parse } from './parse';
+import * as prettier from 'prettier';
+
+const format = (css: string) => {
+  return prettier.format(css, { parser: 'css' });
+};
+
+describe('parse', () => {
+  describe('makeStyles', () => {
+    it('should return postcss AST of valid CSS', () => {
+      const fixture = `
+import { makeStyles } from '@griffel/react';
+
+const mixin = () => ({
+  marginTop: '4px',
+})
+
+export const useStyles = makeStyles({
+  root: {
+    color: 'red',
+    backgroundColor: 'green',
+    ...mixin()
+  }
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      expect(format(root.toString())).toMatchInlineSnapshot(`
+              ".fe3e8s9 {
+                color: red;
+              }
+              .fcnqdeg {
+                background-color: green;
+              }
+              .fvjh0tl {
+                margin-top: 4px;
+              }
+              "
+          `);
+    });
+
+    it('should map style locations to slots', () => {
+      const fixture = `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  slot1: {
+    color: 'red',
+  },
+
+  slot2: {
+    color: 'blue',
+  }
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+
+      root.walk(node => {
+        const slot = node.raw(GRIFFEL_SLOT_RAW);
+        expect(['slot1', 'slot2']).toContain(slot);
+
+        if (node.source) {
+          // This test will depend on the source fixture and its indentation
+          if (slot === 'slot1') {
+            expect(node.source.start).toEqual({ offset: 0, column: 2, line: 5 });
+            expect(node.source.end).toEqual({ offset: 0, column: 3, line: 7 });
+          }
+
+          if (slot === 'slot2') {
+            expect(node.source.start).toEqual({ offset: 0, column: 2, line: 9 });
+            expect(node.source.end).toEqual({ offset: 0, column: 3, line: 11 });
+          }
+        }
+      });
+    });
+
+    it('should hold original source in document raw field', () => {
+      const fixture = `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  slot1: {
+    color: 'red',
+  },
+
+  slot2: {
+    color: 'blue',
+  }
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      expect(root.raw(GRIFFEL_SRC_RAW)).toEqual(fixture);
+    });
+
+    it('should handle multiple declarators', () => {
+      const fixture = `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles1 = makeStyles({
+  slot: {
+    color: 'red',
+  },
+})
+
+export const useStyles2 = makeStyles({
+  slot: {
+    color: 'red',
+  },
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      root.walk(node => {
+        const declarator = node.raw(GRIFFEL_DECLARATOR_RAW);
+        expect(['useStyles1', 'useStyles2']).toContain(declarator);
+
+        if (node.source) {
+          if (declarator === 'useStyles1') {
+            expect(node.source.start).toEqual({ offset: 0, column: 2, line: 5 });
+            expect(node.source.end).toEqual({ offset: 0, column: 3, line: 7 });
+          }
+
+          if (declarator === 'useStyles2') {
+            expect(node.source.start).toEqual({ offset: 0, column: 2, line: 11 });
+            expect(node.source.end).toEqual({ offset: 0, column: 3, line: 13 });
+          }
+        }
+      });
+    });
+  });
+
+  describe('makeResetStyles', () => {
+    it('should return postcss AST of valid CSS', () => {
+      const fixture = `
+import { makeResetStyles } from '@griffel/react';
+
+export const useResetStyles = makeResetStyles({
+  color: 'red',
+  backgroundColor: 'green',
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      expect(format(root.toString())).toMatchInlineSnapshot(`
+        ".rbe9p1m {
+          color: red;
+          background-color: green;
+        }
+        "
+      `);
+    });
+
+    it('should map style locations to reset styles', () => {
+      const fixture = `
+import { makeResetStyles } from '@griffel/react';
+
+export const useResetStyles = makeResetStyles({
+  color: 'red',
+  backgroundColor: 'green',
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+
+      root.walk(node => {
+        const declarator = node.raw(GRIFFEL_DECLARATOR_RAW);
+        expect(declarator).toEqual('useResetStyles');
+
+        if (node.source) {
+          // This test will depend on the source fixture and its indentation
+          expect(node.source.start).toEqual({ offset: 0, column: 46, line: 4 });
+          expect(node.source.end).toEqual({ offset: 0, column: 1, line: 7 });
+        }
+      });
+    });
+
+    it('should hold original source in document raw field', () => {
+      const fixture = `
+import { makeResetStyles } from '@griffel/react';
+
+export const useResetStyles = makeResetStyles({
+  color: 'red',
+  backgroundColor: 'green',
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      expect(root.raw(GRIFFEL_SRC_RAW)).toEqual(fixture);
+    });
+
+    it('should handle multiple declarators', () => {
+      const fixture = `
+import { makeResetStyles } from '@griffel/react';
+
+export const useResetStyles1 = makeResetStyles({
+  color: 'red',
+  backgroundColor: 'green',
+})
+
+export const useResetStyles2 = makeResetStyles({
+  color: 'blue',
+  backgroundColor: 'yellow',
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      root.walk(node => {
+        const declarator = node.raw(GRIFFEL_DECLARATOR_RAW);
+        expect(['useResetStyles1', 'useResetStyles2']).toContain(declarator);
+
+        if (node.source) {
+          if (declarator === 'useResetStyles1') {
+            expect(node.source.start).toEqual({ offset: 0, column: 47, line: 4 });
+            expect(node.source.end).toEqual({ offset: 0, column: 1, line: 7 });
+          }
+
+          if (declarator === 'useResetStyles2') {
+            expect(node.source.start).toEqual({ offset: 0, column: 47, line: 9 });
+            expect(node.source.end).toEqual({ offset: 0, column: 1, line: 12 });
+          }
+        }
+      });
+    });
+  });
+});

--- a/packages/postcss-syntax/src/parse.test.ts
+++ b/packages/postcss-syntax/src/parse.test.ts
@@ -39,6 +39,50 @@ export const useStyles = makeStyles({
           `);
     });
 
+    it('should handle different module source', () => {
+      const fixture = `
+import { foo} from '@foo/foo';
+
+const mixin = () => ({
+  marginTop: '4px',
+})
+
+export const useStyles = foo({
+  root: {
+    color: 'red',
+    backgroundColor: 'green',
+    ...mixin()
+  }
+})
+`;
+      const root = parse(fixture, {
+        from: 'fixture.styles.ts',
+        modules: [{ moduleSource: '@foo/foo', importName: 'foo' }],
+      });
+      expect(format(root.toString())).toMatchInlineSnapshot(`
+              ".fe3e8s9 {
+                color: red;
+              }
+              .fcnqdeg {
+                background-color: green;
+              }
+              .fvjh0tl {
+                margin-top: 4px;
+              }
+              "
+          `);
+
+      root.walk(node => {
+        expect(node.raw(GRIFFEL_DECLARATOR_RAW)).toEqual('useStyles');
+        expect(node.raw(GRIFFEL_SLOT_RAW)).toEqual('root');
+
+        if (node.source) {
+          expect(node.source.start).toEqual({ offset: 0, column: 2, line: 9 });
+          expect(node.source.end).toEqual({ offset: 0, column: 3, line: 13 });
+        }
+      });
+    });
+
     it('should map style locations to slots', () => {
       const fixture = `
 import { makeStyles } from '@griffel/react';
@@ -146,6 +190,37 @@ export const useResetStyles = makeResetStyles({
         }
         "
       `);
+    });
+
+    it('should handle different module source', () => {
+      const fixture = `
+import { foo } from '@foo/foo';
+
+export const useResetStyles = foo({
+  color: 'red',
+  backgroundColor: 'green',
+})
+`;
+      const root = parse(fixture, {
+        from: 'fixture.styles.ts',
+        modules: [{ moduleSource: '@foo/foo', importName: 'makeStyles', resetImportName: 'foo' }],
+      });
+      expect(format(root.toString())).toMatchInlineSnapshot(`
+        ".rbe9p1m {
+          color: red;
+          background-color: green;
+        }
+        "
+      `);
+
+      root.walk(node => {
+        expect(node.raw(GRIFFEL_DECLARATOR_RAW)).toEqual('useResetStyles');
+
+        if (node.source) {
+          expect(node.source.start).toEqual({ offset: 0, column: 34, line: 4 });
+          expect(node.source.end).toEqual({ offset: 0, column: 1, line: 7 });
+        }
+      });
     });
 
     it('should map style locations to reset styles', () => {

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -1,13 +1,20 @@
 import * as postcss from 'postcss';
 import transformSync from './transform-sync';
 import { GRIFFEL_DECLARATOR_RAW, GRIFFEL_SLOT_RAW, GRIFFEL_SRC_RAW } from './constants';
+import { BabelPluginOptions } from '@griffel/babel-preset';
 
-export const parse: postcss.Parser = (css, opts) => {
-  const { from: filename = 'postcss-syntax.styles.ts' } = opts ?? {};
+export type PostCSSParserOptions = Pick<postcss.ProcessOptions<postcss.Document | postcss.Root>, 'from' | 'map'>;
+
+export interface ParserOptions extends PostCSSParserOptions, BabelPluginOptions {}
+
+export const parse = (css: string | { toString(): string }, opts?: ParserOptions) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { from: filename = 'postcss-syntax.styles.ts', map, ...griffelPluginOptions } = opts ?? {};
   const code = css.toString();
   const { metadata } = transformSync(code, {
     filename,
     pluginOptions: {
+      ...griffelPluginOptions,
       generateMetadata: true,
     },
   });

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -1,0 +1,117 @@
+import * as postcss from 'postcss';
+import transformSync from './transform-sync';
+import { GRIFFEL_DECLARATOR_RAW, GRIFFEL_SLOT_RAW, GRIFFEL_SRC_RAW } from './constants';
+
+export const parse: postcss.Parser = (css, opts) => {
+  const { from: filename = 'postcss-syntax.styles.ts' } = opts ?? {};
+  const code = css.toString();
+  const { metadata } = transformSync(code, {
+    filename,
+    pluginOptions: {
+      generateMetadata: true,
+    },
+  });
+
+  const { cssEntries, cssResetEntries, resetLocations, locations } = metadata;
+
+  const cssRuleNodes = Object.entries(cssEntries)
+    .map(([declarator, slots]) => {
+      return Object.entries(slots).reduce((arr, [slot, rules]) => {
+        if (!locations[declarator][slot]) {
+          throw new Error(`No code location for ${declarator}:${slot} - please report a bug`);
+        }
+
+        const location = locations[declarator][slot];
+
+        const nodes = rules.map(rule => {
+          const root = postcss.parse(rule);
+          root.walk(node => {
+            node.raws[GRIFFEL_SLOT_RAW] = slot;
+            node.raws[GRIFFEL_DECLARATOR_RAW] = declarator;
+
+            if (!node.source) {
+              return;
+            }
+
+            // There's currently no way to to map generated CSS to original JS code
+            // Mapping each node to the original slot is probably the best we can do for now
+            node.source.end = {
+              offset: 0,
+              column: location.end.column,
+              line: location.end.line,
+            };
+
+            node.source.start = {
+              offset: 0,
+              column: location.start.column,
+              line: location.start.line,
+            };
+          });
+
+          return root.nodes[0];
+        });
+        return [...arr, ...nodes];
+      }, [] as postcss.ChildNode[]);
+    })
+    .flat();
+
+  const cssResetRuleNodes = Object.entries(cssResetEntries).map(([declarator, [resetRule]]) => {
+    if (!resetLocations[declarator]) {
+      throw new Error(`No code location for ${declarator} - please report a bug`);
+    }
+
+    const location = resetLocations[declarator];
+
+    const root = postcss.parse(resetRule);
+    root.walk(node => {
+      node.raws[GRIFFEL_DECLARATOR_RAW] = declarator;
+
+      if (!node.source) {
+        return;
+      }
+
+      // There's currently no way to to map generated CSS to original JS code through Griffel AOT
+      // Mapping each node to the original slot is probably the best we can do for now
+      node.source.end = {
+        offset: 0,
+        column: location.end.column,
+        line: location.end.line,
+      };
+
+      node.source.start = {
+        offset: 0,
+        column: location.start.column,
+        line: location.start.line,
+      };
+    });
+
+    return root.nodes[0];
+  });
+
+  const root = new postcss.Root();
+  const allNodes = cssRuleNodes.concat(cssResetRuleNodes);
+  for (const rule of allNodes) {
+    root.append(rule);
+  }
+
+  const doc = new postcss.Document();
+
+  root.parent = doc;
+  // https://github.com/callstack/linaria/blob/911b59b0b8bb7de2accce63ece528841f2b29f4a/packages/postcss-linaria/src/parse.ts#L180
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  root.document = doc;
+  doc.nodes.push(root);
+
+  doc.source = {
+    input: new postcss.Input(code),
+    start: {
+      line: 1,
+      column: 1,
+      offset: 0,
+    },
+  };
+
+  doc.raws[GRIFFEL_SRC_RAW] = css;
+  return doc;
+};

--- a/packages/postcss-syntax/src/stringify.ts
+++ b/packages/postcss-syntax/src/stringify.ts
@@ -1,0 +1,13 @@
+import * as postcss from 'postcss';
+import { GRIFFEL_SRC_RAW } from './constants';
+
+export const stringify: postcss.Stringifier = root => {
+  const originalSource = root.raw(GRIFFEL_SRC_RAW);
+  if (originalSource) {
+    console.log(originalSource);
+    return originalSource;
+  }
+
+  // TODO maybe we could generate some default Griffel file with all styles in one slot
+  throw new Error('Griffel syntax stringifier can only stringify AST parsed with the custom syntax');
+};

--- a/packages/postcss-syntax/src/transform-sync.ts
+++ b/packages/postcss-syntax/src/transform-sync.ts
@@ -30,7 +30,10 @@ export default function transformSync(sourceCode: string, options: TransformOpti
     // Ignore all user's configs and apply only our plugin
     babelrc: false,
     configFile: false,
-    presets: [[griffelPreset, options.pluginOptions], locationPreset],
+    presets: [
+      [griffelPreset, options.pluginOptions],
+      [locationPreset, options.pluginOptions],
+    ],
 
     filename: options.filename,
     sourceFileName: options.filename,

--- a/packages/postcss-syntax/src/transform-sync.ts
+++ b/packages/postcss-syntax/src/transform-sync.ts
@@ -1,0 +1,47 @@
+import * as Babel from '@babel/core';
+import griffelPreset, { BabelPluginMetadata, BabelPluginOptions } from '@griffel/babel-preset';
+import locationPreset, { LocationPluginMetadata } from './location-preset';
+
+export type TransformOptions = {
+  filename: string;
+  pluginOptions: BabelPluginOptions;
+};
+
+/**
+ * Transforms passed source code with Babel, uses user's config for parsing, but ignores it for transforms.
+ */
+export default function transformSync(sourceCode: string, options: TransformOptions) {
+  // Parse the code first so Babel will use user's babel config for parsing
+  // During transforms we don't want to use user's config
+  const babelAST = Babel.parseSync(sourceCode, {
+    caller: { name: 'griffel' },
+    filename: options.filename,
+    sourceMaps: true,
+    // TODO - we might need to add some babel config in the eslint rule options
+    // if the user doesn't want to use their normal babel config for this
+    // but let's only add it if it becomes necessary
+  });
+
+  if (babelAST === null) {
+    throw new Error(`Failed to create AST for "${options.filename}" due unknown Babel error...`);
+  }
+
+  const babelFileResult = Babel.transformFromAstSync(babelAST, sourceCode, {
+    // Ignore all user's configs and apply only our plugin
+    babelrc: false,
+    configFile: false,
+    presets: [[griffelPreset, options.pluginOptions], locationPreset],
+
+    filename: options.filename,
+    sourceFileName: options.filename,
+  });
+
+  if (babelFileResult === null) {
+    throw new Error(`Failed to transform "${options.filename}" due unknown Babel error...`);
+  }
+
+  return {
+    metadata: babelFileResult.metadata as unknown as BabelPluginMetadata & LocationPluginMetadata,
+    code: babelFileResult.code,
+  };
+}

--- a/packages/postcss-syntax/tsconfig.json
+++ b/packages/postcss-syntax/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/postcss-syntax/tsconfig.lib.json
+++ b/packages/postcss-syntax/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "environment"]
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "include": ["**/*.ts"]
+}

--- a/packages/postcss-syntax/tsconfig.spec.json
+++ b/packages/postcss-syntax/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node", "environment"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,7 @@
       "@griffel/eslint-plugin": ["packages/eslint-plugin/src/index.ts"],
       "@griffel/jest-serializer": ["packages/jest-serializer/src/index.ts"],
       "@griffel/next-extraction-plugin": ["packages/next-extraction-plugin/src/index.ts"],
+      "@griffel/postcss-syntax": ["packages/postcss-syntax/src/index.ts"],
       "@griffel/style-types": ["packages/style-types/src/index.ts"],
       "@griffel/react": ["packages/react/src/index.ts"],
       "@griffel/webpack-extraction-plugin": ["packages/webpack-extraction-plugin/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -11,6 +11,7 @@
     "@griffel/eslint-plugin": "packages/eslint-plugin",
     "@griffel/jest-serializer": "packages/jest-serializer",
     "@griffel/next-extraction-plugin": "packages/next-extraction-plugin",
+    "@griffel/postcss-syntax": "packages/postcss-syntax",
     "@griffel/react": "packages/react",
     "@griffel/style-types": "packages/style-types",
     "@griffel/webpack-extraction-plugin": "packages/webpack-extraction-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14256,6 +14256,7 @@ __metadata:
     nano-staged: 0.5.0
     next: 12.2.4
     nx: 15.3.3
+    postcss: ^8.4.29
     prettier: 2.8.2
     prism-react-renderer: 1.2.1
     react: 18.2.0
@@ -18524,6 +18525,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "nanoid@npm:3.3.6"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
+  languageName: node
+  linkType: hard
+
 "nanomatch@npm:^1.2.9":
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
@@ -20540,6 +20550,17 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: e39ac60ccd1542d4f9d93d894048aac0d686b3bb38e927d8386005718e6793dbbb46930f0a523fe382f1bbd843c6d980aaea791252bf5e176180e5a4336d9679
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.29":
+  version: 8.4.29
+  resolution: "postcss@npm:8.4.29"
+  dependencies:
+    nanoid: ^3.3.6
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: dd6daa25e781db9ae5b651d9b7bfde0ec6e60e86a37da69a18eb4773d5ddd51e28fc4ff054fbdc04636a31462e6bf09a1e50986f69ac52b10d46b7457cd36d12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implements a postcss [custom syntax](https://postcss.org/docs/how-to-write-custom-syntax) for Griffel that can parse JS code into the output CSS and does a limited mapping of the resulting postcss AST back to the original JS code.

More details are in the new package README