### PR TITLE
chore(react): add "wyw-in-js" field for tag processor

### DIFF
--- a/change/@griffel-react-0fc8fc0d-e86d-4cbd-bc14-a56fe7e4cc07.json
+++ b/change/@griffel-react-0fc8fc0d-e86d-4cbd-bc14-a56fe7e4cc07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add \"wyw-in-js\" field for tag processor",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,12 @@
     "url": "https://github.com/microsoft/griffel"
   },
   "sideEffects": false,
+  "wyw-in-js": {
+    "tags": {
+      "makeStyles": "@griffel/tag-processor/make-styles",
+      "makeResetStyles": "@griffel/tag-processor/make-reset-styles"
+    }
+  },
   "dependencies": {
     "@griffel/core": "^1.15.1",
     "tslib": "^2.1.0"


### PR DESCRIPTION
Adds `wyw-in-js` field to `package.json` to support styles processing with WyW-in-JS compiler (https://wyw-in-js.dev/). The plan is to use this compiler for Vite/esbuild plugins (https://github.com/microsoft/griffel/pull/41) and later switch our Webpack loader to it (https://github.com/microsoft/griffel/pull/414).