### PR TITLE
fix(postcss-syntax): entrypoint to be correct path

### DIFF
--- a/change/@griffel-postcss-syntax-c809b309-b523-4995-97f3-b6f4c4e27cea.json
+++ b/change/@griffel-postcss-syntax-c809b309-b523-4995-97f3-b6f4c4e27cea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: entrypoint to be correct path",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/postcss-syntax/package.json
+++ b/packages/postcss-syntax/package.json
@@ -13,5 +13,5 @@
     "@babel/helper-plugin-utils": "^7.22.5",
     "postcss": "^8.4.29"
   },
-  "main": "index.js"
+  "main": "./src/index.js"
 }

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -8,8 +8,8 @@ export type PostCSSParserOptions = Pick<postcss.ProcessOptions<postcss.Document 
 export interface ParserOptions extends PostCSSParserOptions, BabelPluginOptions {}
 
 export const parse = (css: string | { toString(): string }, opts?: ParserOptions) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { from: filename = 'postcss-syntax.styles.ts', map, ...griffelPluginOptions } = opts ?? {};
+  const { from: filename = 'postcss-syntax.styles.ts' } = opts ?? {};
+  const griffelPluginOptions = extractGrifellBabelPluginOptions(opts);
   const code = css.toString();
   const { metadata } = transformSync(code, {
     filename,
@@ -121,4 +121,14 @@ export const parse = (css: string | { toString(): string }, opts?: ParserOptions
 
   doc.raws[GRIFFEL_SRC_RAW] = css;
   return doc;
+};
+
+const extractGrifellBabelPluginOptions = (opts: ParserOptions = {}) => {
+  const { babelOptions, evaluationRules, generateMetadata, modules } = opts;
+  return {
+    babelOptions,
+    evaluationRules,
+    generateMetadata,
+    modules,
+  };
 };

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -125,10 +125,22 @@ export const parse = (css: string | { toString(): string }, opts?: ParserOptions
 
 const extractGrifellBabelPluginOptions = (opts: ParserOptions = {}) => {
   const { babelOptions, evaluationRules, generateMetadata, modules } = opts;
-  return {
-    babelOptions,
-    evaluationRules,
-    generateMetadata,
-    modules,
-  };
+  const babelPluginOptions: BabelPluginOptions = {};
+  if (babelOptions) {
+    babelPluginOptions.babelOptions = babelOptions;
+  }
+
+  if (evaluationRules) {
+    babelPluginOptions.evaluationRules = evaluationRules;
+  }
+
+  if (generateMetadata) {
+    babelPluginOptions.generateMetadata = generateMetadata;
+  }
+
+  if (modules) {
+    babelPluginOptions.modules = modules;
+  }
+
+  return babelPluginOptions;
 };


### PR DESCRIPTION
Fixes the postcss syntax so that it has the correct entrypoint path. Also creates an extractor for babel plugin options since postcss can sometimes pass more things into options.