### PR TITLE
chore: pack @griffel/babel-preset in E2E tests

### DIFF
--- a/e2e/nextjs/src/test.ts
+++ b/e2e/nextjs/src/test.ts
@@ -26,6 +26,7 @@ async function performTest() {
       packLocalPackage(rootDir, tempDir, '@griffel/style-types'),
       packLocalPackage(rootDir, tempDir, '@griffel/core'),
       packLocalPackage(rootDir, tempDir, '@griffel/react'),
+      packLocalPackage(rootDir, tempDir, '@griffel/babel-preset'),
       packLocalPackage(rootDir, tempDir, '@griffel/webpack-extraction-plugin'),
       packLocalPackage(rootDir, tempDir, '@griffel/webpack-loader'),
       packLocalPackage(rootDir, tempDir, '@griffel/next-extraction-plugin'),

--- a/e2e/rspack/src/test.ts
+++ b/e2e/rspack/src/test.ts
@@ -26,6 +26,7 @@ async function performTest() {
       packLocalPackage(rootDir, tempDir, '@griffel/style-types'),
       packLocalPackage(rootDir, tempDir, '@griffel/core'),
       packLocalPackage(rootDir, tempDir, '@griffel/react'),
+      packLocalPackage(rootDir, tempDir, '@griffel/babel-preset'),
       packLocalPackage(rootDir, tempDir, '@griffel/webpack-extraction-plugin'),
       packLocalPackage(rootDir, tempDir, '@griffel/webpack-loader'),
     ]);


### PR DESCRIPTION
`@griffel/babel-preset` was not packed and used from NPM in tests instead of a local copy.