### PR TITLE
fix: updates heading ahead of time compilation > with vite

### DIFF
--- a/apps/website/docs/react/ahead-of-time-compilation/with-vite.md
+++ b/apps/website/docs/react/ahead-of-time-compilation/with-vite.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# With Webpack
+# With Vite
 
 ## Install
 


### PR DESCRIPTION
Looks like there was a typo, and instead of _With Vite_ the page's header with _With Webpack_.