### PR TITLE
feat: Support stylelint rule disabling for style slots

### DIFF
--- a/change/@griffel-postcss-syntax-8e694cac-d57f-4ce3-9862-ae1bf76fc16a.json
+++ b/change/@griffel-postcss-syntax-8e694cac-d57f-4ce3-9862-ae1bf76fc16a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Support stylelint rule disabling for style slots\u0017\u0017",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/postcss-syntax/src/location-preset.ts
+++ b/packages/postcss-syntax/src/location-preset.ts
@@ -2,13 +2,30 @@ import type { PluginObj, PluginPass, types as t, ConfigAPI } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
 import type { BabelPluginOptions } from '@griffel/babel-preset';
 
+export type CommentDirective = [/** directive */ string, /** value */ string];
+export type CommentDirectivesBySlot = Record</** slot */ string, CommentDirective[]>;
+export type CommentDirectivesByHookDeclarator = Record</** hook declarator */ string, CommentDirectivesBySlot>;
+
+export type LocationsBySlot = Record</** slot */ string, t.SourceLocation>;
+export type LocationsByHookDeclarator = Record</** hook declarator */ string, LocationsBySlot>;
+
+export type ResetCommentDirectivesByHookDeclarator = Record</** hook declarator */ string, CommentDirective[]>;
+
+export type ResetLocationsByHookDeclarator = Record</** hook declarator */ string, t.SourceLocation>;
+
 export interface LocationPluginState extends PluginPass {
-  locations?: Record<string, Record<string, t.SourceLocation>>;
-  resetLocations?: Record<string, t.SourceLocation>;
+  locations?: LocationsByHookDeclarator;
+  commentDirectives?: CommentDirectivesByHookDeclarator;
+
+  resetCommentDirectives?: ResetCommentDirectivesByHookDeclarator;
+  resetLocations?: ResetLocationsByHookDeclarator;
 }
 
 export interface LocationPluginMetadata {
   locations: Record<string, Record<string, t.SourceLocation>>;
+  commentDirectives: CommentDirectivesByHookDeclarator;
+
+  resetCommentDirectives: ResetCommentDirectivesByHookDeclarator;
   resetLocations: Record<string, t.SourceLocation>;
 }
 
@@ -42,6 +59,8 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
     pre() {
       this.locations = {};
       this.resetLocations = {};
+      this.commentDirectives = {};
+      this.resetCommentDirectives = {};
     },
 
     visitor: {
@@ -50,6 +69,8 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
           Object.assign(this.file.metadata, {
             locations: this.locations,
             resetLocations: this.resetLocations,
+            commentDirectives: this.commentDirectives,
+            resetCommentDirectives: this.resetCommentDirectives,
           } as LocationPluginMetadata);
         },
       },
@@ -98,6 +119,13 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
             state.locations[declaratorId][key.node.name] = {
               ...property.node.loc,
             };
+
+            const commentDirectives = parseCommentDirectives(property.node.leadingComments);
+            if (commentDirectives) {
+              state.commentDirectives ??= {};
+              state.commentDirectives[declaratorId] ??= {};
+              state.commentDirectives[declaratorId][key.node.name] = commentDirectives;
+            }
           });
         }
 
@@ -113,11 +141,45 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
           }
 
           state.resetLocations[declaratorId] = resetStyles.node.loc;
+
+          // For reset styles we only care about the comment directives on the variable declaration
+          // The leading commment can either be attached to a variable declaration of an export declaration (i.e. export const useResetStyles = ...)
+          const parentDeclaration =
+            path.findParent(p => p.isExportNamedDeclaration()) ?? path.findParent(p => p.isVariableDeclaration());
+          if (parentDeclaration) {
+            const commentDirectives = parseCommentDirectives(parentDeclaration.node.leadingComments);
+            if (commentDirectives) {
+              state.resetCommentDirectives ??= {};
+              state.resetCommentDirectives[declaratorId] = commentDirectives;
+            }
+          }
         }
       },
     },
   };
 });
+
+function parseCommentDirectives(leadingComments: t.Comment[] | null | undefined): CommentDirective[] | null {
+  if (!leadingComments) {
+    return null;
+  }
+
+  const entries = leadingComments
+    // We don't support comment blocks
+    .filter(comment => comment.type === 'CommentLine')
+    .map(comment => {
+      const commentValue = comment.value.trim();
+      if (!commentValue.startsWith('griffel-')) {
+        return;
+      }
+
+      const tokens = commentValue.split(' ');
+      return [tokens[0], tokens[1]];
+    })
+    .filter(Boolean) as [string, string][];
+
+  return entries;
+}
 
 export default (babel: ConfigAPI, options: LocationPluginOptions) => {
   return {

--- a/packages/postcss-syntax/src/parse.test.ts
+++ b/packages/postcss-syntax/src/parse.test.ts
@@ -173,6 +173,31 @@ export const useStyles2 = makeStyles({
         }
       });
     });
+
+    it('should transform disable comment directive to stylelint disable', () => {
+      const fixture = `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    color: 'red',
+    backgroundColor: 'green',
+  },
+
+  // griffel-csslint-disable foo
+  // griffel-csslint-disable bar
+  slot: {
+      color: 'blue',
+      backgroundColor: 'red',
+  }
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      expect(root.toString()).toMatchInlineSnapshot(`
+        ".fe3e8s9{color:red;}.fcnqdeg{background-color:green;}
+        .f163i14w{color:blue;}.f3xbvq9{background-color:red;} /* stylelint-disable-line foo,bar */"
+      `);
+    });
   });
 
   describe('makeResetStyles', () => {
@@ -287,6 +312,23 @@ export const useResetStyles2 = makeResetStyles({
           });
         }
       });
+    });
+
+    it('should transform disable comment directive to stylelint disable', () => {
+      const fixture = `
+import { makeResetStyles } from '@griffel/react';
+
+// griffel-csslint-disable foo
+// griffel-csslint-disable bar
+export const useResetStyles = makeResetStyles({
+  color: 'pink',
+  backgroundColor: 'magenta',
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts' });
+      expect(root.toString()).toMatchInlineSnapshot(
+        `".r70kha3{color:pink;background-color:magenta;} /* stylelint-disable-line foo,bar */"`,
+      );
     });
   });
 });

--- a/packages/postcss-syntax/src/transform-sync.test.ts
+++ b/packages/postcss-syntax/src/transform-sync.test.ts
@@ -62,4 +62,94 @@ describe('transformSync', () => {
       }
     `);
   });
+
+  it('should parse TS and return comment directives prefixed with griffel-', () => {
+    const sourceCode = `
+    import type { GriffelStyle } from '@griffel/react'
+    import { makeStyles, makeResetStyles } from '@griffel/react';
+
+    export const useStyles = makeStyles({
+      // griffel-csslint-disable foo
+      // griffel-csslint-disable bar
+      root: {
+        color: 'red',
+        backgroundColor: 'green',
+      },
+
+      // griffel-csslint-disable foo
+      foo: {
+        color: 'blue'
+      }
+    })
+
+    // griffel-csslint-disable foo
+    export const useResetStyles = makeResetStyles({
+      color: 'red',
+    })
+
+    // griffel-csslint-disable foo
+    // griffel-csslint-disable bar
+    const useResetStylesExportedLater = makeResetStyles({
+      color: 'red',
+    })
+
+    export { useResetStylesExportedLater };
+    `;
+
+    const options: TransformOptions = {
+      filename: 'test.styles.ts',
+      pluginOptions: {
+        babelOptions: {
+          presets: ['@babel/preset-typescript'],
+        },
+        generateMetadata: true,
+      },
+    };
+
+    const result = transformSync(sourceCode, options);
+
+    expect(result.metadata.commentDirectives).toMatchInlineSnapshot(`
+      Object {
+        "useStyles": Object {
+          "foo": Array [
+            Array [
+              "griffel-csslint-disable",
+              "foo",
+            ],
+          ],
+          "root": Array [
+            Array [
+              "griffel-csslint-disable",
+              "foo",
+            ],
+            Array [
+              "griffel-csslint-disable",
+              "bar",
+            ],
+          ],
+        },
+      }
+    `);
+
+    expect(result.metadata.resetCommentDirectives).toMatchInlineSnapshot(`
+      Object {
+        "useResetStyles": Array [
+          Array [
+            "griffel-csslint-disable",
+            "foo",
+          ],
+        ],
+        "useResetStylesExportedLater": Array [
+          Array [
+            "griffel-csslint-disable",
+            "foo",
+          ],
+          Array [
+            "griffel-csslint-disable",
+            "bar",
+          ],
+        ],
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Adds comment directive parsing in the location preset so that that comments starting with `griffel-` are collected with styles metadata.

```ts
const useStyles = makeStyles({
 // griffel-csslint-disable color-no-hex   
 slot: {
    color: '#fff'
  },
});

// griffel-csslint-disable color-no-hex
const useResetStyles = makeResetStyles({
  color: '#fff'
})
```

Updates the parser to transform `griffel-csslint-disable` to `styleint-disable` comments in output CSS for attached style slots. The above example outputs to

```css
.fxxx { color: red } /* stylelint-disable-line color-no-hex */
.rxxx {  color: red } /* stylelint-disable-line color-no-hex */
```