### PR TITLE
fix: remove eslint exception in `RendererProvider`

### DIFF
--- a/change/@griffel-react-b38d1a6d-6d8d-471e-8e44-e3722096edd2.json
+++ b/change/@griffel-react-b38d1a6d-6d8d-471e-8e44-e3722096edd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: make RendererProvider compatible with React Compiler",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/RendererContext.tsx
+++ b/packages/react/src/RendererContext.tsx
@@ -28,18 +28,13 @@ const RendererContext = React.createContext<GriffelRenderer>(createDOMRenderer()
  * @public
  */
 export const RendererProvider: React.FC<RendererProviderProps> = ({ children, renderer, targetDocument }) => {
-  'use no memo';
-
-  if (canUseDOM()) {
-    // This if statement technically breaks the rules of hooks, but is safe because the condition never changes after
-    // mounting.
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useMemo(() => {
+  React.useMemo(() => {
+    if (canUseDOM()) {
       // "rehydrateCache()" can't be called in effects as it needs to be called before any component will be rendered to
       // avoid double insertion of classes
       rehydrateRendererCache(renderer, targetDocument);
-    }, [renderer, targetDocument]);
-  }
+    }
+  }, [renderer, targetDocument]);
 
   return <RendererContext.Provider value={renderer}>{children}</RendererContext.Provider>;
 };


### PR DESCRIPTION
Changes the code to strictly follow the [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks).

Previously the code conditionally called a hook which prevents React Compiler from making any potential optimizations. Now the conditional has been moved inside the hook.

However, this code is still potentially problematic as we are relying on [`useMemo()` for correctness rather than as a performance optimization](https://react.dev/reference/react/useMemo):

![msedge_dtpiVAZAuS](https://github.com/microsoft/griffel/assets/93940821/a8c0280b-be01-49dc-b4dc-c2c53dea801d)

Depends on #565
