### PR TITLE
docs(eslint-plugin): add missing rule to README

### DIFF
--- a/change/@griffel-eslint-plugin-af581fe2-88f5-44cb-bb57-3d71b2cfcf03.json
+++ b/change/@griffel-eslint-plugin-af581fe2-88f5-44cb-bb57-3d71b2cfcf03.json
@@ -1,6 +1,6 @@
 {
-  "comment": "Fix eslint-plugin README",
-  "type": "patch",
+  "comment": "docs: update README",
+  "type": "none",
   "packageName": "@griffel/eslint-plugin",
   "email": "tigeroakes@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@griffel-eslint-plugin-af581fe2-88f5-44cb-bb57-3d71b2cfcf03.json
+++ b/change/@griffel-eslint-plugin-af581fe2-88f5-44cb-bb57-3d71b2cfcf03.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Fix eslint-plugin README",
+  "type": "patch",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "tigeroakes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -42,9 +42,10 @@ You can find more info about enabled rules in the [Supported Rules section](#sup
 
 **Key**: 🔧 = fixable
 
-| Name                                                                     | Description                                                                                                     | 🔧  |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | --- |
-| [`@griffel/hook-naming`](./src/rules/hook-naming.md)                     | Ensure that hooks returned by the `makeStyles()` function start with "use"                                      | ❌  |
-| [`@griffel/no-shorthands`](./src/rules/no-shorthands.md)                 | Enforce usage of CSS longhands                                                                                  | ✅  |
-| [`@griffel/styles-file`](./src/rules/styles-file.md)                     | Ensures that all `makeStyles()` and `makeResetStyles()` calls are placed in a `.styles.js` or `.styles.ts` file | ❌  |
-| [`@griffel/pseudo-element-naming`](./src/rules/pseudo-element-naming.md) | Ensures that all Pseudo Elements start with two colons                                                          | ✅  |
+| Name                                                                                       | Description                                                                                                     | 🔧  |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | --- |
+| [`@griffel/hook-naming`](./src/rules/hook-naming.md)                                       | Ensure that hooks returned by the `makeStyles()` function start with "use"                                      | ❌  |
+| [`@griffel/no-invalid-shorthand-arguments`](./src/rules/no-invalid-shorthand-arguments.md) | All shorthands must not use space separators, and instead pass in multiple arguments                            | ✅  |
+| [`@griffel/no-shorthands`](./src/rules/no-shorthands.md)                                   | Enforce usage of CSS longhands                                                                                  | ✅  |
+| [`@griffel/styles-file`](./src/rules/styles-file.md)                                       | Ensures that all `makeStyles()` and `makeResetStyles()` calls are placed in a `.styles.js` or `.styles.ts` file | ❌  |
+| [`@griffel/pseudo-element-naming`](./src/rules/pseudo-element-naming.md)                   | Ensures that all Pseudo Elements start with two colons                                                          | ✅  |


### PR DESCRIPTION
no-invalid-shorthand-argument is already implemented but was missing from the README.

Fixes #589