### PR TITLE
fix: build @griffel/eslint-plugin as CJS

### DIFF
--- a/change/@griffel-eslint-plugin-bca332e9-8e32-4b7d-b684-845410f81adb.json
+++ b/change/@griffel-eslint-plugin-bca332e9-8e32-4b7d-b684-845410f81adb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: build @griffel/eslint-plugin as CJS",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node16",
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,

--- a/packages/eslint-plugin/tsconfig.lib.json
+++ b/packages/eslint-plugin/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
+    "module": "node16",
     "types": ["node", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],


### PR DESCRIPTION
Fixes #505.

`@griffel/eslint-plugin` was accidentally built as ESM that caused failures when ESLint tried to load the module.