### PR TITLE
chore: add support for priority in CSS rules

### DIFF
--- a/change/@griffel-core-6531b53b-a58e-43cc-bb63-61c68cda8172.json
+++ b/change/@griffel-core-6531b53b-a58e-43cc-bb63-61c68cda8172.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add support for priority in CSS rules",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-extraction-plugin-1f7409f0-d60c-4d7b-a773-716a0087becb.json
+++ b/change/@griffel-webpack-extraction-plugin-1f7409f0-d60c-4d7b-a773-716a0087becb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add support for priority in CSS rules",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/common/snapshotSerializers.ts
+++ b/packages/core/src/common/snapshotSerializers.ts
@@ -32,7 +32,7 @@ export const griffelRendererSerializer: jest.SnapshotSerializerPlugin = {
           return acc;
         }
 
-        return [...acc, `/** bucket "${styleEl}" **/`, ...cssRules];
+        return [...acc, `/** bucket "${styleEl.slice(0, 1)}" **/`, ...cssRules];
       }
 
       return acc;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -32,6 +32,9 @@ export const DEFINITION_LOOKUP_TABLE = getGlobalVar<Record<SequenceHash, LookupI
 export const DATA_BUCKET_ATTR = 'data-make-styles-bucket';
 
 /** @internal */
+export const DATA_PRIORITY_ATTR = 'data-priority';
+
+/** @internal */
 export const HASH_PREFIX = 'f';
 
 /** @internal */

--- a/packages/core/src/makeStyles.test.ts
+++ b/packages/core/src/makeStyles.test.ts
@@ -162,7 +162,11 @@ describe('makeStyles', () => {
     // Classes emitted by different renderers can be the same
     expect(classesA).toBe(classesB);
     // Style elements should be different for different renderers
-    expect(rendererA.stylesheets.d).not.toBe(rendererB.stylesheets.d);
+    expect(rendererA.stylesheets['d0']).toBeInstanceOf(Object);
+    expect(rendererB.stylesheets['d0']).toBeInstanceOf(Object);
+
+    expect(Object.keys(rendererA.stylesheets)).toEqual(Object.keys(rendererB.stylesheets));
+    expect(rendererA.stylesheets['d0']).not.toBe(rendererB.stylesheets['d0']);
 
     expect(rendererA).toMatchInlineSnapshot(`
       /** bucket "d" **/

--- a/packages/core/src/renderer/createDOMRenderer.test.ts
+++ b/packages/core/src/renderer/createDOMRenderer.test.ts
@@ -72,11 +72,13 @@ describe('createDOMRenderer', () => {
       HTMLCollection [
         <style
           data-make-styles-bucket="d"
+          data-priority="0"
           foo-bar="baz"
           nonce="random"
         />,
         <style
           data-make-styles-bucket="h"
+          data-priority="0"
           foo-bar="baz"
           nonce="random"
         />,
@@ -113,9 +115,11 @@ describe('createDOMRenderer', () => {
         />,
         <style
           data-make-styles-bucket="d"
+          data-priority="0"
         />,
         <style
           data-make-styles-bucket="h"
+          data-priority="0"
         />,
         <style
           data-test="B"

--- a/packages/core/src/renderer/createIsomorphicStyleElement-node.test.ts
+++ b/packages/core/src/renderer/createIsomorphicStyleElement-node.test.ts
@@ -8,7 +8,7 @@ import { createIsomorphicStyleSheet } from './createIsomorphicStyleSheet';
 
 describe('createIsomorphicStyleElement - node', () => {
   it('should insert css rule', () => {
-    const stylesheet = createIsomorphicStyleSheet(undefined, 'd', {});
+    const stylesheet = createIsomorphicStyleSheet(undefined, 'd', 0, {});
     stylesheet.insertRule(".foo { color: 'red' }");
     expect(stylesheet.cssRules()).toMatchInlineSnapshot(`
       Array [
@@ -18,11 +18,12 @@ describe('createIsomorphicStyleElement - node', () => {
   });
 
   it('should set element attributes', () => {
-    const stylesheet = createIsomorphicStyleSheet(undefined, 'd', { 'data-foo': 'foo' });
+    const stylesheet = createIsomorphicStyleSheet(undefined, 'd', 0, { 'data-foo': 'foo' });
     expect(stylesheet.elementAttributes).toMatchInlineSnapshot(`
       Object {
         "data-foo": "foo",
         "data-make-styles-bucket": "d",
+        "data-priority": "0",
       }
     `);
   });

--- a/packages/core/src/renderer/createIsomorphicStyleSheet.test.ts
+++ b/packages/core/src/renderer/createIsomorphicStyleSheet.test.ts
@@ -2,7 +2,7 @@ import { createIsomorphicStyleSheet } from './createIsomorphicStyleSheet';
 
 describe('createIsomorphicStyleElement', () => {
   it('should insert css rule', () => {
-    const stylesheet = createIsomorphicStyleSheet(document.createElement('style'), 'd', {});
+    const stylesheet = createIsomorphicStyleSheet(document.createElement('style'), 'd', 0, {});
     stylesheet.insertRule(".foo { color: 'red' }");
     expect(stylesheet.cssRules()).toMatchInlineSnapshot(`
       Array [
@@ -12,11 +12,12 @@ describe('createIsomorphicStyleElement', () => {
   });
 
   it('should set element attributes', () => {
-    const stylesheet = createIsomorphicStyleSheet(document.createElement('style'), 'd', { 'data-foo': 'foo' });
+    const stylesheet = createIsomorphicStyleSheet(document.createElement('style'), 'd', 0, { 'data-foo': 'foo' });
     expect(stylesheet.elementAttributes).toMatchInlineSnapshot(`
       Object {
         "data-foo": "foo",
         "data-make-styles-bucket": "d",
+        "data-priority": "0",
       }
     `);
 
@@ -24,6 +25,7 @@ describe('createIsomorphicStyleElement', () => {
       <style
         data-foo="foo"
         data-make-styles-bucket="d"
+        data-priority="0"
       />
     `);
 
@@ -36,11 +38,12 @@ describe('createIsomorphicStyleElement', () => {
   });
 
   it('should create HTML style element', () => {
-    const stylesheet = createIsomorphicStyleSheet(document.createElement('style'), 'd', {});
+    const stylesheet = createIsomorphicStyleSheet(document.createElement('style'), 'd', 0, {});
     expect(stylesheet.element).not.toBeUndefined();
     expect(stylesheet.element).toMatchInlineSnapshot(`
       <style
         data-make-styles-bucket="d"
+        data-priority="0"
       />
     `);
   });

--- a/packages/core/src/renderer/createIsomorphicStyleSheet.ts
+++ b/packages/core/src/renderer/createIsomorphicStyleSheet.ts
@@ -1,15 +1,18 @@
-import { DATA_BUCKET_ATTR } from '../constants';
+import { DATA_BUCKET_ATTR, DATA_PRIORITY_ATTR } from '../constants';
 import type { IsomorphicStyleSheet, StyleBucketName } from '../types';
 
 export function createIsomorphicStyleSheet(
   styleElement: HTMLStyleElement | undefined,
   bucketName: StyleBucketName,
+  priority: number,
   elementAttributes: Record<string, string>,
 ): IsomorphicStyleSheet {
   // no CSSStyleSheet in SSR, just append rules here for server render
   const __cssRulesForSSR: string[] = [];
 
   elementAttributes[DATA_BUCKET_ATTR] = bucketName;
+  elementAttributes[DATA_PRIORITY_ATTR] = String(priority);
+
   if (styleElement) {
     for (const attrName in elementAttributes) {
       styleElement.setAttribute(attrName, elementAttributes[attrName]);
@@ -47,6 +50,7 @@ export function createIsomorphicStyleSheetFromElement(element: HTMLStyleElement)
   const stylesheet = createIsomorphicStyleSheet(
     element,
     elementAttributes[DATA_BUCKET_ATTR] as StyleBucketName,
+    Number(elementAttributes[DATA_PRIORITY_ATTR]),
     elementAttributes,
   );
   return stylesheet;

--- a/packages/core/src/renderer/getStyleSheetForBucket.test.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.test.ts
@@ -23,15 +23,60 @@ describe('getStyleSheetForBucket', () => {
       HTMLCollection [
         <style
           data-make-styles-bucket="r"
+          data-priority="0"
         />,
         <style
           data-make-styles-bucket="d"
+          data-priority="0"
         />,
         <style
           data-make-styles-bucket="l"
+          data-priority="0"
         />,
         <style
           data-make-styles-bucket="a"
+          data-priority="0"
+        />,
+      ]
+    `);
+  });
+
+  it('creates elements order & respects priority', () => {
+    const target = createFakeDocument();
+    const renderer = createDOMRenderer();
+
+    getStyleSheetForBucket('a', target, null, renderer, { p: -1 });
+    getStyleSheetForBucket('a', target, null, renderer);
+    getStyleSheetForBucket('a', target, null, renderer, { p: -2 });
+    getStyleSheetForBucket('d', target, null, renderer);
+    getStyleSheetForBucket('d', target, null, renderer, { p: -1 });
+    getStyleSheetForBucket('d', target, null, renderer, { p: -2 });
+
+    expect(target.head.children).toMatchInlineSnapshot(`
+      HTMLCollection [
+        <style
+          data-make-styles-bucket="d"
+          data-priority="-2"
+        />,
+        <style
+          data-make-styles-bucket="d"
+          data-priority="-1"
+        />,
+        <style
+          data-make-styles-bucket="d"
+          data-priority="0"
+        />,
+        <style
+          data-make-styles-bucket="a"
+          data-priority="-2"
+        />,
+        <style
+          data-make-styles-bucket="a"
+          data-priority="-1"
+        />,
+        <style
+          data-make-styles-bucket="a"
+          data-priority="0"
         />,
       ]
     `);
@@ -78,20 +123,25 @@ describe('getStyleSheetForBucket', () => {
       HTMLCollection [
         <style
           data-make-styles-bucket="d"
+          data-priority="0"
         />,
         <style
           data-make-styles-bucket="t"
+          data-priority="0"
         />,
         <style
           data-make-styles-bucket="m"
+          data-priority="0"
           media="(forced-colors: active)"
         />,
         <style
           data-make-styles-bucket="m"
+          data-priority="0"
           media="screen and (prefers-reduced-motion: reduce)"
         />,
         <style
           data-make-styles-bucket="c"
+          data-priority="0"
         />,
       ]
     `);
@@ -186,9 +236,11 @@ describe('getStyleSheetForBucket', () => {
         />,
         <style
           data-make-styles-bucket="r"
+          data-priority="0"
         />,
         <style
           data-make-styles-bucket="d"
+          data-priority="0"
         />,
         <style
           data-test="C"

--- a/packages/core/src/renderer/rehydrateRendererCache.test.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.test.ts
@@ -1,12 +1,26 @@
-import { DATA_BUCKET_ATTR } from '../constants';
+import { DATA_BUCKET_ATTR, DATA_PRIORITY_ATTR } from '../constants';
+import type { GriffelRenderer } from '../types';
 import { createDOMRenderer } from './createDOMRenderer';
 import { rehydrateRendererCache } from './rehydrateRendererCache';
 
 describe('rehydrateRendererCache', () => {
+  let renderer: GriffelRenderer;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production';
+    renderer = createDOMRenderer(document);
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = '';
+  });
+
   it('should rehydrate renderer cache', () => {
-    const renderer = createDOMRenderer(document);
     const styleElement = document.createElement('style');
+
     styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
     document.head.appendChild(styleElement);
     styleElement.textContent = '.foo { color: red; }';
 
@@ -20,18 +34,19 @@ describe('rehydrateRendererCache', () => {
   });
 
   it('should create isomorphic stylesheet', () => {
-    const renderer = createDOMRenderer(document);
     const styleElement = document.createElement('style');
-    document.head.appendChild(styleElement);
     styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '-1');
 
+    document.head.appendChild(styleElement);
     rehydrateRendererCache(renderer, document);
 
-    expect(renderer.stylesheets.d).not.toBeUndefined();
-    expect(renderer.stylesheets.d?.bucketName).toMatchInlineSnapshot(`"d"`);
-    expect(renderer.stylesheets.d?.elementAttributes).toMatchInlineSnapshot(`
+    expect(Object.keys(renderer.stylesheets)).toEqual(['d-1']);
+    expect(renderer.stylesheets['d-1'].bucketName).toMatchInlineSnapshot(`"d"`);
+    expect(renderer.stylesheets['d-1'].elementAttributes).toMatchInlineSnapshot(`
       Object {
         "data-make-styles-bucket": "d",
+        "data-priority": "-1",
       }
     `);
   });

--- a/packages/core/src/renderer/rehydrateRendererCache.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.ts
@@ -1,6 +1,7 @@
 import type { GriffelRenderer, StyleBucketName } from '../types';
-import { createIsomorphicStyleSheetFromElement } from './createIsomorphicStyleSheet';
 import { isDevToolsEnabled, debugData } from '../devtools';
+import { createIsomorphicStyleSheetFromElement } from './createIsomorphicStyleSheet';
+import { getStyleSheetKeyFromElement } from './getStyleSheetForBucket';
 
 // Regexps to extract names of classes and animations
 // https://github.com/styletron/styletron/blob/e0fcae826744eb00ce679ac613a1b10d44256660/packages/styletron-engine-atomic/src/client/client.js#L8
@@ -29,16 +30,16 @@ export function rehydrateRendererCache(
 
     styleElements.forEach(styleElement => {
       const bucketName = styleElement.dataset['makeStylesBucket'] as StyleBucketName;
-      const regex = regexps[bucketName] || STYLES_HYDRATOR;
-
-      const stylesheetKey = bucketName === 'm' ? bucketName + styleElement.media : bucketName;
+      const stylesheetKey = getStyleSheetKeyFromElement(styleElement);
 
       // 👇 If some elements are not created yet, we will register them in renderer
       if (!renderer.stylesheets[stylesheetKey]) {
         renderer.stylesheets[stylesheetKey] = createIsomorphicStyleSheetFromElement(styleElement);
       }
 
+      const regex = regexps[bucketName] || STYLES_HYDRATOR;
       let match;
+
       while ((match = regex.exec(styleElement.textContent!))) {
         // "cacheKey" is either a class name or an animation name
         const [cssRule] = match;

--- a/packages/react/src/renderToStyleElements-node.test.tsx
+++ b/packages/react/src/renderToStyleElements-node.test.tsx
@@ -52,16 +52,24 @@ describe('renderToStyleElements (node)', () => {
       );
 
       expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
-              <style data-make-styles-bucket="d" data-make-styles-rehydration="true">
-                .fe3e8s9 {
-                  color: red;
-                }</style
-              ><style data-make-styles-bucket="h" data-make-styles-rehydration="true">
-                .f14hep94:hover {
-                  color: pink;
-                }
-              </style>
-          `);
+        <style
+          data-make-styles-bucket="d"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          .fe3e8s9 {
+            color: red;
+          }</style
+        ><style
+          data-make-styles-bucket="h"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          .f14hep94:hover {
+            color: pink;
+          }
+        </style>
+      `);
     });
 
     it('handles @at rules', () => {
@@ -98,24 +106,29 @@ describe('renderToStyleElements (node)', () => {
       );
 
       expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
-              <style data-make-styles-bucket="t" data-make-styles-rehydration="true">
-                @supports (display: grid) {
-                  .f1ofq0jl {
-                    color: red;
-                  }
-                }</style
-              ><style
-                media="screen and (max-width: 992px)"
-                data-make-styles-bucket="m"
-                data-make-styles-rehydration="true"
-              >
-                @media screen and (max-width: 992px) {
-                  .fnao3vb:hover {
-                    color: blue;
-                  }
-                }
-              </style>
-          `);
+        <style
+          data-make-styles-bucket="t"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @supports (display: grid) {
+            .f1ofq0jl {
+              color: red;
+            }
+          }</style
+        ><style
+          media="screen and (max-width: 992px)"
+          data-make-styles-bucket="m"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @media screen and (max-width: 992px) {
+            .fnao3vb:hover {
+              color: blue;
+            }
+          }
+        </style>
+      `);
     });
 
     it('handles media query order', () => {
@@ -159,58 +172,70 @@ describe('renderToStyleElements (node)', () => {
       );
 
       expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
-              <style data-make-styles-bucket="d" data-make-styles-rehydration="true">
-                .fe3e8s9 {
-                  color: red;
-                }</style
-              ><style data-make-styles-bucket="t" data-make-styles-rehydration="true">
-                @supports (display: grid) {
-                  .f1vq01kz {
-                    color: green;
-                  }
-                }</style
-              ><style
-                media="(max-width: 1px)"
-                data-make-styles-bucket="m"
-                data-make-styles-rehydration="true"
-              >
-                @media (max-width: 1px) {
-                  .f1f7njb2:hover {
-                    color: blue;
-                  }
-                }</style
-              ><style
-                media="(max-width: 2px)"
-                data-make-styles-bucket="m"
-                data-make-styles-rehydration="true"
-              >
-                @media (max-width: 2px) {
-                  .f1c6999y:hover {
-                    color: blue;
-                  }
-                }</style
-              ><style
-                media="(max-width: 3px)"
-                data-make-styles-bucket="m"
-                data-make-styles-rehydration="true"
-              >
-                @media (max-width: 3px) {
-                  .f1qdcc3n:hover {
-                    color: blue;
-                  }
-                }</style
-              ><style
-                media="(max-width: 4px)"
-                data-make-styles-bucket="m"
-                data-make-styles-rehydration="true"
-              >
-                @media (max-width: 4px) {
-                  .f1b4up97:hover {
-                    color: blue;
-                  }
-                }
-              </style>
-          `);
+        <style
+          data-make-styles-bucket="d"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          .fe3e8s9 {
+            color: red;
+          }</style
+        ><style
+          data-make-styles-bucket="t"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @supports (display: grid) {
+            .f1vq01kz {
+              color: green;
+            }
+          }</style
+        ><style
+          media="(max-width: 1px)"
+          data-make-styles-bucket="m"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @media (max-width: 1px) {
+            .f1f7njb2:hover {
+              color: blue;
+            }
+          }</style
+        ><style
+          media="(max-width: 2px)"
+          data-make-styles-bucket="m"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @media (max-width: 2px) {
+            .f1c6999y:hover {
+              color: blue;
+            }
+          }</style
+        ><style
+          media="(max-width: 3px)"
+          data-make-styles-bucket="m"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @media (max-width: 3px) {
+            .f1qdcc3n:hover {
+              color: blue;
+            }
+          }</style
+        ><style
+          media="(max-width: 4px)"
+          data-make-styles-bucket="m"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @media (max-width: 4px) {
+            .f1b4up97:hover {
+              color: blue;
+            }
+          }
+        </style>
+      `);
     });
 
     it('handles keyframes', () => {
@@ -241,32 +266,40 @@ describe('renderToStyleElements (node)', () => {
       );
 
       expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
-              <style data-make-styles-bucket="d" data-make-styles-rehydration="true">
-                .f1g6ul6r {
-                  animation-name: f1q8eu9e;
-                }
-                .f1fp4ujf {
-                  animation-name: f55c0se;
-                }</style
-              ><style data-make-styles-bucket="k" data-make-styles-rehydration="true">
-                @keyframes f1q8eu9e {
-                  from {
-                    transform: rotate(0deg);
-                  }
-                  to {
-                    transform: rotate(360deg);
-                  }
-                }
-                @keyframes f55c0se {
-                  from {
-                    transform: rotate(0deg);
-                  }
-                  to {
-                    transform: rotate(-360deg);
-                  }
-                }
-              </style>
-          `);
+        <style
+          data-make-styles-bucket="d"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          .f1g6ul6r {
+            animation-name: f1q8eu9e;
+          }
+          .f1fp4ujf {
+            animation-name: f55c0se;
+          }</style
+        ><style
+          data-make-styles-bucket="k"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
+          @keyframes f1q8eu9e {
+            from {
+              transform: rotate(0deg);
+            }
+            to {
+              transform: rotate(360deg);
+            }
+          }
+          @keyframes f55c0se {
+            from {
+              transform: rotate(0deg);
+            }
+            to {
+              transform: rotate(-360deg);
+            }
+          }
+        </style>
+      `);
     });
   });
 
@@ -288,7 +321,11 @@ describe('renderToStyleElements (node)', () => {
       );
 
       expect(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
-        <style data-make-styles-bucket="r" data-make-styles-rehydration="true">
+        <style
+          data-make-styles-bucket="r"
+          data-priority="0"
+          data-make-styles-rehydration="true"
+        >
           .r1tsu58y {
             color: red;
           }

--- a/packages/react/src/renderToStyleElements.test.tsx
+++ b/packages/react/src/renderToStyleElements.test.tsx
@@ -57,11 +57,19 @@ describe('renderToStyleElements (DOM)', () => {
     });
 
     expect(renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
-      <style data-make-styles-bucket="d" data-make-styles-rehydration="true">
+      <style
+        data-make-styles-bucket="d"
+        data-priority="0"
+        data-make-styles-rehydration="true"
+      >
         .fe3e8s9 {
           color: red;
         }</style
-      ><style data-make-styles-bucket="h" data-make-styles-rehydration="true">
+      ><style
+        data-make-styles-bucket="h"
+        data-priority="0"
+        data-make-styles-rehydration="true"
+      >
         .f1ej289o:hover {
           color: green;
         }
@@ -88,14 +96,18 @@ describe('renderToStyleElements (DOM)', () => {
     });
 
     expect(renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)).toMatchInlineSnapshot(`
-        <style data-make-styles-bucket="r" data-make-styles-rehydration="true">
-          .r1tsu58y {
-            color: red;
-          }
-          .r1tsu58y:hover {
-            color: pink;
-          }
-        </style>
-      `);
+      <style
+        data-make-styles-bucket="r"
+        data-priority="0"
+        data-make-styles-rehydration="true"
+      >
+        .r1tsu58y {
+          color: red;
+        }
+        .r1tsu58y:hover {
+          color: pink;
+        }
+      </style>
+    `);
   });
 });

--- a/packages/webpack-extraction-plugin/src/generateCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/generateCSSRules.test.ts
@@ -8,7 +8,7 @@ describe('generateCSSRules', () => {
     };
 
     expect(generateCSSRules(cssRulesByBucket)).toMatchInlineSnapshot(`
-      "/** @griffel:css-start [d] [{}] **/
+      "/** @griffel:css-start [d] null **/
       .baz { color: orange; }
       .foo { color: red; }
       /** @griffel:css-end **/"
@@ -33,20 +33,20 @@ describe('generateCSSRules', () => {
     };
 
     expect(generateCSSRules(cssRulesByBucket)).toMatchInlineSnapshot(`
-      "/** @griffel:css-start [d] [{}] **/
+      "/** @griffel:css-start [d] null **/
       .foo { color: orange; }
       /** @griffel:css-end **/
-      /** @griffel:css-start [d] [{\\"p\\":-2}] **/
+      /** @griffel:css-start [d] {\\"p\\":-2} **/
       .bar { color: red; }
       .baz { color: green; }
       /** @griffel:css-end **/
-      /** @griffel:css-start [d] [{\\"p\\":-3}] **/
+      /** @griffel:css-start [d] {\\"p\\":-3} **/
       .qux { color: blue; }
       /** @griffel:css-end **/
-      /** @griffel:css-start [f] [{}] **/
+      /** @griffel:css-start [f] null **/
       .foo:focus { color: orange; }
       /** @griffel:css-end **/
-      /** @griffel:css-start [f] [{\\"p\\":-2}] **/
+      /** @griffel:css-start [f] {\\"p\\":-2} **/
       .bar:focus { color: red; }
       /** @griffel:css-end **/"
     `);

--- a/packages/webpack-extraction-plugin/src/generateCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/generateCSSRules.ts
@@ -14,7 +14,7 @@ export function generateCSSRules(cssRulesByBucket: CSSRulesByBucket): string {
     for (const bucketEntry of cssBucketEntries) {
       const [cssRule, metadata] = normalizeCSSBucketEntry(bucketEntry);
 
-      const metadataAsJSON = JSON.stringify(metadata ?? {});
+      const metadataAsJSON = JSON.stringify(metadata ?? null);
       const entryKey = `${cssBucketName}-${metadataAsJSON}`;
 
       if (lastEntryKey !== entryKey) {
@@ -22,7 +22,7 @@ export function generateCSSRules(cssRulesByBucket: CSSRulesByBucket): string {
           cssLines.push('/** @griffel:css-end **/');
         }
 
-        cssLines.push(`/** @griffel:css-start [${cssBucketName}] [${metadataAsJSON}] **/`);
+        cssLines.push(`/** @griffel:css-start [${cssBucketName}] ${metadataAsJSON} **/`);
         lastEntryKey = entryKey;
       }
 

--- a/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
@@ -1,5 +1,7 @@
-import { parseCSSRules } from './parseCSSRules';
 import type { CSSRulesByBucket } from '@griffel/core';
+
+import { generateCSSRules } from './generateCSSRules';
+import { parseCSSRules } from './parseCSSRules';
 
 function removeEmptyBuckets(cssRulesByBucket: CSSRulesByBucket) {
   return Object.fromEntries(Object.entries(cssRulesByBucket).filter(([, bucketEntries]) => bucketEntries.length > 0));
@@ -7,47 +9,39 @@ function removeEmptyBuckets(cssRulesByBucket: CSSRulesByBucket) {
 
 describe('parseCSSRules', () => {
   it('handles regular rules', () => {
-    const css = `
-    /** @griffel:css-start [d] **/
-    .fe3e8s9 { color: red; }
-    /** @griffel:css-end **/
-    /** @griffel:css-start [h] **/
-    .faf35ka:hover { color: red; }
-    /** @griffel:css-end **/
-  `;
-    const { cssRulesByBucket, remainingCSS } = parseCSSRules(css);
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['.fe3e8s9{color:red;}'],
+      h: ['.faf35ka:hover{color:red;}'],
+    };
+    const css = generateCSSRules(cssRulesByBucket);
+    const result = parseCSSRules(css);
 
-    expect(removeEmptyBuckets(cssRulesByBucket)).toMatchInlineSnapshot(`
-      Object {
-        "d": Array [
-          ".fe3e8s9{color:red;}",
-        ],
-        "h": Array [
-          ".faf35ka:hover{color:red;}",
-        ],
-      }
-    `);
-    expect(remainingCSS).toBe('');
+    expect(removeEmptyBuckets(result.cssRulesByBucket)).toEqual(cssRulesByBucket);
+    expect(result.remainingCSS).toBe('');
   });
 
   it('handles rules with meta', () => {
-    const css = `
-    /** @griffel:css-start [d] **/
-    .fe3e8s9 { color: red; }
-    /** @griffel:css-end **/
-    /** @griffel:css-start [m] [{"m":"screen and (max-width: 100px)"}] **/
-    @media screen and (max-width: 100px) { .fr5o61b{ color:red; } }
-    /** @griffel:css-end **/
-    /** @griffel:css-start [m] [{"m":"screen and (max-width: 100px)"}] **/
-    @media screen and (max-width: 100px) { .f1j0ers2 { display: grid; } }
-    /** @griffel:css-end **/
-  `;
-    const { cssRulesByBucket, remainingCSS } = parseCSSRules(css);
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['.fe3e8s9{color:red;}', ['.f65sxns{background:green;}', { p: -2 }]],
+      m: [
+        ['@media screen and (max-width: 100px){.fr5o61b{color:red;}}', { m: 'screen and (max-width: 100px)' }],
+        ['@media screen and (max-width: 100px){.f1j0ers2{display:grid;}}', { m: 'screen and (max-width: 100px)' }],
+        ['@media screen and (max-width: 100px){.fr5o61c{padding:0;}}', { m: 'screen and (max-width: 100px)', p: -1 }],
+      ],
+    };
+    const css = generateCSSRules(cssRulesByBucket);
+    const result = parseCSSRules(css);
 
-    expect(removeEmptyBuckets(cssRulesByBucket)).toMatchInlineSnapshot(`
+    expect(removeEmptyBuckets(result.cssRulesByBucket)).toMatchInlineSnapshot(`
       Object {
         "d": Array [
           ".fe3e8s9{color:red;}",
+          Array [
+            ".f65sxns{background:green;}",
+            Object {
+              "p": -2,
+            },
+          ],
         ],
         "m": Array [
           Array [
@@ -62,30 +56,38 @@ describe('parseCSSRules', () => {
               "m": "screen and (max-width: 100px)",
             },
           ],
+          Array [
+            "@media screen and (max-width: 100px){.fr5o61c{padding:0;}}",
+            Object {
+              "m": "screen and (max-width: 100px)",
+              "p": -1,
+            },
+          ],
         ],
       }
     `);
-    expect(remainingCSS).toBe('');
+    expect(result.remainingCSS).toBe('');
   });
 
   it('keeps third parties CSS', () => {
-    const css = `
-    /** @griffel:css-start [d] **/
-    .fe3e8s9 { color: red; }
-    /** @griffel:css-end **/
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['.fe3e8s9{color:red;}'],
+    };
+    const css = generateCSSRules(cssRulesByBucket);
+    const thirdPartyCSS = `
     .foo { color: red }
     /* some comment */
     .bar { color: green }
   `;
-    const { cssRulesByBucket, remainingCSS } = parseCSSRules(css);
+    const result = parseCSSRules(css + thirdPartyCSS);
 
-    expect(removeEmptyBuckets(cssRulesByBucket)).toMatchInlineSnapshot(`
+    expect(removeEmptyBuckets(result.cssRulesByBucket)).toMatchInlineSnapshot(`
       Object {
         "d": Array [
           ".fe3e8s9{color:red;}",
         ],
       }
     `);
-    expect(remainingCSS).toBe('.foo{color:red;}.bar{color:green;}');
+    expect(result.remainingCSS).toBe('.foo{color:red;}.bar{color:green;}');
   });
 });

--- a/packages/webpack-extraction-plugin/src/parseCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/parseCSSRules.ts
@@ -19,10 +19,7 @@ export function parseCSSRules(css: string) {
     if (element.type === COMMENT) {
       if (element.value.indexOf('/** @griffel:css-start') === 0) {
         cssBucketName = element.value.charAt(24) as StyleBucketName;
-
-        if (cssBucketName === 'm') {
-          cssMeta = JSON.parse(element.value.slice(28, -5));
-        }
+        cssMeta = JSON.parse(element.value.slice(27, -4));
 
         continue;
       }
@@ -37,7 +34,7 @@ export function parseCSSRules(css: string) {
 
     if (cssBucketName) {
       const cssRule = serialize([element], stringify);
-      const bucketEntry: CSSBucketEntry = cssBucketName === 'm' ? [cssRule, cssMeta!] : cssRule;
+      const bucketEntry: CSSBucketEntry = cssMeta ? [cssRule, cssMeta!] : cssRule;
 
       cssRulesByBucket[cssBucketName].push(bucketEntry);
       continue;

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -1,7 +1,7 @@
 import type { CSSRulesByBucket, GriffelRenderer } from '@griffel/core';
 import * as prettier from 'prettier';
 
-import { sortCSSRules } from './sortCSSRules';
+import { getUniqueRulesFromSets, sortCSSRules } from './sortCSSRules';
 
 export const cssSerializer: jest.SnapshotSerializerPlugin = {
   test(value) {
@@ -18,6 +18,36 @@ export const cssSerializer: jest.SnapshotSerializerPlugin = {
 };
 
 expect.addSnapshotSerializer(cssSerializer);
+
+describe('getUniqueRulesFromSets', () => {
+  it('removes duplicate rules', () => {
+    const setA: CSSRulesByBucket = {
+      d: ['.baz { color: orange; }', '.foo { color: red; }'],
+      m: [['@media (max-width: 2px) { .foo { color: blue; } }', { m: '(max-width: 2px)' }]],
+    };
+    const setB: CSSRulesByBucket = {
+      d: ['.baz { color: orange; }'],
+      m: [['@media (max-width: 2px) { .yellow { color: blue; } }', { m: '(max-width: 2px)' }]],
+    };
+
+    expect(getUniqueRulesFromSets([setA, setB])).toEqual([
+      { cssRule: '.baz { color: orange; }', priority: 0, media: '', styleBucketName: 'd' },
+      { cssRule: '.foo { color: red; }', priority: 0, media: '', styleBucketName: 'd' },
+      {
+        cssRule: '@media (max-width: 2px) { .foo { color: blue; } }',
+        priority: 0,
+        media: '(max-width: 2px)',
+        styleBucketName: 'm',
+      },
+      {
+        cssRule: '@media (max-width: 2px) { .yellow { color: blue; } }',
+        priority: 0,
+        media: '(max-width: 2px)',
+        styleBucketName: 'm',
+      },
+    ]);
+  });
+});
 
 describe('sortCSSRules', () => {
   it('removes duplicate rules', () => {
@@ -52,65 +82,172 @@ describe('sortCSSRules', () => {
 
   it('sorts rules by buckets order', () => {
     const setA: CSSRulesByBucket = {
-      d: ['.baz { color: orange; }'],
-      f: ['.foo:focus { color: pink; }'],
+      d: ['.default { color: orange; }'],
+      f: ['.focus:focus { color: pink; }'],
     };
     const setB: CSSRulesByBucket = {
-      d: ['.foo { color: red; }'],
-      h: ['.foo:hover { color: yellow; }'],
+      d: ['.default { color: red; }'],
+      h: ['.hover:hover { color: yellow; }'],
     };
 
     expect(sortCSSRules([setA, setB], () => 0)).toMatchInlineSnapshot(`
-      .baz {
+      .default {
         color: orange;
       }
-      .foo {
+      .default {
         color: red;
       }
-      .foo:focus {
+      .focus:focus {
         color: pink;
       }
-      .foo:hover {
+      .hover:hover {
         color: yellow;
       }
     `);
   });
 
-  it('sorts media queries', () => {
+  it('sorts rules by buckets & priority', () => {
     const setA: CSSRulesByBucket = {
-      m: [
-        ['@media (max-width: 2px) { .foo { color: blue; } }', { m: '(max-width: 2px)' }],
-        ['@media (max-width: 3px) { .foo { color: red; } }', { m: '(max-width: 3px)' }],
-      ],
+      d: ['.prio0 { color: orange; }', ['.prio-1 { margin: 0; }', { p: -1 }]],
+      f: ['.prio0:focus { color: pink; }'],
     };
     const setB: CSSRulesByBucket = {
-      d: ['.foo { color: green; }'],
-      m: [['@media (max-width: 1px) { .foo { color: red; } }', { m: '(max-width: 1px)' }]],
+      d: [
+        ['.prio-3 { border: 3px solid red; }', { p: -3 }],
+        ['.prio-2 { background: green; }', { p: -2 }],
+      ],
+      f: [['.prio-1:focus { padding: 0; }', { p: -2 }]],
     };
 
-    const mediaQueryOrder = ['(max-width: 1px)', '(max-width: 2px)', '(max-width: 3px)', '(max-width: 4px)'];
-    const compareMediaQueries: GriffelRenderer['compareMediaQueries'] = (a: string, b: string) =>
-      mediaQueryOrder.indexOf(a) - mediaQueryOrder.indexOf(b);
-
-    expect(sortCSSRules([setA, setB], compareMediaQueries)).toMatchInlineSnapshot(`
-      .foo {
-        color: green;
+    expect(sortCSSRules([setA, setB], () => 0)).toMatchInlineSnapshot(`
+      .prio-3 {
+        border: 3px solid red;
       }
-      @media (max-width: 1px) {
-        .foo {
-          color: red;
-        }
+      .prio-2 {
+        background: green;
       }
-      @media (max-width: 2px) {
-        .foo {
-          color: blue;
-        }
+      .prio-1:focus {
+        padding: 0;
       }
-      @media (max-width: 3px) {
-        .foo {
-          color: red;
-        }
+      .prio-1 {
+        margin: 0;
+      }
+      .prio0 {
+        color: orange;
+      }
+      .prio0:focus {
+        color: pink;
       }
     `);
+  });
+
+  describe('media queries', () => {
+    it('sorts media queries', () => {
+      const setA: CSSRulesByBucket = {
+        m: [
+          ['@media (max-width: 2px) { .mw2 { color: blue; } }', { m: '(max-width: 2px)' }],
+          ['@media (max-width: 3px) { .mw3 { color: red; } }', { m: '(max-width: 3px)' }],
+        ],
+      };
+      const setB: CSSRulesByBucket = {
+        d: ['.default { color: green; }'],
+        m: [['@media (max-width: 1px) { .mw1 { color: red; } }', { m: '(max-width: 1px)' }]],
+      };
+
+      const mediaQueryOrder = ['(max-width: 1px)', '(max-width: 2px)', '(max-width: 3px)', '(max-width: 4px)'];
+      const compareMediaQueries: GriffelRenderer['compareMediaQueries'] = (a, b) =>
+        mediaQueryOrder.indexOf(a) - mediaQueryOrder.indexOf(b);
+
+      expect(sortCSSRules([setA, setB], compareMediaQueries)).toMatchInlineSnapshot(`
+        .default {
+          color: green;
+        }
+        @media (max-width: 1px) {
+          .mw1 {
+            color: red;
+          }
+        }
+        @media (max-width: 2px) {
+          .mw2 {
+            color: blue;
+          }
+        }
+        @media (max-width: 3px) {
+          .mw3 {
+            color: red;
+          }
+        }
+      `);
+    });
+
+    it('handles priority', () => {
+      const setA: CSSRulesByBucket = {
+        m: [
+          ['@media (max-width: 1px) { .mw1-prio0 { display: flex; } }', { m: '(max-width: 1px)' }],
+          ['@media (max-width: 2px) { .mw2-prio0 { display: grid; } }', { m: '(max-width: 2px)' }],
+          ['@media (max-width: 2px) { .mw2-prio-1 { padding: 0; } }', { m: '(max-width: 2px)', p: -1 }],
+        ],
+      };
+      const setB: CSSRulesByBucket = {
+        m: [
+          ['@media (max-width: 1px) { .mw1-prio-1 { padding: 5px; } }', { m: '(max-width: 1px)', p: -1 }],
+          ['@media (max-width: 3px) { .mw3-prio0 { display: table; } }', { m: '(max-width: 3px)' }],
+          ['@media (max-width: 3px) { .mw3-prio-1 { padding: 5px; } }', { m: '(max-width: 3px)', p: -1 }],
+        ],
+      };
+      const setC: CSSRulesByBucket = {
+        m: [
+          ['@media (max-width: 1px) { .mw1-prio-1 { margin: 5px; } }', { m: '(max-width: 1px)', p: -1 }],
+          ['@media (max-width: 1px) { .mw1-prio-3 { border: 5px; } }', { m: '(max-width: 1px)', p: -3 }],
+        ],
+      };
+
+      const mediaQueryOrder = ['(max-width: 1px)', '(max-width: 2px)', '(max-width: 3px)'];
+      const compareMediaQueries: GriffelRenderer['compareMediaQueries'] = (a, b) =>
+        mediaQueryOrder.indexOf(a) - mediaQueryOrder.indexOf(b);
+
+      expect(sortCSSRules([setA, setB, setC], compareMediaQueries)).toMatchInlineSnapshot(`
+        @media (max-width: 1px) {
+          .mw1-prio-3 {
+            border: 5px;
+          }
+        }
+        @media (max-width: 1px) {
+          .mw1-prio-1 {
+            padding: 5px;
+          }
+        }
+        @media (max-width: 1px) {
+          .mw1-prio-1 {
+            margin: 5px;
+          }
+        }
+        @media (max-width: 1px) {
+          .mw1-prio0 {
+            display: flex;
+          }
+        }
+        @media (max-width: 2px) {
+          .mw2-prio-1 {
+            padding: 0;
+          }
+        }
+        @media (max-width: 2px) {
+          .mw2-prio0 {
+            display: grid;
+          }
+        }
+        @media (max-width: 3px) {
+          .mw3-prio-1 {
+            padding: 5px;
+          }
+        }
+        @media (max-width: 3px) {
+          .mw3-prio0 {
+            display: table;
+          }
+        }
+      `);
+    });
   });
 });

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -1,58 +1,46 @@
-import { styleBucketOrdering } from '@griffel/core';
-import type { GriffelRenderer, CSSBucketEntry, CSSRulesByBucket } from '@griffel/core';
+import { styleBucketOrdering, normalizeCSSBucketEntry } from '@griffel/core';
+import type { GriffelRenderer, StyleBucketName, CSSRulesByBucket } from '@griffel/core';
 
-function getCSSRuleFromBucketEntry(entry: CSSBucketEntry): string {
-  return Array.isArray(entry) ? entry[0] : entry;
-}
+// avoid repeatedly calling `indexOf` to determine order during new insertions
+const styleBucketOrderingMap = styleBucketOrdering.reduce((acc, cur, j) => {
+  acc[cur as StyleBucketName] = j;
+  return acc;
+}, {} as Record<StyleBucketName, number>);
 
-function getCSSMetaFromBucketEntry(entry: CSSBucketEntry): Record<string, unknown> {
-  return Array.isArray(entry) ? entry[1] : {};
+type RuleEntry = { styleBucketName: StyleBucketName; cssRule: string; priority: number; media: string };
+
+export function getUniqueRulesFromSets(setOfCSSRules: CSSRulesByBucket[]): RuleEntry[] {
+  const uniqueCSSRules = new Map<string, RuleEntry>();
+
+  for (const cssRulesByBucket of setOfCSSRules) {
+    for (const _styleBucketName in cssRulesByBucket) {
+      const styleBucketName = _styleBucketName as StyleBucketName;
+
+      for (const bucketEntry of cssRulesByBucket[styleBucketName]!) {
+        const [cssRule, meta] = normalizeCSSBucketEntry(bucketEntry);
+
+        const priority = (meta?.['p'] as number | undefined) ?? 0;
+        const media = (meta?.['m'] as string | undefined) ?? '';
+
+        uniqueCSSRules.set(cssRule, { styleBucketName: styleBucketName as StyleBucketName, cssRule, priority, media });
+      }
+    }
+  }
+
+  return Array.from(uniqueCSSRules.values());
 }
 
 export function sortCSSRules(
   setOfCSSRules: CSSRulesByBucket[],
   compareMediaQueries: GriffelRenderer['compareMediaQueries'],
 ): string {
-  return styleBucketOrdering
-    .map(styleBucketName => {
-      return {
-        styleBucketName,
-        cssBucketEntries:
-          // We deduplicate CSS rules there by using them as keys in an object:
-          // - create an array with pairs [key, value]
-          // - use Object.fromEntries() to create an object that contains unique values
-          Object.values(
-            Object.fromEntries(
-              setOfCSSRules.flatMap(cssRulesByBucket => {
-                if (Array.isArray(cssRulesByBucket[styleBucketName])) {
-                  return cssRulesByBucket[styleBucketName]!.map(bucketEntry => [
-                    getCSSRuleFromBucketEntry(bucketEntry),
-                    bucketEntry,
-                  ]);
-                }
-
-                return [];
-              }),
-            ),
-          ),
-      };
-    })
-    .reduce((acc, { styleBucketName, cssBucketEntries }) => {
-      if (styleBucketName === 'm') {
-        return (
-          acc +
-          cssBucketEntries
-            .sort((entryA, entryB) => {
-              return compareMediaQueries(
-                getCSSMetaFromBucketEntry(entryA)['m'] as string,
-                getCSSMetaFromBucketEntry(entryB)['m'] as string,
-              );
-            })
-            .map(entry => entry[0])
-            .join('')
-        );
-      }
-
-      return acc + cssBucketEntries.join('');
-    }, '');
+  return getUniqueRulesFromSets(setOfCSSRules)
+    .sort(
+      (entryA, entryB) =>
+        styleBucketOrderingMap[entryA.styleBucketName] - styleBucketOrderingMap[entryB.styleBucketName],
+    )
+    .sort((entryA, entryB) => entryA.priority - entryB.priority)
+    .sort((entryA, entryB) => compareMediaQueries(entryA.media, entryB.media))
+    .map(entry => entry.cssRule)
+    .join('');
 }


### PR DESCRIPTION
### What's done?

This PR adds support for additional `priority` property in `meta` of CSS rules, this allows to order CSS rules based on it.

For example:

```ts
const rules = [
  '.bar { color: blue }',
  ['.foo { color: red }', { p: -1 }],
]
```

Will produce following CSS:

```css
.foo { color: red }
.bar { color: blue }
```

These changes are needed to support CSS shorthands.

### Minor notes

- `sortCSSRules()` have been refactored to have clearer implementation
- Snapshots in `sortCSSRules()` have been updated to be clearer