### PR TITLE
fix: Persist filename in postcss syntax

### DIFF
--- a/change/@griffel-postcss-syntax-1b3c650d-9bdd-461c-8b2c-45a33787c1eb.json
+++ b/change/@griffel-postcss-syntax-1b3c650d-9bdd-461c-8b2c-45a33787c1eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Persist filename in postcss syntax",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/postcss-syntax/src/parse.test.ts
+++ b/packages/postcss-syntax/src/parse.test.ts
@@ -37,6 +37,8 @@ export const useStyles = makeStyles({
           end: { line: 13, column: 3, index: 208 },
         });
       });
+
+      expect(root.source?.input.file?.endsWith('fixture.styles.ts')).toBe(true);
     });
 
     it('should handle different module source', () => {

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -72,7 +72,7 @@ export const parse = (css: string | { toString(): string }, opts?: ParserOptions
     cssRules.push(cssRule);
   });
 
-  const root = postcss.parse(cssRules.join('\n'));
+  const root = postcss.parse(cssRules.join('\n'), { from: filename });
   root.walk(node => {
     if (!node.source || node.source.start === undefined) {
       return;


### PR DESCRIPTION
Persists the correct filename during postcss parsing so that any resulting error messages will have the correct filename path instead of an autogenerated `<input cdfsdf/>` -like hash