### PR TITLE
fix: use custom fallback type for legacy types

### DIFF
--- a/change/@griffel-style-types-1902f2bf-3bed-4124-992b-7cbfc8bf05ba.json
+++ b/change/@griffel-style-types-1902f2bf-3bed-4124-992b-7cbfc8bf05ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use custom fallback type for legacy types",
+  "packageName": "@griffel/style-types",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/e2e/typescript/src/assets/legacy/fixture.ts
+++ b/e2e/typescript/src/assets/legacy/fixture.ts
@@ -197,11 +197,9 @@ assertType({
     ...typedMixin,
     color: 'var(--customColor)',
   },
-  // @ts-expect-error FIXME - this is supposed to pass!
   ':after': {
     ...typedMixin,
   },
-  // @ts-expect-error FIXME - this is supposed to pass!
   ':before': {
     ...typedMixin,
     color: 'var(--customColor)',

--- a/packages/style-types/src/legacy/makeStyles.ts
+++ b/packages/style-types/src/legacy/makeStyles.ts
@@ -1,6 +1,6 @@
 import type * as CSS from 'csstype';
 
-import type { GriffelStylesCSSValue } from '../shared';
+import type { Fallback, GriffelStylesCSSValue } from '../shared';
 import type { GriffelStylesUnsupportedCSSProperties } from '../unsupported-properties';
 
 //
@@ -9,7 +9,7 @@ import type { GriffelStylesUnsupportedCSSProperties } from '../unsupported-prope
 //
 
 type GriffelStylesCSSProperties = Omit<
-  CSS.PropertiesFallback<GriffelStylesCSSValue>,
+  Fallback<CSS.Properties<GriffelStylesCSSValue>>,
   // We have custom definition for "animationName"
   'animationName'
 > &


### PR DESCRIPTION
The same as #511, but for legacy types.