### PR TITLE
chore: improve CSS generation

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-8c8cbb98-803e-46ce-9061-62ebe75fc727.json
+++ b/change/@griffel-webpack-extraction-plugin-8c8cbb98-803e-46ce-9061-62ebe75fc727.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: improve CSS generation",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/src/generateCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/generateCSSRules.test.ts
@@ -1,0 +1,54 @@
+import type { CSSRulesByBucket } from '@griffel/core';
+import { generateCSSRules } from './generateCSSRules';
+
+describe('generateCSSRules', () => {
+  it('generates CSS rules', () => {
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['.baz { color: orange; }', '.foo { color: red; }'],
+    };
+
+    expect(generateCSSRules(cssRulesByBucket)).toMatchInlineSnapshot(`
+      "/** @griffel:css-start [d] [{}] **/
+      .baz { color: orange; }
+      .foo { color: red; }
+      /** @griffel:css-end **/"
+    `);
+  });
+
+  it('handles empty CSS rules', () => {
+    const cssRulesByBucket: CSSRulesByBucket = {};
+
+    expect(generateCSSRules(cssRulesByBucket)).toMatchInlineSnapshot(`""`);
+  });
+
+  it('handle CSS rules with mixed metadata', () => {
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: [
+        '.foo { color: orange; }',
+        ['.bar { color: red; }', { p: -2 }],
+        ['.baz { color: green; }', { p: -2 }],
+        ['.qux { color: blue; }', { p: -3 }],
+      ],
+      f: ['.foo:focus { color: orange; }', ['.bar:focus { color: red; }', { p: -2 }]],
+    };
+
+    expect(generateCSSRules(cssRulesByBucket)).toMatchInlineSnapshot(`
+      "/** @griffel:css-start [d] [{}] **/
+      .foo { color: orange; }
+      /** @griffel:css-end **/
+      /** @griffel:css-start [d] [{\\"p\\":-2}] **/
+      .bar { color: red; }
+      .baz { color: green; }
+      /** @griffel:css-end **/
+      /** @griffel:css-start [d] [{\\"p\\":-3}] **/
+      .qux { color: blue; }
+      /** @griffel:css-end **/
+      /** @griffel:css-start [f] [{}] **/
+      .foo:focus { color: orange; }
+      /** @griffel:css-end **/
+      /** @griffel:css-start [f] [{\\"p\\":-2}] **/
+      .bar:focus { color: red; }
+      /** @griffel:css-end **/"
+    `);
+  });
+});

--- a/packages/webpack-extraction-plugin/src/generateCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/generateCSSRules.ts
@@ -1,0 +1,38 @@
+import { type CSSRulesByBucket, normalizeCSSBucketEntry } from '@griffel/core';
+
+export function generateCSSRules(cssRulesByBucket: CSSRulesByBucket): string {
+  const entries = Object.entries(cssRulesByBucket);
+
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const cssLines: string[] = [];
+  let lastEntryKey: string = '';
+
+  for (const [cssBucketName, cssBucketEntries] of entries) {
+    for (const bucketEntry of cssBucketEntries) {
+      const [cssRule, metadata] = normalizeCSSBucketEntry(bucketEntry);
+
+      const metadataAsJSON = JSON.stringify(metadata ?? {});
+      const entryKey = `${cssBucketName}-${metadataAsJSON}`;
+
+      if (lastEntryKey !== entryKey) {
+        if (lastEntryKey !== '') {
+          cssLines.push('/** @griffel:css-end **/');
+        }
+
+        cssLines.push(`/** @griffel:css-start [${cssBucketName}] [${metadataAsJSON}] **/`);
+        lastEntryKey = entryKey;
+      }
+
+      cssLines.push(cssRule);
+    }
+  }
+
+  if (cssLines.length > 0) {
+    cssLines.push('/** @griffel:css-end **/');
+  }
+
+  return cssLines.join('\n');
+}


### PR DESCRIPTION
The PR improves CSS generation inside the webpack loader from `@griffel/webpack-extraction-plugin`. That makes output shorter and removes special handling for `media` bucket.

### Before

(comments are generated for every rule)

```css
/** @griffel:css-start [d] [{}] **/
.baz { color: orange; }
/** @griffel:css-end **/
/** @griffel:css-start [d] [{}] **/
.foo { color: red; }
/** @griffel:css-end **/
/** @griffel:css-start [d] [{}] **/
.qux { color: magenta; }
/** @griffel:css-end **/
```

### After

(rules are merged into blocks)

```css
/** @griffel:css-start [d] [{}] **/
.baz { color: orange; }
.foo { color: red; }
.qux { color: magenta; }
/** @griffel:css-end **/
```