### PR TITLE
chore(core): remove prefixing for "ms-"

### DIFF
--- a/change/@griffel-core-37cc7380-d4cc-4151-8ad7-c78576d587f7.json
+++ b/change/@griffel-core-37cc7380-d4cc-4151-8ad7-c78576d587f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove prefixing for \"ms-\"",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/stylis/prefixerPlugin.test.ts
+++ b/packages/core/src/runtime/stylis/prefixerPlugin.test.ts
@@ -139,13 +139,13 @@ describe('prefix', () => {
 
     test('user-select', () => {
       expect(prefix(`user-select:none;`, 11)).toEqual(
-        [`-webkit-user-select:none;`, `-moz-user-select:none;`, `-ms-user-select:none;`, `user-select:none;`].join(''),
+        [`-webkit-user-select:none;`, `-moz-user-select:none;`, `user-select:none;`].join(''),
       );
     });
 
     test('appearance', () => {
       expect(prefix(`appearance:none;`, 10)).toEqual(
-        [`-webkit-appearance:none;`, `-moz-appearance:none;`, `-ms-appearance:none;`, `appearance:none;`].join(''),
+        [`-webkit-appearance:none;`, `-moz-appearance:none;`, `appearance:none;`].join(''),
       );
     });
 

--- a/packages/core/src/runtime/stylis/prefixerPlugin.ts
+++ b/packages/core/src/runtime/stylis/prefixerPlugin.ts
@@ -6,7 +6,6 @@ import {
   indexof,
   replace,
   match,
-  MS,
   MOZ,
   WEBKIT,
   copy,
@@ -48,7 +47,7 @@ export function prefix(value: string, length: number, children?: Element[]): str
     case 5349:
     case 4246:
     case 6968:
-      return WEBKIT + value + MOZ + value + MS + value + value;
+      return WEBKIT + value + MOZ + value + value;
     // cursor
     // @ts-expect-error fall through is intentional here
     case 6187:
@@ -153,9 +152,6 @@ export function prefixerPlugin(
                       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                       // @ts-ignore
                       copy(element, { props: [replace(value, /:(plac\w+)/, ':' + MOZ + '$1')] }),
-                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                      // @ts-ignore
-                      copy(element, { props: [replace(value, /:(plac\w+)/, MS + 'input-$1')] }),
                     ],
                     callback,
                   );


### PR DESCRIPTION
Removes prefixing for `ms-` rules as we don't support IE and legacy Edge.