### PR TITLE
fix: update export in @griffel/eslint-plugin

### DIFF
--- a/change/@griffel-eslint-plugin-6c46ffbc-f2b8-4ee8-8082-1f74398823df.json
+++ b/change/@griffel-eslint-plugin-6c46ffbc-f2b8-4ee8-8082-1f74398823df.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update export in @griffel/eslint-plugin",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -22,4 +22,4 @@ const plugin = {
   rules,
 };
 
-export default plugin;
+export = plugin;


### PR DESCRIPTION
Follow up for #521. Needed to produce `module.exports = plugin`.