### PR TITLE
chore: improve error reporting

### DIFF
--- a/change/@griffel-babel-preset-0b574090-5363-4d0e-bdea-7fb46436796a.json
+++ b/change/@griffel-babel-preset-0b574090-5363-4d0e-bdea-7fb46436796a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: improve error reporting",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/__fixtures__/error-on-undefined/fixture.ts
+++ b/packages/babel-preset/__fixtures__/error-on-undefined/fixture.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@griffel/react';
+// @ts-expect-error This module does not have exported member 'colors'
+import { colors } from './tokens';
+
+export const useClassesA = makeStyles({
+  root: { color: colors.foreground },
+});

--- a/packages/babel-preset/__fixtures__/error-on-undefined/tokens.ts
+++ b/packages/babel-preset/__fixtures__/error-on-undefined/tokens.ts
@@ -1,0 +1,1 @@
+export const tokens = {};

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -254,6 +254,11 @@ pluginTester({
       error: /function accepts only a single param/,
     },
     {
+      title: 'errors: throws on undefined',
+      fixture: path.resolve(fixturesDir, 'error-on-undefined', 'fixture.ts'),
+      error: /Cannot read properties of undefined/,
+    },
+    {
       title: 'errors: throws on invalid config',
       fixture: path.resolve(fixturesDir, 'error-config-babel-options', 'fixture.ts'),
       pluginOptions: {

--- a/packages/babel-preset/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-preset/src/utils/evaluatePathsInVM.ts
@@ -81,6 +81,10 @@ function addPreval(path: NodePath<t.Program>, lazyDeps: Array<t.Expression | t.S
   );
 }
 
+function isError(e: unknown): e is Error {
+  return Object.prototype.toString.call(e) === '[object Error]';
+}
+
 /**
  * Evaluates passed paths in Node environment to resolve all lazy values.
  */
@@ -107,7 +111,12 @@ export function evaluatePathsInVM(
 
   for (let i = 0; i < nodePaths.length; i++) {
     const nodePath = nodePaths[i];
+    const result = results[i];
 
-    nodePath.replaceWith(t.valueToNode(results[i]));
+    if (isError(result)) {
+      throw result;
+    }
+
+    nodePath.replaceWith(t.valueToNode(result));
   }
 }


### PR DESCRIPTION
Related to #513.

Improves error handling: instead of cryptic "don't know how to turn this value into a node" we will throw an original error.