### PR TITLE
feat(webpack-extraction-plugin): add "unstable_attachToEntryPoint" option

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-7334bfc7-abbd-4b74-a335-a5ceb1421fa6.json
+++ b/change/@griffel-webpack-extraction-plugin-7334bfc7-abbd-4b74-a335-a5ceb1421fa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add \"unstable_attachToEntryPoint\" option",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.test.ts
@@ -345,7 +345,7 @@ describe('GriffelCSSExtractionPlugin', () => {
   // Unstable
   // --------------------
   testFixture('unstable-attach-to-main', {
-    pluginOptions: { unstable_attachToMainEntryPoint: true },
+    pluginOptions: { unstable_attachToEntryPoint: 'main' },
     webpackConfig: {
       entry: {
         bundleB: path.resolve(__dirname, '..', '__fixtures__', 'webpack', 'unstable-attach-to-main', 'codeB.ts'),


### PR DESCRIPTION
This PR adds `unstable_attachToEntryPoint` config option that replaces `unstable_attachToMainEntryPoint`. To migrate please do:

```diff
new GriffelCSSExtractionPlugin({
- unstable_attachToMainEntryPoint: true,
+ unstable_attachToEntryPoint: 'main',
})
```