### PR TITLE
fix: fix sorting of buckets in sortCSSRules()

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-6ce6c02b-7add-4430-8e51-b247db585301.json
+++ b/change/@griffel-webpack-extraction-plugin-6ce6c02b-7add-4430-8e51-b247db585301.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix sorting of buckets in sortCSSRules()",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -110,8 +110,10 @@ describe('sortCSSRules', () => {
     const setA: CSSRulesByBucket = {
       d: ['.prio0 { color: orange; }', ['.prio-1 { margin: 0; }', { p: -1 }]],
       f: ['.prio0:focus { color: pink; }'],
+      h: [['.prio-1:hover { padding: 0; }', { p: -1 }]],
     };
     const setB: CSSRulesByBucket = {
+      r: ['.reset { margin: 0; padding: 0 }'],
       d: [
         ['.prio-3 { border: 3px solid red; }', { p: -3 }],
         ['.prio-2 { background: green; }', { p: -2 }],
@@ -120,14 +122,15 @@ describe('sortCSSRules', () => {
     };
 
     expect(sortCSSRules([setA, setB], () => 0)).toMatchInlineSnapshot(`
+      .reset {
+        margin: 0;
+        padding: 0;
+      }
       .prio-3 {
         border: 3px solid red;
       }
       .prio-2 {
         background: green;
-      }
-      .prio-1:focus {
-        padding: 0;
       }
       .prio-1 {
         margin: 0;
@@ -135,8 +138,14 @@ describe('sortCSSRules', () => {
       .prio0 {
         color: orange;
       }
+      .prio-1:focus {
+        padding: 0;
+      }
       .prio0:focus {
         color: pink;
+      }
+      .prio-1:hover {
+        padding: 0;
       }
     `);
   });

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -35,11 +35,11 @@ export function sortCSSRules(
   compareMediaQueries: GriffelRenderer['compareMediaQueries'],
 ): string {
   return getUniqueRulesFromSets(setOfCSSRules)
+    .sort((entryA, entryB) => entryA.priority - entryB.priority)
     .sort(
       (entryA, entryB) =>
         styleBucketOrderingMap[entryA.styleBucketName] - styleBucketOrderingMap[entryB.styleBucketName],
     )
-    .sort((entryA, entryB) => entryA.priority - entryB.priority)
     .sort((entryA, entryB) => compareMediaQueries(entryA.media, entryB.media))
     .map(entry => entry.cssRule)
     .join('');


### PR DESCRIPTION
Followup for #539.

Priority of CSS rules had higher priority in sort than buckets order. This PR fixes it.