### PR TITLE
fix(core): improve detection of custom idents in shorthands.gridArea()

### DIFF
--- a/change/@griffel-core-f665f81b-8374-4996-981e-c3191ff46cc4.json
+++ b/change/@griffel-core-f665f81b-8374-4996-981e-c3191ff46cc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: improve detection of custom idents in shorthands.gridArea()",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/shorthands/gridArea.test.ts
+++ b/packages/core/src/shorthands/gridArea.test.ts
@@ -1,4 +1,14 @@
-import { gridArea } from './gridArea';
+import { gridArea, isCustomIdent } from './gridArea';
+
+it('isCustomIdent', () => {
+  expect(isCustomIdent('auto')).toBe(false);
+  expect(isCustomIdent(2)).toBe(false);
+  expect(isCustomIdent('2')).toBe(false);
+  expect(isCustomIdent('2 span')).toBe(false);
+
+  expect(isCustomIdent('areaA')).toBe(true);
+  expect(isCustomIdent('area1')).toBe(true);
+});
 
 describe('gridArea(all)', () => {
   it('for auto', () => {

--- a/packages/core/src/shorthands/gridArea.ts
+++ b/packages/core/src/shorthands/gridArea.ts
@@ -11,10 +11,10 @@ function isValidGridAreaInput(value: GridAreaInput) {
 
 // A custom-ident can be an alpha-numeric string including dash (-), underscore, escaped (\) characters, and escaped unicode
 const customIdentRegEx = /^[a-zA-Z0-9\-_\\#;]+$/;
-const nonCustomIdentRegEx = /^-moz-initial$|^auto$|^initial$|^inherit$|^revert$|^unset$|^span \d+$|\d.*/;
+const nonCustomIdentRegEx = /^-moz-initial$|^auto$|^initial$|^inherit$|^revert$|^unset$|^span \d+$|^\d.*/;
 
 // See https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident
-function isCustomIdent(value: GridAreaInput | undefined): boolean {
+export function isCustomIdent(value: GridAreaInput | undefined): boolean {
   return (
     value !== undefined && typeof value === 'string' && customIdentRegEx.test(value) && !nonCustomIdentRegEx.test(value)
   );


### PR DESCRIPTION
Fixes #469.

### Before

```js
gridArea('header1')  // => 

// {
//   gridRowStart: 'header1',
//   gridColumnStart: 'auto',
//   gridRowEnd:  'auto',
//   gridColumnEnd:  'auto',
// }
```

### After

```js
gridArea('header1')  // => 

// {
//   gridRowStart: 'header1',
//   gridColumnStart: 'header1',
//   gridRowEnd: 'header1',
//   gridColumnEnd: 'header1',
// }
```