### PR TITLE
Improve speed of serializer test function

### DIFF
--- a/change/@griffel-jest-serializer-584b8140-267b-4569-be55-89a684191ee4.json
+++ b/change/@griffel-jest-serializer-584b8140-267b-4569-be55-89a684191ee4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: improve performance of serializer test function",
+  "packageName": "@griffel/jest-serializer",
+  "email": "reubenrakete@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jest-serializer/src/index.test.tsx
+++ b/packages/jest-serializer/src/index.test.tsx
@@ -44,7 +44,7 @@ const TestResetComponent: React.FC<{ id?: string }> = ({ id }) => {
   const classes = useStyles1();
   const baseClassName = useBaseStyles();
 
-  const className = mergeClasses('class-a', classes.paddingLeft, baseClassName, 'class-b');
+  const className = mergeClasses('class-a', baseClassName, classes.paddingLeft, 'class-b');
 
   return <div data-testid={id} className={className} />;
 };
@@ -103,13 +103,19 @@ describe('serializer', () => {
         class="class-a class-b"
       />
     `);
+
+    expect(render(<div className="foo bar" />).container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="foo bar"
+      />
+    `);
   });
 
   it('handles HTML strings', () => {
     expect(render(<TestResetComponent />).container.innerHTML).toMatchInlineSnapshot(
       `"<div class="class-a class-b"></div>"`,
     );
-    expect(render(<TestResetComponent />).container.innerHTML).toMatchInlineSnapshot(
+    expect(render(<TestComponent />).container.innerHTML).toMatchInlineSnapshot(
       `"<div class="class-a class-b"></div>"`,
     );
   });

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -36,6 +36,7 @@ export function print(val: unknown) {
 
       return Array.isArray(classes) ? classes.join('|') : classes;
     });
+
     regexParts.push(name, ...rules);
   }
   /**
@@ -48,7 +49,9 @@ export function print(val: unknown) {
   /**
    * Trim whitespace from className
    */
-  return `"${valStrippedClassNames.replace(/(class|className)="([^"]*)\s+"/, '$1="$2"')}"`;
+  return `"${valStrippedClassNames.replace(/(?:class|className)="(.*)"/, (match, p1) =>
+    match.replace(p1, p1.trim()),
+  )}"`;
 }
 
 export function test(val: unknown) {

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -53,7 +53,7 @@ export function print(val: unknown) {
 
 export function test(val: unknown) {
   if (typeof val === 'string') {
-    return lookupRegex()?.test(val) ?? false;
+    return val.split(' ').some(v => DEBUG_RESET_CLASSES[v] || DEFINITION_LOOKUP_TABLE[v]);
   }
   return false;
 }


### PR DESCRIPTION
The `test` function for the serializer plugin is called many times (from jest docs)
> Pay attention to efficiency in test because pretty-format calls it often.
https://github.com/jestjs/jest/tree/main/packages/pretty-format#test

Using the serializer for many elements causes a large slowdown due to the fact it constructs a large regex every time it's called
![image (9)](https://github.com/microsoft/griffel/assets/2422566/21d94e77-d497-4cdc-8267-8006aedaf4ce)

I believe this can be improved because
1. Both `DEBUG_RESET_CLASSES` and `DEFINITION_LOOKUP_TABLE` are maps so we should be able to lookup a class without doing a string search
1. classes will always be space separated in the string, so we can split the string by spaces to isolate individual classes

This PR changes the `test` function to use a faster implementation
Simple benchmark test - https://jsperf.app/nevedi
![image (6)](https://github.com/microsoft/griffel/assets/2422566/595dad56-0227-4694-b62c-425f4cf7f03d)
