### PR TITLE
fix(extension): include `index.html` in publish

### DIFF
--- a/change/@griffel-devtools-f10a728e-3ede-491b-b048-924af4a9ec5e.json
+++ b/change/@griffel-devtools-f10a728e-3ede-491b-b048-924af4a9ec5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: include `index.html` in publish",
+  "packageName": "@griffel/devtools",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/devtools/project.json
+++ b/packages/devtools/project.json
@@ -44,6 +44,7 @@
           "sourceMap": false,
           "namedChunks": false,
           "extractLicenses": true,
+          "runtimeChunk": false,
           "vendorChunk": false
         },
         "development": {}

--- a/packages/devtools/webpack.config.js
+++ b/packages/devtools/webpack.config.js
@@ -1,7 +1,7 @@
-const { composePlugins, withNx } = require('@nx/webpack');
+const { composePlugins, withNx, withWeb } = require('@nx/webpack');
 
 // Nx plugins for webpack.
-module.exports = composePlugins(withNx(), config => {
+module.exports = composePlugins(withNx(), withWeb(), config => {
   // Note: This was added by an Nx migration. Webpack builds are required to have a corresponding Webpack config file.
   // See: https://nx.dev/recipes/webpack/webpack-config-setup
   return config;


### PR DESCRIPTION
_If Nx upgrade broke nothing, you simply don't know what it broke._

Updates configs to include `index.html` into artifacts & excludes runtime chunk.