### PR TITLE
make `shorthands.flex` work the same as `flex` shorthand in css

### DIFF
--- a/packages/core/src/shorthands/flex.test.ts
+++ b/packages/core/src/shorthands/flex.test.ts
@@ -29,7 +29,7 @@ describe('flex', () => {
     expect(flex(2)).toEqual({
       flexGrow: 2,
       flexShrink: 1,
-      flexBasis: 0,
+      flexBasis: '0%',
     });
   });
 
@@ -69,7 +69,7 @@ describe('flex', () => {
     expect(flex(2, 2)).toEqual({
       flexGrow: 2,
       flexShrink: 2,
-      flexBasis: 0,
+      flexBasis: '0%',
     });
   });
 

--- a/packages/core/src/shorthands/flex.ts
+++ b/packages/core/src/shorthands/flex.ts
@@ -66,7 +66,7 @@ export function flex(...values: FlexInput): FlexStyle {
       return {
         flexGrow: firstValue as number,
         flexShrink: 1,
-        flexBasis: 0,
+        flexBasis: '0%',
       };
     }
 
@@ -86,7 +86,7 @@ export function flex(...values: FlexInput): FlexStyle {
       return {
         flexGrow: firstValue,
         flexShrink: secondValue,
-        flexBasis: 0,
+        flexBasis: '0%',
       };
     }
 


### PR DESCRIPTION
Flex basis should be `0%` instead of `0px`, this is how web browsers work.