### PR TITLE
update make-static-styles.md

### DIFF
--- a/apps/website/docs/react/api/make-static-styles.md
+++ b/apps/website/docs/react/api/make-static-styles.md
@@ -8,6 +8,8 @@ import OutputTitle from '@site/src/components/OutputTitle'
 
 Creates styles with a global selector. This is especially useful for CSS resets, for example [normalize.css](https://github.com/necolas/normalize.css/).
 
+`makeStaticStyles` returns [a React hook](https://reactjs.org/docs/hooks-intro.html) that should be called inside a component.
+
 ## Defining styles with objects
 
 ```js


### PR DESCRIPTION
fixes #443 
- Mentioned that `makeStaticStyles` returns a React hook.
#

Note:
I couldn't figure out if `makeStaticStyles` supports shorthands or not. I have tried this on my codesandbox and it was not working. If I am going the wrong way or if it's expected behavior that shorthands are not Okay. Then I will add this as well. Please review.
Ref: https://codesandbox.io/s/shorthands-check-n342ls