### PR TITLE
fix(core): restore prefixing for "background-clip: text"

### DIFF
--- a/change/@griffel-core-05e2f791-537a-45f8-82e7-5145a7745834.json
+++ b/change/@griffel-core-05e2f791-537a-45f8-82e7-5145a7745834.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: restore prefixing for \"background-clip: text\"",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/__snapshots__/compileAtomicCSSRule.test.ts.snap
+++ b/packages/core/src/runtime/__snapshots__/compileAtomicCSSRule.test.ts.snap
@@ -72,9 +72,9 @@ Array [
 ]
 `;
 
-exports[`compileAtomicCSSRule does not prefix background-clip:text 1`] = `
+exports[`compileAtomicCSSRule does not prefix background-clip:content-box 1`] = `
 Array [
-  ".foo{background-clip:text;}",
+  ".foo{background-clip:content-box;}",
 ]
 `;
 

--- a/packages/core/src/runtime/compileAtomicCSSRule.test.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.test.ts
@@ -39,7 +39,7 @@ describe('compileAtomicCSSRule', () => {
     ['clip-path', 'circle(40%)'],
     ['width', 'fit-content'],
     ['width', 'min-block-size'],
-    ['background-clip', 'text'],
+    ['background-clip', 'content-box'],
     ['animation', '3s linear 1s slidein;'],
     ['animation-delay', '3s'],
     ['animation-direction', 'normal'],

--- a/packages/core/src/runtime/stylis/prefixerPlugin.test.ts
+++ b/packages/core/src/runtime/stylis/prefixerPlugin.test.ts
@@ -20,6 +20,17 @@ describe('prefix', () => {
       );
     });
 
+    test('background-clip', () => {
+      expect(prefix(`background-clip:border-box;`, 15)).toMatchInlineSnapshot(`"background-clip:border-box;"`);
+      expect(prefix(`background-clip:padding-box;`, 15)).toMatchInlineSnapshot(`"background-clip:padding-box;"`);
+      expect(prefix(`background-clip:content-box;`, 15)).toMatchInlineSnapshot(`"background-clip:content-box;"`);
+
+      // Prefixes only "text" value
+      expect(prefix(`background-clip:text;`, 15)).toMatchInlineSnapshot(
+        `"-webkit-background-clip:text;background-clip:text;"`,
+      );
+    });
+
     test('text', () => {
       expect(prefix(`text-align:left;`, 10)).toEqual([`text-align:left;`].join(''));
       expect(prefix(`text-transform:none;`, 14)).toEqual([`text-transform:none;`].join(''));
@@ -259,10 +270,6 @@ describe('prefix', () => {
       expect(prefix(`max-width:max(150px, 200px);`, 9)).toMatchInlineSnapshot(`"max-width:max(150px, 200px);"`);
       expect(prefix(`min-height:max(100px, 50px);`, 10)).toMatchInlineSnapshot(`"min-height:max(100px, 50px);"`);
       expect(prefix(`max-height:min(150px, 200px);`, 10)).toMatchInlineSnapshot(`"max-height:min(150px, 200px);"`);
-    });
-
-    test('background-clip', () => {
-      expect(prefix(`background-clip:text;`, 15)).toMatchInlineSnapshot(`"background-clip:text;"`);
     });
 
     test('animation', () => {

--- a/packages/core/src/runtime/stylis/prefixerPlugin.ts
+++ b/packages/core/src/runtime/stylis/prefixerPlugin.ts
@@ -26,7 +26,7 @@ export function prefix(value: string, length: number, children?: Element[]): str
     case 3191:
     case 6645:
     case 3005:
-    // mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite,
+    // mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite
     case 6391:
     case 5879:
     case 5623:
@@ -34,6 +34,13 @@ export function prefix(value: string, length: number, children?: Element[]): str
     case 4599:
     case 4855:
       return WEBKIT + value + value;
+    // background-clip: text
+    case 4215:
+      switch (charat(value, length + 1)) {
+        case 116:
+          return WEBKIT + value + value;
+      }
+      break;
     // tab-size
     case 4789:
       return MOZ + value + value;


### PR DESCRIPTION
Fixes #457.

The PR restores prefixing for `background-clip: text` case.