### PR TITLE
chore: refactor at rules to be a separate param in functions

### DIFF
--- a/change/@griffel-core-6be177be-0e28-4c2b-b669-fbf43322e4aa.json
+++ b/change/@griffel-core-6be177be-0e28-4c2b-b669-fbf43322e4aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: refactor at rules to be a separate param in functions",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/compileAtomicCSSRule.test.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.test.ts
@@ -1,17 +1,17 @@
 import { compileAtomicCSSRule, normalizePseudoSelector } from './compileAtomicCSSRule';
 import type { CompileAtomicCSSOptions } from './compileAtomicCSSRule';
+import type { AtRules } from './utils/types';
 
-const defaultOptions: Pick<
-  CompileAtomicCSSOptions,
-  'rtlClassName' | 'className' | 'media' | 'selectors' | 'support' | 'layer' | 'container'
-> = {
+const defaultOptions: Pick<CompileAtomicCSSOptions, 'rtlClassName' | 'className' | 'selectors'> = {
   className: 'foo',
   rtlClassName: 'rtl-foo',
-  media: '',
   selectors: [],
-  support: '',
-  layer: '',
+};
+const defaultAtRules: AtRules = {
   container: '',
+  layer: '',
+  media: '',
+  supports: '',
 };
 
 describe('compileAtomicCSSRule', () => {
@@ -54,34 +54,43 @@ describe('compileAtomicCSSRule', () => {
     ['scroll-margin', '0'],
   ])('does not prefix %s:%s', (property, value) => {
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        property,
-        value,
-      }),
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          property,
+          value,
+        },
+        defaultAtRules,
+      ),
     ).toMatchSnapshot();
   });
 
   it('handles pseudo', () => {
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        selectors: [':hover'],
-        property: 'color',
-        value: 'red',
-      }),
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          selectors: [':hover'],
+          property: 'color',
+          value: 'red',
+        },
+        defaultAtRules,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         ".foo:hover{color:red;}",
       ]
     `);
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        selectors: [':focus:hover'],
-        property: 'color',
-        value: 'red',
-      }),
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          selectors: [':focus:hover'],
+          property: 'color',
+          value: 'red',
+        },
+        defaultAtRules,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         ".foo:focus:hover{color:red;}",
@@ -91,11 +100,14 @@ describe('compileAtomicCSSRule', () => {
 
   it('handles array of values', () => {
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        property: 'color',
-        value: ['red', 'blue'],
-      }),
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          property: 'color',
+          value: ['red', 'blue'],
+        },
+        defaultAtRules,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         ".foo{color:red;color:blue;}",
@@ -105,24 +117,28 @@ describe('compileAtomicCSSRule', () => {
 
   it('handles at-rules', () => {
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        media: '(max-width: 100px)',
-        property: 'color',
-        value: 'red',
-      }),
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          property: 'color',
+          value: 'red',
+        },
+        { ...defaultAtRules, media: '(max-width: 100px)' },
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         "@media (max-width: 100px){.foo{color:red;}}",
       ]
     `);
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        support: '(display: table-cell)',
-        property: 'color',
-        value: 'red',
-      }),
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          property: 'color',
+          value: 'red',
+        },
+        { ...defaultAtRules, supports: '(display: table-cell)' },
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         "@supports (display: table-cell){.foo{color:red;}}",
@@ -132,15 +148,18 @@ describe('compileAtomicCSSRule', () => {
 
   it('handles rtl properties', () => {
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
 
-        property: 'paddingLeft',
-        value: '10px',
+          property: 'paddingLeft',
+          value: '10px',
 
-        rtlProperty: 'paddingRight',
-        rtlValue: '10px',
-      }),
+          rtlProperty: 'paddingRight',
+          rtlValue: '10px',
+        },
+        defaultAtRules,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         ".foo{padding-left:10px;}",
@@ -151,16 +170,19 @@ describe('compileAtomicCSSRule', () => {
 
   it('handles rtl properties with pseudo selectors', () => {
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        selectors: [':before'],
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          selectors: [':before'],
 
-        property: 'paddingLeft',
-        value: '10px',
+          property: 'paddingLeft',
+          value: '10px',
 
-        rtlProperty: 'paddingRight',
-        rtlValue: '10px',
-      }),
+          rtlProperty: 'paddingRight',
+          rtlValue: '10px',
+        },
+        defaultAtRules,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         ".foo:before{padding-left:10px;}",
@@ -171,13 +193,16 @@ describe('compileAtomicCSSRule', () => {
 
   it('handles rtl properties with fallback values', () => {
     expect(
-      compileAtomicCSSRule({
-        ...defaultOptions,
-        property: 'paddingLeft',
-        value: [0, '10px'],
-        rtlProperty: 'paddingRight',
-        rtlValue: [0, '10px'],
-      }),
+      compileAtomicCSSRule(
+        {
+          ...defaultOptions,
+          property: 'paddingLeft',
+          value: [0, '10px'],
+          rtlProperty: 'paddingRight',
+          rtlValue: [0, '10px'],
+        },
+        defaultAtRules,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         ".foo{padding-left:0;padding-left:10px;}",
@@ -189,24 +214,30 @@ describe('compileAtomicCSSRule', () => {
   describe('global', () => {
     it('compiles global rules', () => {
       expect(
-        compileAtomicCSSRule({
-          ...defaultOptions,
-          selectors: [':global(body)'],
-          property: 'color',
-          value: 'red',
-        }),
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            selectors: [':global(body)'],
+            property: 'color',
+            value: 'red',
+          },
+          defaultAtRules,
+        ),
       ).toMatchInlineSnapshot(`
               Array [
                 "body .foo{color:red;}",
               ]
           `);
       expect(
-        compileAtomicCSSRule({
-          ...defaultOptions,
-          selectors: [':global(.fui-FluentProvider)', '& .focus:hover'],
-          property: 'color',
-          value: 'red',
-        }),
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            selectors: [':global(.fui-FluentProvider)', '& .focus:hover'],
+            property: 'color',
+            value: 'red',
+          },
+          defaultAtRules,
+        ),
       ).toMatchInlineSnapshot(`
               Array [
                 ".fui-FluentProvider .foo .focus:hover{color:red;}",
@@ -216,15 +247,18 @@ describe('compileAtomicCSSRule', () => {
 
     it('compiles global rules with RTL', () => {
       expect(
-        compileAtomicCSSRule({
-          ...defaultOptions,
-          selectors: [':global(body)'],
-          property: 'paddingLeft',
-          value: '10px',
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            selectors: [':global(body)'],
+            property: 'paddingLeft',
+            value: '10px',
 
-          rtlProperty: 'paddingRight',
-          rtlValue: '10px',
-        }),
+            rtlProperty: 'paddingRight',
+            rtlValue: '10px',
+          },
+          defaultAtRules,
+        ),
       ).toMatchInlineSnapshot(`
               Array [
                 "body .foo{padding-left:10px;}",

--- a/packages/core/src/runtime/compileAtomicCSSRule.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.ts
@@ -1,15 +1,11 @@
 import { hyphenateProperty } from './utils/hyphenateProperty';
 import { normalizeNestedProperty } from './utils/normalizeNestedProperty';
+import type { AtRules } from './utils/types';
 import { compileCSSRules } from './compileCSSRules';
 
 export interface CompileAtomicCSSOptions {
   className: string;
-
   selectors: string[];
-  media: string;
-  layer: string;
-  support: string;
-  container: string;
 
   property: string;
   value: number | string | Array<number | string>;
@@ -55,20 +51,10 @@ function createCSSRule(classNameSelector: string, cssDeclaration: string, pseudo
 
 export function compileAtomicCSSRule(
   options: CompileAtomicCSSOptions,
+  atRules: AtRules,
 ): [string? /* ltr definition */, string? /* rtl definition */] {
-  const {
-    className,
-    media,
-    layer,
-    selectors,
-    support,
-    property,
-    rtlClassName,
-    rtlProperty,
-    rtlValue,
-    value,
-    container,
-  } = options;
+  const { className, selectors, property, rtlClassName, rtlProperty, rtlValue, value } = options;
+  const { container, layer, media, supports } = atRules;
 
   const classNameSelector = `.${className}`;
   const cssDeclaration = Array.isArray(value)
@@ -94,8 +80,8 @@ export function compileAtomicCSSRule(
     cssRule = `@layer ${layer} { ${cssRule} }`;
   }
 
-  if (support) {
-    cssRule = `@supports ${support} { ${cssRule} }`;
+  if (supports) {
+    cssRule = `@supports ${supports} { ${cssRule} }`;
   }
 
   if (container) {

--- a/packages/core/src/runtime/getStyleBucketName.test.ts
+++ b/packages/core/src/runtime/getStyleBucketName.test.ts
@@ -2,23 +2,29 @@ import { getStyleBucketName } from './getStyleBucketName';
 
 describe('getStyleBucketName', () => {
   it('returns bucketName based on mapping', () => {
-    expect(getStyleBucketName([], '', '', '', '')).toBe('d');
-    expect(getStyleBucketName(['.foo'], '', '', '', '')).toBe('d');
+    expect(getStyleBucketName([], { container: '', media: '', supports: '', layer: '' })).toBe('d');
+    expect(getStyleBucketName(['.foo'], { container: '', media: '', supports: '', layer: '' })).toBe('d');
 
-    expect(getStyleBucketName([' :link'], '', '', '', '')).toBe('l');
-    expect(getStyleBucketName([' :hover '], '', '', '', '')).toBe('h');
+    expect(getStyleBucketName([' :link'], { container: '', media: '', supports: '', layer: '' })).toBe('l');
+    expect(getStyleBucketName([' :hover '], { container: '', media: '', supports: '', layer: '' })).toBe('h');
 
-    expect(getStyleBucketName([':link'], '', '', '', '')).toBe('l');
-    expect(getStyleBucketName([':visited'], '', '', '', '')).toBe('v');
-    expect(getStyleBucketName([':focus-within'], '', '', '', '')).toBe('w');
-    expect(getStyleBucketName([':focus'], '', '', '', '')).toBe('f');
-    expect(getStyleBucketName([':focus-visible'], '', '', '', '')).toBe('i');
-    expect(getStyleBucketName([':hover'], '', '', '', '')).toBe('h');
-    expect(getStyleBucketName([':active'], '', '', '', '')).toBe('a');
+    expect(getStyleBucketName([':link'], { container: '', media: '', supports: '', layer: '' })).toBe('l');
+    expect(getStyleBucketName([':visited'], { container: '', media: '', supports: '', layer: '' })).toBe('v');
+    expect(getStyleBucketName([':focus-within'], { container: '', media: '', supports: '', layer: '' })).toBe('w');
+    expect(getStyleBucketName([':focus'], { container: '', media: '', supports: '', layer: '' })).toBe('f');
+    expect(getStyleBucketName([':focus-visible'], { container: '', media: '', supports: '', layer: '' })).toBe('i');
+    expect(getStyleBucketName([':hover'], { container: '', media: '', supports: '', layer: '' })).toBe('h');
+    expect(getStyleBucketName([':active'], { container: '', media: '', supports: '', layer: '' })).toBe('a');
 
-    expect(getStyleBucketName([':active'], 'theme', '', '', '')).toBe('t');
-    expect(getStyleBucketName([':active'], '', '(max-width: 100px)', '', '')).toBe('m');
-    expect(getStyleBucketName([':active'], '', '', '(display: table-cell)', '')).toBe('t');
-    expect(getStyleBucketName([':active'], '', '', '', 'foo (max-width: 1px)')).toBe('c');
+    expect(getStyleBucketName([':active'], { container: '', media: '', supports: '', layer: 'theme' })).toBe('t');
+    expect(
+      getStyleBucketName([':active'], { container: '', media: '(max-width: 100px)', supports: '', layer: '' }),
+    ).toBe('m');
+    expect(
+      getStyleBucketName([':active'], { container: '', media: '', supports: '(display: table-cell)', layer: '' }),
+    ).toBe('t');
+    expect(
+      getStyleBucketName([':active'], { container: 'foo (max-width: 1px)', media: '', supports: '', layer: '' }),
+    ).toBe('c');
   });
 });

--- a/packages/core/src/runtime/getStyleBucketName.ts
+++ b/packages/core/src/runtime/getStyleBucketName.ts
@@ -1,4 +1,5 @@
 import type { StyleBucketName } from '../types';
+import type { AtRules } from './utils/types';
 
 /**
  * Maps the long pseudo name to the short pseudo name. Pseudos that match here will be ordered, everything else will
@@ -42,23 +43,17 @@ const pseudosMap: Record<string, StyleBucketName | undefined> = {
  *
  * @internal
  */
-export function getStyleBucketName(
-  selectors: string[],
-  layer: string,
-  media: string,
-  support: string,
-  container: string,
-): StyleBucketName {
-  if (media) {
+export function getStyleBucketName(selectors: string[], atRules: AtRules): StyleBucketName {
+  if (atRules.media) {
     return 'm';
   }
 
-  // We are grouping all the at-rules like @supports etc under `t` bucket.
-  if (layer || support) {
+  // We are grouping all the at-rules like @supports etc. under `t` bucket.
+  if (atRules.layer || atRules.supports) {
     return 't';
   }
 
-  if (container) {
+  if (atRules.container) {
     return 'c';
   }
 

--- a/packages/core/src/runtime/utils/hashClassName.ts
+++ b/packages/core/src/runtime/utils/hashClassName.ts
@@ -1,35 +1,26 @@
 import hashString from '@emotion/hash';
+
 import { HASH_PREFIX } from '../../constants';
+import type { AtRules } from './types';
 
 interface HashedClassNameParts {
   property: string;
   value: string;
   selector: string;
-  media: string;
-  layer: string;
-  support: string;
-  container: string;
 }
 
-export function hashClassName({
-  container,
-  media,
-  layer,
-  property,
-  selector,
-  support,
-  value,
-}: HashedClassNameParts): string {
-  const classNameHash = hashString(
-    selector +
-      container +
-      media +
-      layer +
-      support +
-      property +
-      // Trimming of value is required to generate consistent hashes
-      value.trim(),
+export function hashClassName({ property, selector, value }: HashedClassNameParts, atRules: AtRules): string {
+  return (
+    HASH_PREFIX +
+    hashString(
+      selector +
+        atRules.container +
+        atRules.media +
+        atRules.layer +
+        atRules.supports +
+        property +
+        // Trimming of value is required to generate consistent hashes
+        value.trim(),
+    )
   );
-
-  return HASH_PREFIX + classNameHash;
 }

--- a/packages/core/src/runtime/utils/hashPropertyKey.test.ts
+++ b/packages/core/src/runtime/utils/hashPropertyKey.test.ts
@@ -2,10 +2,12 @@ import { hashPropertyKey } from './hashPropertyKey';
 
 describe('hashPropertyKey', () => {
   it('generates hashes that always start with letters', () => {
-    expect(hashPropertyKey('', '', '', '', 'color')).toBe('sj55zd');
-    expect(hashPropertyKey('', '', '', '', 'display')).toBe('mc9l5x');
+    const atRules = { container: '', media: '', supports: '', layer: '' };
 
-    expect(hashPropertyKey('', '', '', '', 'backgroundColor')).toBe('De3pzq');
-    expect(hashPropertyKey(':hover', '', '', '', 'color')).toBe('Bi91k9c');
+    expect(hashPropertyKey('', 'color', atRules)).toBe('sj55zd');
+    expect(hashPropertyKey('', 'display', atRules)).toBe('mc9l5x');
+
+    expect(hashPropertyKey('', 'backgroundColor', atRules)).toBe('De3pzq');
+    expect(hashPropertyKey(':hover', 'color', atRules)).toBe('Bi91k9c');
   });
 });

--- a/packages/core/src/runtime/utils/hashPropertyKey.ts
+++ b/packages/core/src/runtime/utils/hashPropertyKey.ts
@@ -1,15 +1,11 @@
 import hash from '@emotion/hash';
-import type { PropertyHash } from '../../types';
 
-export function hashPropertyKey(
-  selector: string,
-  container: string,
-  media: string,
-  support: string,
-  property: string,
-): PropertyHash {
+import type { PropertyHash } from '../../types';
+import type { AtRules } from './types';
+
+export function hashPropertyKey(selector: string, property: string, atRules: AtRules): PropertyHash {
   // uniq key based on property & selector, used for merging later
-  const computedKey = selector + container + media + support + property;
+  const computedKey = selector + atRules.container + atRules.media + atRules.supports + property;
 
   // "key" can be really long as it includes selectors, we use hashes to reduce sizes of keys
   // ".foo :hover" => "abcd"

--- a/packages/core/src/runtime/utils/types.ts
+++ b/packages/core/src/runtime/utils/types.ts
@@ -1,0 +1,6 @@
+export type AtRules = {
+  container: string;
+  media: string;
+  layer: string;
+  supports: string;
+};


### PR DESCRIPTION
Performs internals refactor to reduce number of arguments in `resolveStyleRules()`.