### PR TITLE
Fix inputSourceMap Babel error

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-593a69cc-cc81-40f5-af41-6bce970f9e8f.json
+++ b/change/@griffel-webpack-extraction-plugin-593a69cc-cc81-40f5-af41-6bce970f9e8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: replace null inputSourceMap with undefined",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-loader-0c8121e6-efb9-45f6-bba1-42cfc2b86834.json
+++ b/change/@griffel-webpack-loader-0c8121e6-efb9-45f6-bba1-42cfc2b86834.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Replace null inputSourceMap with undefined",
+  "comment": "fix: replace null inputSourceMap with undefined",
   "packageName": "@griffel/webpack-loader",
   "email": "alinazaieva@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@griffel-webpack-loader-0c8121e6-efb9-45f6-bba1-42cfc2b86834.json
+++ b/change/@griffel-webpack-loader-0c8121e6-efb9-45f6-bba1-42cfc2b86834.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace null inputSourceMap with undefined",
+  "packageName": "@griffel/webpack-loader",
+  "email": "alinazaieva@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -18,13 +18,17 @@ const virtualLoaderPath = path.resolve(__dirname, '..', 'virtual-loader', 'index
 const virtualCSSFilePath = path.resolve(__dirname, '..', 'virtual-loader', 'griffel.css');
 
 /**
- * Webpack can also pass sourcemaps as a string, Babel accepts only objects.
+ * Webpack can also pass sourcemaps as a string or null, Babel accepts only objects, boolean and undefined.
  * See https://github.com/babel/babel-loader/pull/889.
  */
 function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOptions['inputSourceMap'] {
   try {
     if (typeof inputSourceMap === 'string') {
       return JSON.parse(inputSourceMap) as TransformOptions['inputSourceMap'];
+    }
+
+    if (inputSourceMap === null) {
+      return undefined;
     }
 
     return inputSourceMap as TransformOptions['inputSourceMap'];

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -29,13 +29,17 @@ export function shouldTransformSourceCode(
 }
 
 /**
- * Webpack can also pass sourcemaps as a string, Babel accepts only objects.
+ * Webpack can also pass sourcemaps as a string or null, Babel accepts only objects, boolean and undefined.
  * See https://github.com/babel/babel-loader/pull/889.
  */
 function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOptions['inputSourceMap'] {
   try {
     if (typeof inputSourceMap === 'string') {
       return JSON.parse(inputSourceMap) as TransformOptions['inputSourceMap'];
+    }
+
+    if (inputSourceMap === null) {
+      return undefined;
     }
 
     return inputSourceMap as TransformOptions['inputSourceMap'];


### PR DESCRIPTION
Fixes #465 by adding an explicit check for `null` to `parseSourceMap` utility.