### PR TITLE
fix: metadata entries should be defined by default

### DIFF
--- a/change/@griffel-babel-preset-96f2826d-0876-42d6-8ef0-f3dbd6c45004.json
+++ b/change/@griffel-babel-preset-96f2826d-0876-42d6-8ef0-f3dbd6c45004.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: metadata entries should be defined by default",
+  "packageName": "@griffel/babel-preset",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { transformPlugin } from './transformPlugin';
+import { BabelPluginMetadata } from './types';
 
 const prettierConfig = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../../../.prettierrc'), { encoding: 'utf-8' }),
@@ -284,6 +285,20 @@ describe('babel preset', () => {
     });
 
     expect(babelFileResult?.metadata).toMatchInlineSnapshot(`Object {}`);
+  });
+
+  it('should return empty metadata when file contains no griffel code', () => {
+    const code = 'export {}';
+    const babelFileResult = Babel.transformSync(code, {
+      babelrc: false,
+      configFile: false,
+      plugins: [[transformPlugin, { generateMetadata: true }]],
+      filename: 'test.js',
+      presets: ['@babel/typescript'],
+    });
+
+    expect((babelFileResult?.metadata as BabelPluginMetadata | undefined)?.cssEntries).toEqual({});
+    expect((babelFileResult?.metadata as BabelPluginMetadata | undefined)?.cssResetEntries).toEqual({});
   });
 
   it('should generate metadata for makeStyles when configured', () => {

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -228,6 +228,13 @@ export const transformPlugin = declare<Partial<BabelPluginOptions>, PluginObj<Ba
       this.calleePaths = [];
       this.cssEntries = {};
       this.cssResetEntries = {};
+
+      if (pluginOptions.generateMetadata) {
+        Object.assign(this.file.metadata, {
+          cssResetEntries: {},
+          cssEntries: {},
+        } as BabelPluginMetadata);
+      }
     },
 
     visitor: {


### PR DESCRIPTION
If the user configures the preset to generate metadata, the objects should be defined by default to align with typings.

This fixes the edge case where the preset runs on a file without Griffel - in a backwards compatible way.