### PR TITLE
chore: remove development warnings from production code

### DIFF
--- a/change/@griffel-core-f62e4d27-94b5-466e-b76a-b36e48520a8f.json
+++ b/change/@griffel-core-f62e4d27-94b5-466e-b76a-b36e48520a8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove development warnings from production code",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/runtime/warnings/warnAboutUnresolvedRule.ts
+++ b/packages/core/src/runtime/warnings/warnAboutUnresolvedRule.ts
@@ -2,33 +2,38 @@ import type { GriffelResetStyle, GriffelStyle } from '@griffel/style-types';
 import { logError } from './logError';
 
 export function warnAboutUnresolvedRule(property: string, value: GriffelStyle | GriffelResetStyle) {
-  const ruleText = JSON.stringify(value, null, 2);
-  const message: string[] = [
-    '@griffel/react: A rule was not resolved to CSS properly. ' +
-      'Please check your `makeStyles` or `makeResetStyles` calls for following:',
-    ' '.repeat(2) + 'makeStyles({',
-    ' '.repeat(4) + `[slot]: {`,
-    ' '.repeat(6) +
-      `"${property}": ${ruleText
-        .split('\n')
-        .map((l, n) => ' '.repeat(n === 0 ? 0 : 6) + l)
-        .join('\n')}`,
-    ' '.repeat(4) + '}',
-    ' '.repeat(2) + `})`,
-    '',
-  ];
+  const message: string = /*#__PURE__*/ (() => {
+    const ruleText = JSON.stringify(value, null, 2);
 
-  if (property.indexOf('&') === -1) {
-    message.push(
-      `It looks that you're are using a nested selector, but it is missing an ampersand placeholder where the generated class name should be injected.`,
-    );
-    message.push(`Try to update a property to include it i.e "${property}" => "&${property}".`);
-  } else {
-    message.push('');
-    message.push(
-      "If it's not obvious what triggers a problem, please report an issue at https://github.com/microsoft/griffel/issues",
-    );
-  }
+    const message = [
+      '@griffel/react: A rule was not resolved to CSS properly. ' +
+        'Please check your `makeStyles` or `makeResetStyles` calls for following:',
+      ' '.repeat(2) + 'makeStyles({',
+      ' '.repeat(4) + `[slot]: {`,
+      ' '.repeat(6) +
+        `"${property}": ${ruleText
+          .split('\n')
+          .map((l, n) => ' '.repeat(n === 0 ? 0 : 6) + l)
+          .join('\n')}`,
+      ' '.repeat(4) + '}',
+      ' '.repeat(2) + `})`,
+      '',
+    ];
 
-  logError(message.join('\n'));
+    if (property.indexOf('&') === -1) {
+      message.push(
+        `It looks that you're are using a nested selector, but it is missing an ampersand placeholder where the generated class name should be injected.`,
+      );
+      message.push(`Try to update a property to include it i.e "${property}" => "&${property}".`);
+    } else {
+      message.push('');
+      message.push(
+        "If it's not obvious what triggers a problem, please report an issue at https://github.com/microsoft/griffel/issues",
+      );
+    }
+
+    return message.join('\n');
+  })();
+
+  logError(message);
 }

--- a/packages/core/src/runtime/warnings/warnAboutUnsupportedProperties.ts
+++ b/packages/core/src/runtime/warnings/warnAboutUnsupportedProperties.ts
@@ -2,7 +2,7 @@ import type { GriffelStyle } from '@griffel/style-types';
 import { logError } from './logError';
 
 export function warnAboutUnsupportedProperties(property: string, value: GriffelStyle[keyof GriffelStyle]) {
-  logError(
+  const message = /*#__PURE__*/ (() =>
     [
       `@griffel/react: You are using unsupported shorthand CSS property "${property}". ` +
         `Please check your "makeStyles" calls, there *should not* be following:`,
@@ -11,6 +11,7 @@ export function warnAboutUnsupportedProperties(property: string, value: GriffelS
       ' '.repeat(2) + `})`,
       '',
       'Learn why CSS shorthands are not supported: https://aka.ms/griffel-css-shorthands',
-    ].join('\n'),
-  );
+    ].join('\n'))();
+
+  logError(message);
 }


### PR DESCRIPTION
Warnings were leaking to production code:

![image](https://github.com/microsoft/griffel/assets/14183168/19a3c4fe-4902-4243-b4e5-f33b2f59eb1e)

Fixes #581.