### PR TITLE
test(postcss-syntax): add e2e wiring @griffel/postcss-syntax into stylelint

### DIFF
--- a/e2e/stylelint/README.md
+++ b/e2e/stylelint/README.md
@@ -1,0 +1,22 @@
+# @griffel/e2e-stylelint
+
+End-to-end test that verifies [`@griffel/postcss-syntax`](../../packages/postcss-syntax) can be
+wired into [stylelint](https://stylelint.io/) as a
+[custom syntax](https://stylelint.io/developer-guide/syntaxes) to lint Griffel CSS-in-JS files.
+
+The test packs the local `@griffel/postcss-syntax` and `@griffel/babel-preset` packages, installs
+`stylelint` into a temporary project, and runs `stylelint` (configured with the Griffel custom
+syntax) against `*.styles.ts` fixtures:
+
+- **`green.styles.ts`** — a valid file, asserts stylelint reports no problems.
+- **`error.styles.ts`** — a `makeStyles` call with an unmatchable `:nth-child(0)` selector, asserts
+  stylelint reports the built-in `selector-anb-no-unmatchable` rule for the generated CSS.
+- **`disabled.styles.ts`** — the same violation, but suppressed with a `griffel-csslint-disable`
+  comment directive; asserts the directive emits a `stylelint-disable-line` and stylelint reports no
+  problems.
+
+Run it with:
+
+```sh
+yarn nx run @griffel/e2e-stylelint:test
+```

--- a/e2e/stylelint/eslint.config.mjs
+++ b/e2e/stylelint/eslint.config.mjs
@@ -1,0 +1,16 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  {
+    ignores: ['**/dist', '**/out-tsc'],
+  },
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];

--- a/e2e/stylelint/package.json
+++ b/e2e/stylelint/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@griffel/e2e-stylelint",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/stylelint/project.json
+++ b/e2e/stylelint/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "@griffel/e2e-stylelint",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "e2e/stylelint/src",
+  "projectType": "library",
+  "implicitDependencies": ["@griffel/postcss-syntax", "@griffel/babel-preset"],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": [{ "target": "build", "dependencies": true }],
+      "options": {
+        "cwd": "e2e/stylelint",
+        "commands": [{ "command": "node src/test.ts" }]
+      },
+      "outputs": []
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "e2e/stylelint",
+        "commands": [{ "command": "tsc -b --pretty" }],
+        "outputPath": []
+      }
+    }
+  },
+  "tags": []
+}

--- a/e2e/stylelint/src/assets/.stylelintrc.json
+++ b/e2e/stylelint/src/assets/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "customSyntax": "@griffel/postcss-syntax",
+  "rules": {
+    "selector-anb-no-unmatchable": true
+  }
+}

--- a/e2e/stylelint/src/assets/disabled.styles.ts
+++ b/e2e/stylelint/src/assets/disabled.styles.ts
@@ -1,0 +1,14 @@
+import { makeStyles } from '@griffel/react';
+
+// Same violation as `error.styles.ts`, but the `griffel-csslint-disable` comment
+// directive on the slot instructs the Griffel PostCSS syntax to emit a
+// `/* stylelint-disable-line selector-anb-no-unmatchable */` comment for this
+// slot's generated CSS, so stylelint should report no problems.
+export const useStyles = makeStyles({
+  // griffel-csslint-disable selector-anb-no-unmatchable
+  root: {
+    ':nth-child(0)': {
+      color: 'red',
+    },
+  },
+});

--- a/e2e/stylelint/src/assets/error.styles.ts
+++ b/e2e/stylelint/src/assets/error.styles.ts
@@ -1,0 +1,11 @@
+import { makeStyles } from '@griffel/react';
+
+// An invalid file: `:nth-child(0)` is an unmatchable An+B selector, so stylelint
+// should report the `selector-anb-no-unmatchable` rule for the generated CSS.
+export const useStyles = makeStyles({
+  root: {
+    ':nth-child(0)': {
+      color: 'red',
+    },
+  },
+});

--- a/e2e/stylelint/src/assets/green.styles.ts
+++ b/e2e/stylelint/src/assets/green.styles.ts
@@ -1,0 +1,10 @@
+import { makeStyles } from '@griffel/react';
+
+// A valid file: no rules from `.stylelintrc.json` are violated, so stylelint
+// should report no problems for the CSS generated from this file.
+export const useStyles = makeStyles({
+  root: {
+    color: 'red',
+    backgroundColor: 'green',
+  },
+});

--- a/e2e/stylelint/src/test.ts
+++ b/e2e/stylelint/src/test.ts
@@ -1,0 +1,101 @@
+import { configureYarn, copyAssets, createTempDir, installPackages, packLocalPackage, sh } from '@griffel/e2e-utils';
+import path from 'path';
+
+const RULE = 'selector-anb-no-unmatchable';
+
+/**
+ * Runs stylelint against a single fixture file and reports whether it exited
+ * cleanly along with its (merged stdout + stderr) output.
+ */
+async function lint(tempDir: string, file: string): Promise<{ passed: boolean; output: string }> {
+  try {
+    const output = await sh(`npx stylelint ${file} 2>&1`, tempDir, true);
+    return { passed: true, output };
+  } catch (e) {
+    // `sh` rejects when stylelint exits with a non-zero code (problems found)
+    return { passed: false, output: (e as Error).message };
+  }
+}
+
+async function performTest() {
+  let tempDir: string;
+
+  try {
+    const rootDir = path.resolve(import.meta.dirname, '..', '..', '..');
+    const assetsPath = path.resolve(import.meta.dirname, 'assets');
+
+    tempDir = createTempDir('stylelint');
+
+    await copyAssets({ assetsPath, tempDir });
+    await configureYarn({ tempDir, rootDir });
+
+    const resolutions = [
+      await packLocalPackage(rootDir, tempDir, '@griffel/postcss-syntax'),
+      await packLocalPackage(rootDir, tempDir, '@griffel/babel-preset'),
+    ];
+
+    await installPackages({
+      packages: ['stylelint'],
+      resolutions,
+      tempDir,
+      rootDir,
+    });
+  } catch (e) {
+    console.error('❌', 'Something went wrong setting up the test:');
+    console.error((e as Error)?.stack ?? e);
+    process.exit(1);
+  }
+
+  // Stylelint is wired to parse `*.styles.ts` files through the Griffel PostCSS custom
+  // syntax (see assets/.stylelintrc.json). Each fixture asserts a different behavior.
+  let failed = false;
+
+  // 1. `green.styles.ts` has no violations — stylelint should pass.
+  {
+    const { passed, output } = await lint(tempDir, 'green.styles.ts');
+
+    if (passed) {
+      console.log('✅', 'green.styles.ts passed stylelint with no reported problems');
+    } else {
+      failed = true;
+      console.error('❌', 'green.styles.ts should have passed stylelint, but problems were reported:');
+      console.error(output);
+    }
+  }
+
+  // 2. `error.styles.ts` has an unmatchable An+B selector — stylelint should report it.
+  {
+    const { passed, output } = await lint(tempDir, 'error.styles.ts');
+
+    if (!passed && output.includes(RULE)) {
+      console.log('✅', `error.styles.ts correctly reported ${RULE}`);
+    } else {
+      failed = true;
+      console.error('❌', `error.styles.ts should have reported ${RULE}, but it did not:`);
+      console.error(output);
+    }
+  }
+
+  // 3. `disabled.styles.ts` has the same violation but suppresses it via a
+  //    `griffel-csslint-disable` comment directive — stylelint should pass.
+  {
+    const { passed, output } = await lint(tempDir, 'disabled.styles.ts');
+
+    if (passed) {
+      console.log('✅', `disabled.styles.ts suppressed ${RULE} via griffel-csslint-disable`);
+    } else {
+      failed = true;
+      console.error(
+        '❌',
+        `disabled.styles.ts should have suppressed ${RULE} via griffel-csslint-disable, but problems were reported:`,
+      );
+      console.error(output);
+    }
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+}
+
+performTest();

--- a/e2e/stylelint/tsconfig.json
+++ b/e2e/stylelint/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/e2e/stylelint/tsconfig.lib.json
+++ b/e2e/stylelint/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "environment"]
+  },
+  "include": ["**/*.ts", "**/*.js"],
+  "exclude": ["src/assets"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3832,6 +3832,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@griffel/e2e-stylelint@workspace:e2e/stylelint":
+  version: 0.0.0-use.local
+  resolution: "@griffel/e2e-stylelint@workspace:e2e/stylelint"
+  languageName: unknown
+  linkType: soft
+
 "@griffel/e2e-typescript@workspace:e2e/typescript":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-typescript@workspace:e2e/typescript"


### PR DESCRIPTION
Adds an `e2e/stylelint` project that validates the [`@griffel/postcss-syntax`](https://github.com/microsoft/griffel/tree/main/packages/postcss-syntax) + [stylelint](https://stylelint.io/) integration end to end.

The test packs the local `@griffel/postcss-syntax` and `@griffel/babel-preset` packages, installs `stylelint` into a temporary project, configures it with the Griffel PostCSS [custom syntax](https://stylelint.io/developer-guide/syntaxes), and lints `*.styles.ts` fixtures covering three cases:

- **`green.styles.ts`** — a valid file reports no problems.
- **`error.styles.ts`** — an unmatchable `:nth-child(0)` selector is reported via stylelint's built-in `selector-anb-no-unmatchable` rule.
- **`disabled.styles.ts`** — the same violation is suppressed through a `griffel-csslint-disable` comment directive (emitted as `stylelint-disable-line`).

Run it with:

```sh
yarn nx run @griffel/e2e-stylelint:test
```
