### PR TITLE
chore: enable "@typescript-eslint/consistent-type-imports" lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,14 @@
     }
   },
   "rules": {
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "disallowTypeAnnotations": false,
+        "fixStyle": "separate-type-imports",
+        "prefer": "type-imports"
+      }
+    ],
     "import/no-extraneous-dependencies": ["error", { "devDependencies": false }],
     "jest/no-focused-tests": "error"
   },

--- a/change/@griffel-babel-preset-22e7d18a-90dc-4b20-8b64-b7721c50f648.json
+++ b/change/@griffel-babel-preset-22e7d18a-90dc-4b20-8b64-b7721c50f648.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-core-bd502a98-9791-4b3a-bc14-f291877c3a9d.json
+++ b/change/@griffel-core-bd502a98-9791-4b3a-bc14-f291877c3a9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-devtools-9b22c6d5-022f-466e-90db-c6ffd4872865.json
+++ b/change/@griffel-devtools-9b22c6d5-022f-466e-90db-c6ffd4872865.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/devtools",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-eslint-plugin-1902eaba-f335-4ef6-8f1c-7506582fa6f5.json
+++ b/change/@griffel-eslint-plugin-1902eaba-f335-4ef6-8f1c-7506582fa6f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-jest-serializer-cca934ab-06c6-4c1e-aae4-841c7a25c52c.json
+++ b/change/@griffel-jest-serializer-cca934ab-06c6-4c1e-aae4-841c7a25c52c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/jest-serializer",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-postcss-syntax-52955b9b-1bb7-4ec9-a243-928ecf9c36ad.json
+++ b/change/@griffel-postcss-syntax-52955b9b-1bb7-4ec9-a243-928ecf9c36ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-shadow-dom-de5a9200-951e-4f22-b812-5edc408eba44.json
+++ b/change/@griffel-shadow-dom-de5a9200-951e-4f22-b812-5edc408eba44.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/shadow-dom",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-style-types-8c434fba-46c8-4fdc-9294-43bbcf6f2c95.json
+++ b/change/@griffel-style-types-8c434fba-46c8-4fdc-9294-43bbcf6f2c95.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/style-types",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-tag-processor-d5996bf1-dca6-428d-be1e-e49f01e57ab5.json
+++ b/change/@griffel-tag-processor-d5996bf1-dca6-428d-be1e-e49f01e57ab5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/tag-processor",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-extraction-plugin-aa250f01-bfb5-4ada-9673-c9c400e620b7.json
+++ b/change/@griffel-webpack-extraction-plugin-aa250f01-bfb5-4ada-9673-c9c400e620b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-loader-659f4d63-718b-45a7-9df1-d14faaf85784.json
+++ b/change/@griffel-webpack-loader-659f4d63-718b-45a7-9df1-d14faaf85784.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable \"@typescript-eslint/consistent-type-imports\" lint rule",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-preset/__fixtures__/function-mixin/mixins.ts
+++ b/packages/babel-preset/__fixtures__/function-mixin/mixins.ts
@@ -1,4 +1,4 @@
-import { GriffelStyle } from '@griffel/core';
+import type { GriffelStyle } from '@griffel/core';
 import { tokens } from './tokens';
 
 export const createMixin = (rule: GriffelStyle): GriffelStyle => ({

--- a/packages/babel-preset/__fixtures__/object-mixins/mixins.ts
+++ b/packages/babel-preset/__fixtures__/object-mixins/mixins.ts
@@ -1,4 +1,4 @@
-import { GriffelStyle } from '@griffel/core';
+import type { GriffelStyle } from '@griffel/core';
 import { tokens } from './tokens';
 
 export const flexStyles: GriffelStyle = {

--- a/packages/babel-preset/__fixtures__/object-sequence-expr/code.ts
+++ b/packages/babel-preset/__fixtures__/object-sequence-expr/code.ts
@@ -1,4 +1,5 @@
-import { makeStyles, GriffelStyle } from '@griffel/react';
+import type { GriffelStyle } from '@griffel/react';
+import { makeStyles } from '@griffel/react';
 
 const switchClassName = 'fui-Switch';
 let _a: Record<string, GriffelStyle>;

--- a/packages/babel-preset/__fixtures__/object-sequence-expr/output.ts
+++ b/packages/babel-preset/__fixtures__/object-sequence-expr/output.ts
@@ -1,4 +1,5 @@
-import { __styles, GriffelStyle } from '@griffel/react';
+import type { GriffelStyle } from '@griffel/react';
+import { __styles } from '@griffel/react';
 const switchClassName = 'fui-Switch';
 let _a: Record<string, GriffelStyle>;
 export const useStyles = __styles(

--- a/packages/babel-preset/__fixtures__/shared-mixins/mixins.ts
+++ b/packages/babel-preset/__fixtures__/shared-mixins/mixins.ts
@@ -1,4 +1,4 @@
-import { GriffelStyle } from '@griffel/core';
+import type { GriffelStyle } from '@griffel/core';
 
 export const sharedStyles: Record<string, GriffelStyle> = {
   root: { display: 'flex' },

--- a/packages/babel-preset/src/assets/normalizeStyleRules.ts
+++ b/packages/babel-preset/src/assets/normalizeStyleRules.ts
@@ -1,4 +1,4 @@
-import { GriffelAnimation, GriffelStyle } from '@griffel/core';
+import type { GriffelAnimation, GriffelStyle } from '@griffel/core';
 import { tokenize } from 'stylis';
 
 import { isAssetUrl } from './isAssetUrl';

--- a/packages/babel-preset/src/assets/replaceAssetsWithImports.ts
+++ b/packages/babel-preset/src/assets/replaceAssetsWithImports.ts
@@ -1,4 +1,5 @@
-import { NodePath, traverse, types as t } from '@babel/core';
+import type { NodePath } from '@babel/core';
+import { traverse, types as t } from '@babel/core';
 import * as path from 'path';
 import { tokenize } from 'stylis';
 

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { transformPlugin } from './transformPlugin';
-import { BabelPluginMetadata } from './types';
+import type { BabelPluginMetadata } from './types';
 
 const prettierConfig = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../../../.prettierrc'), { encoding: 'utf-8' }),

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -1,22 +1,17 @@
-import { NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
+import type { NodePath, PluginObj, PluginPass } from '@babel/core';
+import { types as t } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
 import { Module } from '@linaria/babel-preset';
 import shakerEvaluator from '@linaria/shaker';
-import {
-  resolveStyleRulesForSlots,
-  GriffelStyle,
-  resolveResetStyleRules,
-  CSSRulesByBucket,
-  CSSClassesMapBySlot,
-  normalizeCSSBucketEntry,
-} from '@griffel/core';
+import type { GriffelStyle, CSSRulesByBucket, CSSClassesMapBySlot } from '@griffel/core';
+import { resolveStyleRulesForSlots, resolveResetStyleRules, normalizeCSSBucketEntry } from '@griffel/core';
 import * as path from 'path';
 
 import { normalizeStyleRules } from './assets/normalizeStyleRules';
 import { replaceAssetsWithImports } from './assets/replaceAssetsWithImports';
 import { dedupeCSSRules } from './utils/dedupeCSSRules';
 import { evaluatePaths } from './utils/evaluatePaths';
-import { BabelPluginOptions, BabelPluginMetadata } from './types';
+import type { BabelPluginOptions, BabelPluginMetadata } from './types';
 import { validateOptions } from './validateOptions';
 
 type FunctionKinds = 'makeStyles' | 'makeResetStyles';

--- a/packages/babel-preset/src/utils/evaluatePaths.ts
+++ b/packages/babel-preset/src/utils/evaluatePaths.ts
@@ -1,4 +1,4 @@
-import { NodePath, types as t } from '@babel/core';
+import type { NodePath, types as t } from '@babel/core';
 
 import type { BabelPluginOptions } from '../types';
 import { evaluatePathsInVM } from './evaluatePathsInVM';

--- a/packages/babel-preset/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-preset/src/utils/evaluatePathsInVM.ts
@@ -1,8 +1,10 @@
-import { NodePath, types as t } from '@babel/core';
-import { Scope } from '@babel/traverse';
-import * as template from '@babel/template';
+import { types as t } from '@babel/core';
+import type { NodePath } from '@babel/core';
 import generator from '@babel/generator';
-import { Module, StrictOptions } from '@linaria/babel-preset';
+import * as template from '@babel/template';
+import type { Scope } from '@babel/traverse';
+import type { StrictOptions } from '@linaria/babel-preset';
+import { Module } from '@linaria/babel-preset';
 
 import type { BabelPluginOptions } from '../types';
 

--- a/packages/babel-preset/src/validateOptions.test.ts
+++ b/packages/babel-preset/src/validateOptions.test.ts
@@ -1,7 +1,7 @@
 import type { Evaluator } from '@linaria/babel-preset';
 
 import { validateOptions } from './validateOptions';
-import { BabelPluginOptions } from './types';
+import type { BabelPluginOptions } from './types';
 
 describe('validateOptions', () => {
   describe('modules', () => {

--- a/packages/babel-preset/src/validateOptions.ts
+++ b/packages/babel-preset/src/validateOptions.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 
 import { configSchema } from './schema';
-import { BabelPluginOptions } from './types';
+import type { BabelPluginOptions } from './types';
 
 const ajv = new Ajv();
 

--- a/packages/core/src/common/snapshotSerializers.ts
+++ b/packages/core/src/common/snapshotSerializers.ts
@@ -2,10 +2,10 @@
 
 import * as prettier from 'prettier';
 
-import { resolveStyleRules } from '../runtime/resolveStyleRules';
+import type { resolveStyleRules } from '../runtime/resolveStyleRules';
 import { normalizeCSSBucketEntry } from '../runtime/utils/normalizeCSSBucketEntry';
 import type { CSSRulesByBucket, GriffelRenderer } from '../types';
-import { resolveResetStyleRules } from '../runtime/resolveResetStyleRules';
+import type { resolveResetStyleRules } from '../runtime/resolveResetStyleRules';
 
 // eslint-disable-next-line eqeqeq
 const isObject = (value: unknown) => value != null && !Array.isArray(value) && typeof value === 'object';

--- a/packages/core/src/devtools/getDebugTree.test.ts
+++ b/packages/core/src/devtools/getDebugTree.test.ts
@@ -1,8 +1,8 @@
 import { SEQUENCE_PREFIX } from '../constants';
 import { makeStyles } from '../makeStyles';
+import type { MakeStylesOptions } from '../makeStyles';
 import { mergeClasses } from '../mergeClasses';
 import { createDOMRenderer } from '../renderer/createDOMRenderer';
-import { MakeStylesOptions } from '../makeStyles';
 import { getDebugTree } from './getDebugTree';
 
 jest.mock('./isDevToolsEnabled', () => ({

--- a/packages/core/src/devtools/getDebugTree.ts
+++ b/packages/core/src/devtools/getDebugTree.ts
@@ -1,7 +1,7 @@
 import { DEFINITION_LOOKUP_TABLE } from '../constants';
-import { LookupItem, SequenceHash } from '../types';
+import type { LookupItem, SequenceHash } from '../types';
 import { debugData } from './store';
-import { DebugSequence } from './types';
+import type { DebugSequence } from './types';
 import { getDebugClassNames } from './utils';
 
 export function getDebugTree(debugSequenceHash: SequenceHash, parentNode?: DebugSequence) {

--- a/packages/core/src/devtools/store.test.ts
+++ b/packages/core/src/devtools/store.test.ts
@@ -2,7 +2,7 @@ import { SEQUENCE_PREFIX } from '../constants';
 import { makeStyles } from '../makeStyles';
 import { mergeClasses } from '../mergeClasses';
 import { createDOMRenderer } from '../renderer/createDOMRenderer';
-import { MakeStylesOptions } from '../makeStyles';
+import type { MakeStylesOptions } from '../makeStyles';
 import { debugData } from './store';
 
 jest.mock('./isDevToolsEnabled', () => ({

--- a/packages/core/src/devtools/types.ts
+++ b/packages/core/src/devtools/types.ts
@@ -1,4 +1,4 @@
-import { SequenceHash } from '../types';
+import type { SequenceHash } from '../types';
 
 declare global {
   interface Window {

--- a/packages/core/src/devtools/utils.ts
+++ b/packages/core/src/devtools/utils.ts
@@ -1,5 +1,5 @@
-import { CSSClasses, LookupItem } from '../types';
-import { DebugAtomicClassName, DebugSequence } from './types';
+import type { CSSClasses, LookupItem } from '../types';
+import type { DebugAtomicClassName, DebugSequence } from './types';
 
 function getDirectionalClassName(classes: CSSClasses, direction: 'ltr' | 'rtl'): string {
   return Array.isArray(classes) ? (direction === 'rtl' ? classes[1] : classes[0]) : classes;

--- a/packages/core/src/makeStaticStyles.test.ts
+++ b/packages/core/src/makeStaticStyles.test.ts
@@ -2,7 +2,7 @@ import { createDOMRenderer } from './renderer/createDOMRenderer';
 import { griffelRendererSerializer } from './common/snapshotSerializers';
 import { makeStaticStyles } from './makeStaticStyles';
 import { makeStyles } from './makeStyles';
-import { GriffelRenderer } from './types';
+import type { GriffelRenderer } from './types';
 
 expect.addSnapshotSerializer(griffelRendererSerializer);
 

--- a/packages/core/src/mergeClasses.ts
+++ b/packages/core/src/mergeClasses.ts
@@ -9,7 +9,7 @@ import {
 } from './constants';
 import { hashSequence } from './runtime/utils/hashSequence';
 import { reduceToClassName } from './runtime/reduceToClassNameForSlots';
-import { CSSClassesMap, SequenceHash } from './types';
+import type { CSSClassesMap, SequenceHash } from './types';
 
 // Contains a mapping of previously resolved sequences of atomic classnames
 export const mergeClassesCachedResults: Record<string, string> = {};

--- a/packages/core/src/renderer/createDOMRenderer-node.test.ts
+++ b/packages/core/src/renderer/createDOMRenderer-node.test.ts
@@ -4,7 +4,7 @@
 
 // 👆 this is intentionally to test in SSR like environment
 
-import { CSSRulesByBucket } from '../types';
+import type { CSSRulesByBucket } from '../types';
 import { createDOMRenderer } from './createDOMRenderer';
 
 describe('createDOMRenderer', () => {

--- a/packages/core/src/renderer/createDOMRenderer.test.ts
+++ b/packages/core/src/renderer/createDOMRenderer.test.ts
@@ -1,6 +1,6 @@
-import { CSSRulesByBucket } from '../types';
-import { createDOMRenderer } from './createDOMRenderer';
 import { griffelRendererSerializer } from '../common/snapshotSerializers';
+import type { CSSRulesByBucket } from '../types';
+import { createDOMRenderer } from './createDOMRenderer';
 
 expect.addSnapshotSerializer(griffelRendererSerializer);
 

--- a/packages/core/src/renderer/createDOMRenderer.ts
+++ b/packages/core/src/renderer/createDOMRenderer.ts
@@ -1,6 +1,6 @@
 import { injectDevTools, isDevToolsEnabled, debugData } from '../devtools';
 import { normalizeCSSBucketEntry } from '../runtime/utils/normalizeCSSBucketEntry';
-import { GriffelRenderer, StyleBucketName } from '../types';
+import type { GriffelRenderer, StyleBucketName } from '../types';
 import { getStyleSheetForBucket } from './getStyleSheetForBucket';
 import { safeInsertRule } from './safeInsertRule';
 

--- a/packages/core/src/renderer/createIsomorphicStyleSheet.ts
+++ b/packages/core/src/renderer/createIsomorphicStyleSheet.ts
@@ -1,5 +1,5 @@
 import { DATA_BUCKET_ATTR } from '../constants';
-import { IsomorphicStyleSheet, StyleBucketName } from '../types';
+import type { IsomorphicStyleSheet, StyleBucketName } from '../types';
 
 export function createIsomorphicStyleSheet(
   styleElement: HTMLStyleElement | undefined,

--- a/packages/core/src/renderer/getStyleSheetForBucket.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.ts
@@ -1,5 +1,5 @@
 import { DATA_BUCKET_ATTR } from '../constants';
-import { GriffelRenderer, IsomorphicStyleSheet, StyleBucketName } from '../types';
+import type { GriffelRenderer, IsomorphicStyleSheet, StyleBucketName } from '../types';
 import { createIsomorphicStyleSheet } from './createIsomorphicStyleSheet';
 
 /**

--- a/packages/core/src/renderer/rehydrateRendererCache.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.ts
@@ -1,4 +1,4 @@
-import { GriffelRenderer, StyleBucketName } from '../types';
+import type { GriffelRenderer, StyleBucketName } from '../types';
 import { createIsomorphicStyleSheetFromElement } from './createIsomorphicStyleSheet';
 import { isDevToolsEnabled, debugData } from '../devtools';
 

--- a/packages/core/src/resolveStyleRulesForSlots.test.ts
+++ b/packages/core/src/resolveStyleRulesForSlots.test.ts
@@ -1,5 +1,5 @@
 import { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
-import { StylesBySlots } from './types';
+import type { StylesBySlots } from './types';
 
 describe('resolveStyleRulesForSlots', () => {
   it('returns classnames and CSS rules to apply', () => {

--- a/packages/core/src/resolveStyleRulesForSlots.ts
+++ b/packages/core/src/resolveStyleRulesForSlots.ts
@@ -1,7 +1,7 @@
 import type { GriffelStyle } from '@griffel/style-types';
 
 import { resolveStyleRules } from './runtime/resolveStyleRules';
-import { CSSClassesMapBySlot, CSSRulesByBucket, StyleBucketName, StylesBySlots } from './types';
+import type { CSSClassesMapBySlot, CSSRulesByBucket, StyleBucketName, StylesBySlots } from './types';
 
 /**
  * Calls resolveStyleRules() for each slot, is also used by build time transform.

--- a/packages/core/src/runtime/compileAtomicCSSRule.test.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.test.ts
@@ -1,4 +1,5 @@
-import { compileAtomicCSSRule, CompileAtomicCSSOptions, normalizePseudoSelector } from './compileAtomicCSSRule';
+import { compileAtomicCSSRule, normalizePseudoSelector } from './compileAtomicCSSRule';
+import type { CompileAtomicCSSOptions } from './compileAtomicCSSRule';
 
 const defaultOptions: Pick<
   CompileAtomicCSSOptions,

--- a/packages/core/src/runtime/getStyleBucketName.ts
+++ b/packages/core/src/runtime/getStyleBucketName.ts
@@ -1,4 +1,4 @@
-import { StyleBucketName } from '../types';
+import type { StyleBucketName } from '../types';
 
 /**
  * Maps the long pseudo name to the short pseudo name. Pseudos that match here will be ordered, everything else will

--- a/packages/core/src/runtime/reduceToClassNameForSlots.ts
+++ b/packages/core/src/runtime/reduceToClassNameForSlots.ts
@@ -1,6 +1,6 @@
 import { DEFINITION_LOOKUP_TABLE } from '../constants';
 import { hashSequence } from './utils/hashSequence';
-import { CSSClassesMapBySlot, CSSClassesMap, CSSClasses } from '../types';
+import type { CSSClassesMapBySlot, CSSClassesMap, CSSClasses } from '../types';
 
 /**
  * Reduces a classname map for slot to a classname string. Uses classnames according to text directions.

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -1,6 +1,6 @@
 import { griffelRulesSerializer } from '../common/snapshotSerializers';
 import { resolveStyleRules } from './resolveStyleRules';
-import { CSSClassesMap, CSSClasses, CSSRulesByBucket } from '../types';
+import type { CSSClassesMap, CSSClasses, CSSRulesByBucket } from '../types';
 import { UNSUPPORTED_CSS_PROPERTIES } from '..';
 
 expect.addSnapshotSerializer(griffelRulesSerializer);

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -3,8 +3,9 @@ import type { GriffelAnimation, GriffelStyle } from '@griffel/style-types';
 import { convert, convertProperty } from 'rtl-css-js/core';
 
 import { HASH_PREFIX, UNSUPPORTED_CSS_PROPERTIES } from '../constants';
-import { CSSClassesMap, CSSRulesByBucket, StyleBucketName, CSSBucketEntry } from '../types';
-import { compileAtomicCSSRule, CompileAtomicCSSOptions } from './compileAtomicCSSRule';
+import type { CSSClassesMap, CSSRulesByBucket, StyleBucketName, CSSBucketEntry } from '../types';
+import type { CompileAtomicCSSOptions } from './compileAtomicCSSRule';
+import { compileAtomicCSSRule } from './compileAtomicCSSRule';
 import { compileKeyframeRule, compileKeyframesCSS } from './compileKeyframeCSS';
 import { generateCombinedQuery } from './utils/generateCombinedMediaQuery';
 import { isMediaQuerySelector } from './utils/isMediaQuerySelector';

--- a/packages/core/src/runtime/utils/cssifyObject.ts
+++ b/packages/core/src/runtime/utils/cssifyObject.ts
@@ -1,4 +1,4 @@
-import { GriffelStaticStyle, GriffelStyle } from '@griffel/style-types';
+import type { GriffelStaticStyle, GriffelStyle } from '@griffel/style-types';
 import { hyphenateProperty } from './hyphenateProperty';
 
 export function cssifyObject(style: GriffelStyle | GriffelStaticStyle) {

--- a/packages/core/src/runtime/utils/hashPropertyKey.ts
+++ b/packages/core/src/runtime/utils/hashPropertyKey.ts
@@ -1,5 +1,5 @@
 import hash from '@emotion/hash';
-import { PropertyHash } from '../../types';
+import type { PropertyHash } from '../../types';
 
 export function hashPropertyKey(
   selector: string,

--- a/packages/core/src/runtime/utils/hashSequence.ts
+++ b/packages/core/src/runtime/utils/hashSequence.ts
@@ -1,7 +1,7 @@
 import hash from '@emotion/hash';
 
 import { DEBUG_SEQUENCE_SEPARATOR, SEQUENCE_HASH_LENGTH, SEQUENCE_PREFIX } from '../../constants';
-import { SequenceHash } from '../../types';
+import type { SequenceHash } from '../../types';
 
 function padEndHash(value: string): string {
   const hashLength = value.length;

--- a/packages/core/src/runtime/utils/normalizeCSSBucketEntry.ts
+++ b/packages/core/src/runtime/utils/normalizeCSSBucketEntry.ts
@@ -1,4 +1,4 @@
-import { CSSBucketEntry } from '../../types';
+import type { CSSBucketEntry } from '../../types';
 
 /**
  * @internal

--- a/packages/core/src/shorthands/borderWidth.ts
+++ b/packages/core/src/shorthands/borderWidth.ts
@@ -1,6 +1,7 @@
 import type { GriffelStyle } from '@griffel/style-types';
+
 import { generateStyles } from './generateStyles';
-import { BorderWidthInput } from './types';
+import type { BorderWidthInput } from './types';
 
 type BorderWidthStyle = Pick<
   GriffelStyle,

--- a/packages/core/src/shorthands/flex.ts
+++ b/packages/core/src/shorthands/flex.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 import type { GriffelStyle } from '@griffel/style-types';
 import type { FlexInput } from './types';

--- a/packages/core/src/shorthands/textDecoration.ts
+++ b/packages/core/src/shorthands/textDecoration.ts
@@ -1,5 +1,5 @@
 import type { GriffelStyle } from '@griffel/style-types';
-import {
+import type {
   TextDecorationColorInput,
   TextDecorationLineInput,
   TextDecorationStyleInput,

--- a/packages/core/src/shorthands/transition.ts
+++ b/packages/core/src/shorthands/transition.ts
@@ -1,5 +1,5 @@
 import type { GriffelStyle } from '@griffel/style-types';
-import {
+import type {
   TransitionDelayInput,
   TransitionDurationInput,
   TransitionPropertyInput,

--- a/packages/core/src/shorthands/types.ts
+++ b/packages/core/src/shorthands/types.ts
@@ -1,5 +1,5 @@
 import type { GriffelStylesCSSValue, ValueOrArray } from '@griffel/style-types';
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 export type BorderWidthInput = ValueOrArray<CSS.Property.BorderWidth<GriffelStylesCSSValue>>;
 export type BorderStyleInput = ValueOrArray<CSS.Property.BorderStyle>;

--- a/packages/core/src/shorthands/utils.ts
+++ b/packages/core/src/shorthands/utils.ts
@@ -1,5 +1,5 @@
 import type { GriffelStylesCSSValue } from '@griffel/style-types';
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 const LINE_STYLES: CSS.DataType.LineStyle[] = [
   'none',

--- a/packages/devtools/src/HighlightedCSS.tsx
+++ b/packages/devtools/src/HighlightedCSS.tsx
@@ -1,5 +1,6 @@
 import { makeStyles, shorthands } from '@griffel/react';
-import Highlight, { defaultProps, PrismTheme } from 'prism-react-renderer';
+import type { PrismTheme } from 'prism-react-renderer';
+import Highlight, { defaultProps } from 'prism-react-renderer';
 import * as React from 'react';
 
 import { tokens } from './themes';

--- a/packages/devtools/src/sourceMap/sourceMapConsumer.ts
+++ b/packages/devtools/src/sourceMap/sourceMapConsumer.ts
@@ -1,4 +1,5 @@
-import { SourceMapConsumer, MappedPosition, RawSourceMap } from 'source-map-js';
+import type { MappedPosition, RawSourceMap } from 'source-map-js';
+import { SourceMapConsumer } from 'source-map-js';
 
 export const resources: Promise<chrome.devtools.inspectedWindow.Resource[]> = new Promise(resolve => {
   chrome.devtools.inspectedWindow.getResources(currResources => {

--- a/packages/devtools/src/stories/FlattenView.stories.tsx
+++ b/packages/devtools/src/stories/FlattenView.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Story } from '@storybook/react';
 import type { DebugResult } from '@griffel/core';
+import type { Story } from '@storybook/react';
 
 import { FlattenView } from '../FlattenView';
 import { darkTheme, lightTheme } from '../themes';

--- a/packages/eslint-plugin/src/rules/hook-naming.ts
+++ b/packages/eslint-plugin/src/rules/hook-naming.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils } from '@typescript-eslint/utils';
+import type { ESLintUtils } from '@typescript-eslint/utils';
 
 import { createRule } from '../utils/createRule';
 import { isIdentifier, isMakeStylesCallExpression } from '../utils/helpers';

--- a/packages/eslint-plugin/src/rules/no-shorthands.ts
+++ b/packages/eslint-plugin/src/rules/no-shorthands.ts
@@ -1,5 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
-import * as CSS from 'csstype';
+import type { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import type * as CSS from 'csstype';
 
 import { createRule } from '../utils/createRule';
 import { isIdentifier, isLiteral, isMakeStylesCallExpression, isObjectExpression, isProperty } from '../utils/helpers';

--- a/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
+++ b/packages/eslint-plugin/src/rules/pseudo-element-naming.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import type { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createRule } from '../utils/createRule';
 import { isMakeStylesCallExpression, isObjectExpression, isProperty, isStringLiteral } from '../utils/helpers';

--- a/packages/eslint-plugin/src/rules/styles-file.ts
+++ b/packages/eslint-plugin/src/rules/styles-file.ts
@@ -1,5 +1,5 @@
 import { createRule } from '../utils/createRule';
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import type { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
 import { isMakeStylesCallExpression } from '../utils/helpers';
 
 const MATCHING_PACKAGES = new Set(['@fluentui/react-components', '@griffel/core', '@griffel/react']);

--- a/packages/eslint-plugin/src/utils/helpers.ts
+++ b/packages/eslint-plugin/src/utils/helpers.ts
@@ -1,4 +1,5 @@
-import { AST_NODE_TYPES, ASTUtils, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 type IsHelper<NodeType extends AST_NODE_TYPES> = (node: TSESTree.Node | null | undefined) => node is TSESTree.Node & {
   type: NodeType;

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -1,4 +1,5 @@
-import { DEBUG_RESET_CLASSES, DEFINITION_LOOKUP_TABLE, CSSClasses } from '@griffel/core';
+import type { CSSClasses } from '@griffel/core';
+import { DEBUG_RESET_CLASSES, DEFINITION_LOOKUP_TABLE } from '@griffel/core';
 
 export function print(val: unknown) {
   /**

--- a/packages/postcss-syntax/src/createSyntax.ts
+++ b/packages/postcss-syntax/src/createSyntax.ts
@@ -1,7 +1,8 @@
-import * as postcss from 'postcss';
+import type { BabelPluginOptions } from '@griffel/babel-preset';
+import type * as postcss from 'postcss';
+
 import { parse } from './parse';
 import { stringify } from './stringify';
-import { BabelPluginOptions } from '@griffel/babel-preset';
 
 /**
  * Creates a custom syntax with configured options for @griffel/babel-preset

--- a/packages/postcss-syntax/src/location-preset.ts
+++ b/packages/postcss-syntax/src/location-preset.ts
@@ -1,6 +1,6 @@
-import { PluginObj, PluginPass, types as t, ConfigAPI } from '@babel/core';
+import type { PluginObj, PluginPass, types as t, ConfigAPI } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
-import { BabelPluginOptions } from '@griffel/babel-preset';
+import type { BabelPluginOptions } from '@griffel/babel-preset';
 
 export interface LocationPluginState extends PluginPass {
   locations?: Record<string, Record<string, t.SourceLocation>>;

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -1,7 +1,7 @@
 import * as postcss from 'postcss';
 import transformSync from './transform-sync';
 import { GRIFFEL_DECLARATOR_RAW, GRIFFEL_SLOT_RAW, GRIFFEL_SRC_RAW } from './constants';
-import { BabelPluginOptions } from '@griffel/babel-preset';
+import type { BabelPluginOptions } from '@griffel/babel-preset';
 
 export type PostCSSParserOptions = Pick<postcss.ProcessOptions<postcss.Document | postcss.Root>, 'from' | 'map'>;
 

--- a/packages/postcss-syntax/src/stringify.ts
+++ b/packages/postcss-syntax/src/stringify.ts
@@ -1,4 +1,4 @@
-import * as postcss from 'postcss';
+import type * as postcss from 'postcss';
 import { GRIFFEL_SRC_RAW } from './constants';
 
 export const stringify: postcss.Stringifier = root => {

--- a/packages/postcss-syntax/src/transform-sync.ts
+++ b/packages/postcss-syntax/src/transform-sync.ts
@@ -1,6 +1,8 @@
 import * as Babel from '@babel/core';
-import griffelPreset, { BabelPluginMetadata, BabelPluginOptions } from '@griffel/babel-preset';
-import locationPreset, { LocationPluginMetadata } from './location-preset';
+import type { BabelPluginMetadata, BabelPluginOptions } from '@griffel/babel-preset';
+import griffelPreset from '@griffel/babel-preset';
+import type { LocationPluginMetadata } from './location-preset';
+import locationPreset from './location-preset';
 
 export type TransformOptions = {
   filename: string;

--- a/packages/react/src/insertionFactory.test.ts
+++ b/packages/react/src/insertionFactory.test.ts
@@ -2,7 +2,7 @@ import type { GriffelRenderer } from '@griffel/core';
 
 import { insertionFactory } from './insertionFactory';
 import { useInsertionEffect as _useInsertionEffect } from './useInsertionEffect';
-import * as React from 'react';
+import type * as React from 'react';
 
 jest.mock('./useInsertionEffect', () => ({
   useInsertionEffect: jest.fn().mockImplementation(fn => fn()),

--- a/packages/react/src/renderToStyleElements.test.tsx
+++ b/packages/react/src/renderToStyleElements.test.tsx
@@ -1,4 +1,5 @@
-import { createDOMRenderer, GriffelRenderer } from '@griffel/core';
+import type { GriffelRenderer } from '@griffel/core';
+import { createDOMRenderer } from '@griffel/core';
 import * as prettier from 'prettier';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/packages/react/src/stories/ComponentStyles.stories.tsx
+++ b/packages/react/src/stories/ComponentStyles.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Story } from '@storybook/react';
+import type { Story } from '@storybook/react';
+
 import { makeStyles, mergeClasses, shorthands } from '../';
 
 const tokens = {

--- a/packages/react/src/stories/DOMRendererFilter.stories.tsx
+++ b/packages/react/src/stories/DOMRendererFilter.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Story } from '@storybook/react';
+import type { Story } from '@storybook/react';
 
 import { createDOMRenderer } from '@griffel/core';
 import { makeStyles, RendererProvider, shorthands } from '../';

--- a/packages/react/src/stories/FallbackValues.stories.tsx
+++ b/packages/react/src/stories/FallbackValues.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Story } from '@storybook/react';
+import type { Story } from '@storybook/react';
 
 import { makeStyles, shorthands, TextDirectionProvider } from '../';
 

--- a/packages/shadow-dom/src/createShadowDOMRenderer.ts
+++ b/packages/shadow-dom/src/createShadowDOMRenderer.ts
@@ -2,7 +2,7 @@ import { normalizeCSSBucketEntry, safeInsertRule } from '@griffel/core';
 import type { GriffelRenderer, StyleBucketName } from '@griffel/core';
 
 import { createFallbackRenderer } from './createFallbackRenderer';
-import { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';
+import type { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';
 import { findInsertionPoint } from './findInsertionPoint';
 
 const SUPPORTS_CONSTRUCTABLE_STYLESHEETS: boolean = (() => {

--- a/packages/shadow-dom/src/findInsertionPoint.ts
+++ b/packages/shadow-dom/src/findInsertionPoint.ts
@@ -1,4 +1,6 @@
-import { StyleBucketName, styleBucketOrdering } from '@griffel/core';
+import { styleBucketOrdering } from '@griffel/core';
+import type { StyleBucketName } from '@griffel/core';
+
 import type { ExtendedCSSStyleSheet, GriffelShadowDOMRenderer } from './types';
 
 const styleBucketOrderingMap = styleBucketOrdering.reduce((acc, cur, j) => {

--- a/packages/shadow-dom/src/stories/createShadowDOMRenderer.stories.tsx
+++ b/packages/shadow-dom/src/stories/createShadowDOMRenderer.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import type { default as _root } from 'react-shadow';
 // @ts-expect-error Typings are missing
-import { createProxy as _createProxy, default as _root } from 'react-shadow';
+import { createProxy as _createProxy } from 'react-shadow';
 
 import { makeStyles, RendererProvider, shorthands } from '@griffel/react';
 import { createShadowDOMRenderer } from '../../src';

--- a/packages/style-types/src/legacy/makeResetStyles.ts
+++ b/packages/style-types/src/legacy/makeResetStyles.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 import type { GriffelStylesCSSValue, ValueOrArray } from '../shared';
 
 //

--- a/packages/style-types/src/legacy/makeStaticStyles.ts
+++ b/packages/style-types/src/legacy/makeStaticStyles.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 //
 // Types for makeStaticStyles()

--- a/packages/style-types/src/legacy/makeStyles.ts
+++ b/packages/style-types/src/legacy/makeStyles.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 import type { GriffelStylesCSSValue } from '../shared';
 import type { GriffelStylesUnsupportedCSSProperties } from '../unsupported-properties';

--- a/packages/style-types/src/makeResetStyles.ts
+++ b/packages/style-types/src/makeResetStyles.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 import type { GriffelStylesCSSValue } from './shared';
 
 //

--- a/packages/style-types/src/makeStaticStyles.ts
+++ b/packages/style-types/src/makeStaticStyles.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 //
 // Types for makeStaticStyles()

--- a/packages/style-types/src/makeStyles.ts
+++ b/packages/style-types/src/makeStyles.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 import type { GriffelStylesCSSValue } from './shared';
 import type { GriffelStylesUnsupportedCSSProperties } from './unsupported-properties';

--- a/packages/style-types/src/unsupported-properties.ts
+++ b/packages/style-types/src/unsupported-properties.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 /**
  * Griffel doesn't support expansion of CSS shorthands.

--- a/packages/tag-processor/src/MakeResetStylesProcessor.ts
+++ b/packages/tag-processor/src/MakeResetStylesProcessor.ts
@@ -5,7 +5,7 @@ import type { ValueCache } from '@wyw-in-js/processor-utils';
 import { createRuleLiteral } from './assets/createRuleLiteral';
 import { normalizeStyleRules } from './assets/normalizeStyleRules';
 import BaseGriffelProcessor from './BaseGriffelProcessor';
-import { FileContext } from './types';
+import type { FileContext } from './types';
 
 export default class MakeResetStylesProcessor extends BaseGriffelProcessor {
   #ltrClassName: string | null = null;

--- a/packages/tag-processor/src/MakeStylesProcessor.ts
+++ b/packages/tag-processor/src/MakeStylesProcessor.ts
@@ -1,5 +1,5 @@
-import { GriffelStyle, resolveStyleRulesForSlots } from '@griffel/core';
-import type { CSSClassesMapBySlot, CSSRulesByBucket } from '@griffel/core';
+import { resolveStyleRulesForSlots } from '@griffel/core';
+import type { CSSClassesMapBySlot, CSSRulesByBucket, GriffelStyle } from '@griffel/core';
 import type { ValueCache } from '@wyw-in-js/processor-utils';
 
 import { createRuleLiteral } from './assets/createRuleLiteral';

--- a/packages/tag-processor/src/assets/normalizeStyleRules.ts
+++ b/packages/tag-processor/src/assets/normalizeStyleRules.ts
@@ -1,7 +1,7 @@
 import type { GriffelAnimation, GriffelResetStyle, GriffelStyle } from '@griffel/core';
 import { tokenize } from 'stylis';
 
-import { FileContext } from '../types';
+import type { FileContext } from '../types';
 
 /**
  * Linaria v4 emits absolute paths for assets, we normalize these paths to be relative from the project root to be the

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -6,8 +6,9 @@ import * as prettier from 'prettier';
 import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import { GriffelCSSExtractionPlugin, GriffelCSSExtractionPluginOptions } from './GriffelCSSExtractionPlugin';
-import { WebpackLoaderOptions } from './webpackLoader';
+import type { GriffelCSSExtractionPluginOptions } from './GriffelCSSExtractionPlugin';
+import { GriffelCSSExtractionPlugin } from './GriffelCSSExtractionPlugin';
+import type { WebpackLoaderOptions } from './webpackLoader';
 
 type TestOptions = {
   only?: boolean;

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -1,4 +1,5 @@
-import { defaultCompareMediaQueries, GriffelRenderer } from '@griffel/core';
+import type { GriffelRenderer } from '@griffel/core';
+import { defaultCompareMediaQueries } from '@griffel/core';
 import { Compilation, NormalModule } from 'webpack';
 import type { Chunk, Compiler, Module, sources } from 'webpack';
 

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
@@ -1,4 +1,5 @@
-import { NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
+import { types as t } from '@babel/core';
+import type { NodePath, PluginObj, PluginPass } from '@babel/core';
 import { addNamed } from '@babel/helper-module-imports';
 import { declare } from '@babel/helper-plugin-utils';
 import type { CSSRulesByBucket } from '@griffel/core';

--- a/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
@@ -1,5 +1,5 @@
 import { parseCSSRules } from './parseCSSRules';
-import { CSSRulesByBucket } from '@griffel/core';
+import type { CSSRulesByBucket } from '@griffel/core';
 
 function removeEmptyBuckets(cssRulesByBucket: CSSRulesByBucket) {
   return Object.fromEntries(Object.entries(cssRulesByBucket).filter(([, bucketEntries]) => bucketEntries.length > 0));

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -1,4 +1,4 @@
-import { CSSRulesByBucket, GriffelRenderer } from '@griffel/core';
+import type { CSSRulesByBucket, GriffelRenderer } from '@griffel/core';
 import * as prettier from 'prettier';
 
 import { sortCSSRules } from './sortCSSRules';

--- a/packages/webpack-extraction-plugin/src/transformSync.ts
+++ b/packages/webpack-extraction-plugin/src/transformSync.ts
@@ -1,7 +1,8 @@
 import * as Babel from '@babel/core';
 import type { CSSRulesByBucket } from '@griffel/core';
 
-import { babelPluginStripGriffelRuntime, StripRuntimeBabelPluginMetadata } from './babelPluginStripGriffelRuntime';
+import type { StripRuntimeBabelPluginMetadata } from './babelPluginStripGriffelRuntime';
+import { babelPluginStripGriffelRuntime } from './babelPluginStripGriffelRuntime';
 
 export type TransformOptions = {
   filename: string;

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -1,9 +1,11 @@
 import { normalizeCSSBucketEntry } from '@griffel/core';
 import * as path from 'path';
-import * as webpack from 'webpack';
+import type * as webpack from 'webpack';
 
-import { transformSync, TransformResult, TransformOptions } from './transformSync';
-import { GriffelCssLoaderContextKey, SupplementedLoaderContext } from './constants';
+import type { TransformResult, TransformOptions } from './transformSync';
+import { transformSync } from './transformSync';
+import type { SupplementedLoaderContext } from './constants';
+import { GriffelCssLoaderContextKey } from './constants';
 
 export type WebpackLoaderOptions = {
   /**

--- a/packages/webpack-loader/src/transformSync.ts
+++ b/packages/webpack-loader/src/transformSync.ts
@@ -1,5 +1,6 @@
 import * as Babel from '@babel/core';
-import griffelPreset, { BabelPluginOptions } from '@griffel/babel-preset';
+import type { BabelPluginOptions } from '@griffel/babel-preset';
+import griffelPreset from '@griffel/babel-preset';
 
 export type TransformOptions = {
   filename: string;

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -1,9 +1,11 @@
-import { BabelPluginOptions, EvalCache, Module } from '@griffel/babel-preset';
+import type { BabelPluginOptions } from '@griffel/babel-preset';
+import { EvalCache, Module } from '@griffel/babel-preset';
 import * as enhancedResolve from 'enhanced-resolve';
 import * as path from 'path';
-import * as webpack from 'webpack';
+import type * as webpack from 'webpack';
 
-import { transformSync, TransformResult, TransformOptions } from './transformSync';
+import type { TransformResult, TransformOptions } from './transformSync';
+import { transformSync } from './transformSync';
 import { optionsSchema } from './schema';
 
 export type WebpackLoaderOptions = BabelPluginOptions & {


### PR DESCRIPTION
This PR enables "@typescript-eslint/consistent-type-imports" lint rule and fixes all violations.