### PR TITLE
feat(shadow-dom): add `insertionPoint` to `createShadowDOMRenderer()` options

### DIFF
--- a/change/@griffel-shadow-dom-0964b9c8-3382-4396-aebb-8fefcd90f377.json
+++ b/change/@griffel-shadow-dom-0964b9c8-3382-4396-aebb-8fefcd90f377.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add insertionPoint API to @griffel/shadow-dom",
+  "packageName": "@griffel/shadow-dom",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/shadow-dom/src/createShadowDOMRenderer.test.ts
+++ b/packages/shadow-dom/src/createShadowDOMRenderer.test.ts
@@ -1,4 +1,7 @@
 import { createShadowDOMRenderer } from './createShadowDOMRenderer';
+import { ExtendedCSSStyleSheet } from './types';
+
+type CSSStyleSheetWithId = CSSStyleSheet & { id: string };
 
 describe('createShadowDOMRenderer', () => {
   it('returns a renderer', () => {
@@ -8,74 +11,225 @@ describe('createShadowDOMRenderer', () => {
   });
 
   describe('CSS insertion', () => {
-    const shadowRoot = document.createElement('div').attachShadow({ mode: 'open' });
-    const renderer = createShadowDOMRenderer(shadowRoot);
+    let shadowRoot: ShadowRoot;
+    let renderer: ReturnType<typeof createShadowDOMRenderer>;
 
-    // jsdom doesn't support adoptedStyleSheets yet
-    shadowRoot.adoptedStyleSheets = [];
+    beforeEach(() => {
+      shadowRoot = document.createElement('div').attachShadow({ mode: 'open' });
 
-    renderer.insertCSSRules({ d: ['a {}'] });
-    renderer.insertCSSRules({ t: ['a {}'] });
-
-    renderer.insertCSSRules({
-      m: [[`a {}`, { m: '(forced-colors: active)' }]],
-    });
-    renderer.insertCSSRules({
-      m: [[`a {}`, { m: '(prefers-reduced-motion)' }]],
+      // jsdom doesn't support adoptedStyleSheets yet
+      shadowRoot.adoptedStyleSheets = [];
     });
 
-    renderer.insertCSSRules({ h: ['a {}'] });
-    renderer.insertCSSRules({ f: ['a {}'] });
-    renderer.insertCSSRules({ a: ['a {}'] });
-    renderer.insertCSSRules({ v: ['a {}'] });
-    renderer.insertCSSRules({ l: ['a {}'] });
+    it('inserts styles in the correct order', () => {
+      renderer = createShadowDOMRenderer(shadowRoot);
 
-    renderer.insertCSSRules({ t: ['a {}'] });
+      renderer.insertCSSRules({ d: ['a {}'] });
+      renderer.insertCSSRules({ t: ['a {}'] });
 
-    expect(renderer.adoptedStyleSheets?.map(sheet => ({ bucketName: sheet.bucketName, metadata: sheet.metadata })))
-      .toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "bucketName": "d",
-          "metadata": Object {},
-        },
-        Object {
-          "bucketName": "l",
-          "metadata": Object {},
-        },
-        Object {
-          "bucketName": "v",
-          "metadata": Object {},
-        },
-        Object {
-          "bucketName": "f",
-          "metadata": Object {},
-        },
-        Object {
-          "bucketName": "h",
-          "metadata": Object {},
-        },
-        Object {
-          "bucketName": "a",
-          "metadata": Object {},
-        },
-        Object {
-          "bucketName": "t",
-          "metadata": Object {},
-        },
-        Object {
-          "bucketName": "m",
-          "metadata": Object {
-            "m": "(forced-colors: active)",
+      renderer.insertCSSRules({
+        m: [[`a {}`, { m: '(forced-colors: active)' }]],
+      });
+      renderer.insertCSSRules({
+        m: [[`a {}`, { m: '(prefers-reduced-motion)' }]],
+      });
+
+      renderer.insertCSSRules({ h: ['a {}'] });
+      renderer.insertCSSRules({ f: ['a {}'] });
+      renderer.insertCSSRules({ a: ['a {}'] });
+      renderer.insertCSSRules({ v: ['a {}'] });
+      renderer.insertCSSRules({ l: ['a {}'] });
+
+      renderer.insertCSSRules({ t: ['a {}'] });
+
+      expect(renderer.adoptedStyleSheets?.map(sheet => ({ bucketName: sheet.bucketName, metadata: sheet.metadata })))
+        .toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "bucketName": "d",
+            "metadata": Object {},
           },
-        },
-        Object {
-          "bucketName": "m",
-          "metadata": Object {
-            "m": "(prefers-reduced-motion)",
+          Object {
+            "bucketName": "l",
+            "metadata": Object {},
           },
-        },
-      ]
-    `);
+          Object {
+            "bucketName": "v",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "f",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "h",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "a",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "t",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "m",
+            "metadata": Object {
+              "m": "(forced-colors: active)",
+            },
+          },
+          Object {
+            "bucketName": "m",
+            "metadata": Object {
+              "m": "(prefers-reduced-motion)",
+            },
+          },
+        ]
+      `);
+    });
+
+    it('inserts styles in the correct order with insertionPoint', () => {
+      const other1 = new CSSStyleSheet() as CSSStyleSheetWithId;
+      other1.id = 'other1';
+
+      const other2 = new CSSStyleSheet() as CSSStyleSheetWithId;
+      other2.id = 'other2';
+
+      const insertionPoint = new CSSStyleSheet() as CSSStyleSheetWithId;
+      insertionPoint.id = 'insertionPoint';
+      shadowRoot.adoptedStyleSheets = [other1, insertionPoint, other2];
+
+      renderer = createShadowDOMRenderer(shadowRoot, {
+        insertionPoint: insertionPoint as unknown as ExtendedCSSStyleSheet,
+      });
+
+      renderer.insertCSSRules({ d: ['a {}'] });
+      renderer.insertCSSRules({ t: ['a {}'] });
+
+      renderer.insertCSSRules({
+        m: [[`a {}`, { m: '(forced-colors: active)' }]],
+      });
+      renderer.insertCSSRules({
+        m: [[`a {}`, { m: '(prefers-reduced-motion)' }]],
+      });
+
+      renderer.insertCSSRules({ h: ['a {}'] });
+      renderer.insertCSSRules({ f: ['a {}'] });
+      renderer.insertCSSRules({ a: ['a {}'] });
+      renderer.insertCSSRules({ v: ['a {}'] });
+      renderer.insertCSSRules({ l: ['a {}'] });
+
+      renderer.insertCSSRules({ t: ['a {}'] });
+
+      expect(renderer.adoptedStyleSheets?.map(sheet => ({ bucketName: sheet.bucketName, metadata: sheet.metadata })))
+        .toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "bucketName": "d",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "l",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "v",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "f",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "h",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "a",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "t",
+            "metadata": Object {},
+          },
+          Object {
+            "bucketName": "m",
+            "metadata": Object {
+              "m": "(forced-colors: active)",
+            },
+          },
+          Object {
+            "bucketName": "m",
+            "metadata": Object {
+              "m": "(prefers-reduced-motion)",
+            },
+          },
+        ]
+      `);
+
+      const res = shadowRoot.adoptedStyleSheets?.map(sheet => {
+        if ('bucketName' in sheet) {
+          const eSheet = sheet as ExtendedCSSStyleSheet;
+          return { bucketName: eSheet.bucketName, metadata: eSheet.metadata };
+        } else {
+          return { id: (sheet as unknown as CSSStyleSheetWithId).id };
+        }
+      });
+
+      expect(res).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "id": "other1",
+            },
+            Object {
+              "id": "insertionPoint",
+            },
+            Object {
+              "bucketName": "d",
+              "metadata": Object {},
+            },
+            Object {
+              "bucketName": "l",
+              "metadata": Object {},
+            },
+            Object {
+              "bucketName": "v",
+              "metadata": Object {},
+            },
+            Object {
+              "bucketName": "f",
+              "metadata": Object {},
+            },
+            Object {
+              "bucketName": "h",
+              "metadata": Object {},
+            },
+            Object {
+              "bucketName": "a",
+              "metadata": Object {},
+            },
+            Object {
+              "bucketName": "t",
+              "metadata": Object {},
+            },
+            Object {
+              "bucketName": "m",
+              "metadata": Object {
+                "m": "(forced-colors: active)",
+              },
+            },
+            Object {
+              "bucketName": "m",
+              "metadata": Object {
+                "m": "(prefers-reduced-motion)",
+              },
+            },
+            Object {
+              "id": "other2",
+            },
+          ]
+        `);
+    });
   });
 });

--- a/packages/shadow-dom/src/createShadowDOMRenderer.ts
+++ b/packages/shadow-dom/src/createShadowDOMRenderer.ts
@@ -3,7 +3,7 @@ import type { GriffelRenderer, StyleBucketName } from '@griffel/core';
 
 import { createFallbackRenderer } from './createFallbackRenderer';
 import type { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';
-import { findInsertionPoint } from './findInsertionPoint';
+import { findInsertionPoint, findShadowRootInsertionPoint } from './findInsertionPoint';
 
 const SUPPORTS_CONSTRUCTABLE_STYLESHEETS: boolean = (() => {
   try {
@@ -18,7 +18,7 @@ export interface CreateShadowDomRendererOptions {
   /**
    * If specified, a renderer will insert created CSSStyleSheets after this CSSStyleSheet.
    */
-  insertionPoint?: ExtendedCSSStyleSheet;
+  insertionPoint?: CSSStyleSheet;
 }
 
 let rendererId = 0;
@@ -92,10 +92,20 @@ export function createShadowDOMRenderer(shadowRoot: ShadowRoot, options: CreateS
             metadata,
 
             styleSheet => {
-              const targetStyleSheet = findInsertionPoint(renderer, styleSheet, insertionPoint);
+              const targetStyleSheet = findInsertionPoint(renderer, styleSheet);
+              const shadowRootTargetSheet = findShadowRootInsertionPoint(
+                renderer,
+                shadowRoot,
+                targetStyleSheet,
+                insertionPoint,
+              );
 
               renderer.adoptedStyleSheets = insertBefore(renderer.adoptedStyleSheets, styleSheet, targetStyleSheet);
-              shadowRoot.adoptedStyleSheets = insertBefore(shadowRoot.adoptedStyleSheets, styleSheet, targetStyleSheet);
+              shadowRoot.adoptedStyleSheets = insertBefore(
+                shadowRoot.adoptedStyleSheets,
+                styleSheet,
+                shadowRootTargetSheet,
+              );
             },
           );
 

--- a/packages/shadow-dom/src/createShadowDOMRenderer.ts
+++ b/packages/shadow-dom/src/createShadowDOMRenderer.ts
@@ -93,12 +93,7 @@ export function createShadowDOMRenderer(shadowRoot: ShadowRoot, options: CreateS
 
             styleSheet => {
               const targetStyleSheet = findInsertionPoint(renderer, styleSheet);
-              const shadowRootTargetSheet = findShadowRootInsertionPoint(
-                renderer,
-                shadowRoot,
-                targetStyleSheet,
-                insertionPoint,
-              );
+              const shadowRootTargetSheet = findShadowRootInsertionPoint(shadowRoot, targetStyleSheet, insertionPoint);
 
               renderer.adoptedStyleSheets = insertBefore(renderer.adoptedStyleSheets, styleSheet, targetStyleSheet);
               shadowRoot.adoptedStyleSheets = insertBefore(

--- a/packages/shadow-dom/src/createShadowDOMRenderer.ts
+++ b/packages/shadow-dom/src/createShadowDOMRenderer.ts
@@ -14,6 +14,13 @@ const SUPPORTS_CONSTRUCTABLE_STYLESHEETS: boolean = (() => {
   }
 })();
 
+export interface CreateShadowDomRendererOptions {
+  /**
+   * If specified, a renderer will insert created CSSStyleSheets after this CSSStyleSheet.
+   */
+  insertionPoint?: ExtendedCSSStyleSheet;
+}
+
 let rendererId = 0;
 
 function getCSSStyleSheetForBucket(
@@ -54,12 +61,14 @@ function insertBefore<T extends CSSStyleSheet | ExtendedCSSStyleSheet>(
   return [...arr.slice(0, index), sheetToInsert, ...arr.slice(index)];
 }
 
-export function createShadowDOMRenderer(shadowRoot: ShadowRoot) {
+export function createShadowDOMRenderer(shadowRoot: ShadowRoot, options: CreateShadowDomRendererOptions = {}) {
   if (!SUPPORTS_CONSTRUCTABLE_STYLESHEETS) {
     return createFallbackRenderer(shadowRoot) as GriffelRenderer & {
       adoptedStyleSheets?: never;
     };
   }
+
+  const { insertionPoint } = options;
 
   const cssSheetsCache: Record<string, ExtendedCSSStyleSheet> = {};
   const renderer: GriffelShadowDOMRenderer = {
@@ -83,7 +92,7 @@ export function createShadowDOMRenderer(shadowRoot: ShadowRoot) {
             metadata,
 
             styleSheet => {
-              const targetStyleSheet = findInsertionPoint(renderer, styleSheet);
+              const targetStyleSheet = findInsertionPoint(renderer, styleSheet, insertionPoint);
 
               renderer.adoptedStyleSheets = insertBefore(renderer.adoptedStyleSheets, styleSheet, targetStyleSheet);
               shadowRoot.adoptedStyleSheets = insertBefore(shadowRoot.adoptedStyleSheets, styleSheet, targetStyleSheet);

--- a/packages/shadow-dom/src/findInsertionPoint.test.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.test.ts
@@ -32,6 +32,26 @@ describe('findInsertionPoint', () => {
     expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
   });
 
+  it('handles insertionPoint in otherwise empty array', () => {
+    const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+
+    const renderer = createRendererMock([insertionPoint]);
+    const styleSheet = createStyleSheetMock('d', {});
+
+    expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
+  });
+
+  it('handles insertionPoint with other (non-Griffel) stylesheets', () => {
+    const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+    const other1 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+    const other2 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+
+    const renderer = createRendererMock([other1, insertionPoint, other2]);
+    const styleSheet = createStyleSheetMock('d', {});
+
+    expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
+  });
+
   it('finds a position at beginning', () => {
     const renderer = createRendererMock([
       createStyleSheetMock('d', {}),
@@ -63,6 +83,26 @@ describe('findInsertionPoint', () => {
       const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
 
       expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
+    });
+
+    it('handles insertionPoint in otherwise empty array', () => {
+      const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+
+      const renderer = createRendererMock([insertionPoint]);
+      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
+
+      expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
+    });
+
+    it('handles insertionPoint with other (non-Griffel) stylesheets', () => {
+      const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+      const other1 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+      const other2 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+
+      const renderer = createRendererMock([other1, insertionPoint, other2]);
+      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
+
+      expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
     });
 
     it('finds a position at beginning', () => {

--- a/packages/shadow-dom/src/findInsertionPoint.test.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.test.ts
@@ -32,25 +32,14 @@ describe('findInsertionPoint', () => {
     expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
   });
 
-  it('handles insertionPoint in otherwise empty array', () => {
-    const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+  // it('handles insertionPoint in otherwise empty array', () => {
+  //   const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
 
-    const renderer = createRendererMock([insertionPoint]);
-    const styleSheet = createStyleSheetMock('d', {});
+  //   const renderer = createRendererMock([]);
+  //   const styleSheet = createStyleSheetMock('d', {});
 
-    expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
-  });
-
-  it('handles insertionPoint with other (non-Griffel) stylesheets', () => {
-    const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-    const other1 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-    const other2 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-
-    const renderer = createRendererMock([other1, insertionPoint, other2]);
-    const styleSheet = createStyleSheetMock('d', {});
-
-    expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
-  });
+  //   expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
+  // });
 
   it('finds a position at beginning', () => {
     const renderer = createRendererMock([
@@ -85,25 +74,14 @@ describe('findInsertionPoint', () => {
       expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
     });
 
-    it('handles insertionPoint in otherwise empty array', () => {
-      const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
+    // it('handles insertionPoint in otherwise empty array', () => {
+    //   const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
 
-      const renderer = createRendererMock([insertionPoint]);
-      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
+    //   const renderer = createRendererMock([]);
+    //   const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
 
-      expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
-    });
-
-    it('handles insertionPoint with other (non-Griffel) stylesheets', () => {
-      const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-      const other1 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-      const other2 = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-
-      const renderer = createRendererMock([other1, insertionPoint, other2]);
-      const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
-
-      expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
-    });
+    //   expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
+    // });
 
     it('finds a position at beginning', () => {
       const renderer = createRendererMock([createStyleSheetMock('c', {})]);

--- a/packages/shadow-dom/src/findInsertionPoint.test.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.test.ts
@@ -32,15 +32,6 @@ describe('findInsertionPoint', () => {
     expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
   });
 
-  // it('handles insertionPoint in otherwise empty array', () => {
-  //   const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-
-  //   const renderer = createRendererMock([]);
-  //   const styleSheet = createStyleSheetMock('d', {});
-
-  //   expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
-  // });
-
   it('finds a position at beginning', () => {
     const renderer = createRendererMock([
       createStyleSheetMock('d', {}),
@@ -73,15 +64,6 @@ describe('findInsertionPoint', () => {
 
       expect(findInsertionPoint(renderer, styleSheet)).toBe(null);
     });
-
-    // it('handles insertionPoint in otherwise empty array', () => {
-    //   const insertionPoint = new CSSStyleSheet() as ExtendedCSSStyleSheet;
-
-    //   const renderer = createRendererMock([]);
-    //   const styleSheet = createStyleSheetMock('m', { m: '(max-width: 3px)' });
-
-    //   expect(findInsertionPoint(renderer, styleSheet, insertionPoint)).toBe(insertionPoint);
-    // });
 
     it('finds a position at beginning', () => {
       const renderer = createRendererMock([createStyleSheetMock('c', {})]);

--- a/packages/shadow-dom/src/findInsertionPoint.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.ts
@@ -50,10 +50,6 @@ export function findShadowRootInsertionPoint(
 ): CSSStyleSheet | null {
   const styleSheets = shadowRoot.adoptedStyleSheets;
 
-  if (renderer.adoptedStyleSheets.length < 1) {
-    return insertionPoint ? styleSheets[styleSheets.indexOf(insertionPoint) + 1] : null;
-  }
-
   if (rendererTargetStyleSheet) {
     return styleSheets[styleSheets.indexOf(rendererTargetStyleSheet)];
   }

--- a/packages/shadow-dom/src/findInsertionPoint.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.ts
@@ -11,7 +11,6 @@ const styleBucketOrderingMap = styleBucketOrdering.reduce((acc, cur, j) => {
 export function findInsertionPoint(
   renderer: GriffelShadowDOMRenderer,
   styleSheet: ExtendedCSSStyleSheet,
-  insertionPoint?: ExtendedCSSStyleSheet,
 ): ExtendedCSSStyleSheet | null {
   let styleSheets = renderer.adoptedStyleSheets;
   const targetOrder = styleBucketOrderingMap[styleSheet.bucketName];
@@ -32,16 +31,41 @@ export function findInsertionPoint(
     const styleElement = styleSheets[i];
 
     if (comparer(styleElement) > 0) {
-      return styleSheets[i + 1] ?? insertionPoint ?? null;
+      return styleSheets[i + 1] ?? null;
     }
-  }
-
-  if (insertionPoint) {
-    return insertionPoint;
   }
 
   if (styleSheets.length > 0) {
     return styleSheets[0];
+  }
+
+  return null;
+}
+
+export function findShadowRootInsertionPoint(
+  renderer: GriffelShadowDOMRenderer,
+  shadowRoot: ShadowRoot,
+  rendererTargetStyleSheet: ExtendedCSSStyleSheet | null,
+  insertionPoint?: CSSStyleSheet,
+): CSSStyleSheet | null {
+  const styleSheets = shadowRoot.adoptedStyleSheets;
+
+  if (renderer.adoptedStyleSheets.length < 1) {
+    return insertionPoint ? styleSheets[styleSheets.indexOf(insertionPoint) + 1] : null;
+  }
+
+  if (rendererTargetStyleSheet) {
+    return styleSheets[styleSheets.indexOf(rendererTargetStyleSheet)];
+  }
+
+  if (insertionPoint) {
+    let i = styleSheets.indexOf(insertionPoint) + 1;
+    let targetSheet = styleSheets[i];
+    while ('bucketName' in targetSheet) {
+      targetSheet = styleSheets[i++];
+    }
+
+    return targetSheet;
   }
 
   return null;

--- a/packages/shadow-dom/src/findInsertionPoint.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.ts
@@ -11,6 +11,7 @@ const styleBucketOrderingMap = styleBucketOrdering.reduce((acc, cur, j) => {
 export function findInsertionPoint(
   renderer: GriffelShadowDOMRenderer,
   styleSheet: ExtendedCSSStyleSheet,
+  insertionPoint?: ExtendedCSSStyleSheet,
 ): ExtendedCSSStyleSheet | null {
   let styleSheets = renderer.adoptedStyleSheets;
   const targetOrder = styleBucketOrderingMap[styleSheet.bucketName];
@@ -31,8 +32,12 @@ export function findInsertionPoint(
     const styleElement = styleSheets[i];
 
     if (comparer(styleElement) > 0) {
-      return styleSheets[i + 1] ?? null;
+      return styleSheets[i + 1] ?? insertionPoint ?? null;
     }
+  }
+
+  if (insertionPoint) {
+    return insertionPoint;
   }
 
   if (styleSheets.length > 0) {

--- a/packages/shadow-dom/src/findInsertionPoint.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.ts
@@ -43,7 +43,6 @@ export function findInsertionPoint(
 }
 
 export function findShadowRootInsertionPoint(
-  renderer: GriffelShadowDOMRenderer,
   shadowRoot: ShadowRoot,
   rendererTargetStyleSheet: ExtendedCSSStyleSheet | null,
   insertionPoint?: CSSStyleSheet,
@@ -51,17 +50,17 @@ export function findShadowRootInsertionPoint(
   const styleSheets = shadowRoot.adoptedStyleSheets;
 
   if (rendererTargetStyleSheet) {
-    return styleSheets[styleSheets.indexOf(rendererTargetStyleSheet)];
+    return styleSheets[styleSheets.indexOf(rendererTargetStyleSheet)] ?? null;
   }
 
   if (insertionPoint) {
     let i = styleSheets.indexOf(insertionPoint) + 1;
     let targetSheet = styleSheets[i];
-    while ('bucketName' in targetSheet) {
+    while (targetSheet && 'bucketName' in targetSheet) {
       targetSheet = styleSheets[i++];
     }
 
-    return targetSheet;
+    return targetSheet ?? null;
   }
 
   return null;

--- a/packages/shadow-dom/src/index.ts
+++ b/packages/shadow-dom/src/index.ts
@@ -1,2 +1,2 @@
 export { createShadowDOMRenderer } from './createShadowDOMRenderer';
-export type { GriffelShadowDOMRenderer } from './types';
+export type { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';


### PR DESCRIPTION
Exposes the `insertionPoint` API for shadow DOM similar to vanilla Griffel.

[See Fluent UI Contrib for more details](https://github.com/microsoft/fluentui-contrib/issues/59).