### PR TITLE
feat: postcss-syntax should silence parse errors on demand

### DIFF
--- a/packages/postcss-syntax/src/parse.test.ts
+++ b/packages/postcss-syntax/src/parse.test.ts
@@ -273,6 +273,35 @@ export const useStyles = makeStyles({
         .f163i14w{color:blue;}.f3xbvq9{background-color:red;} /* stylelint-disable-line foo,bar */"
       `);
     });
+
+    it('should not throw on failure to parse JS code when `silenceOnParseErrors` is set', () => {
+      const fixture = `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  slot: {
+      // simulate user WIP code
+      color: 'bl,
+  }
+})
+`;
+      const root = parse(fixture, { from: 'fixture.styles.ts', silenceParseErrors: true });
+      expect(root.toString()).toMatchInlineSnapshot(`"/* Failed to parse griffel styles: fixture.styles.ts */"`);
+    });
+
+    it('should throw on failure to parse JS code', () => {
+      const fixture = `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  slot: {
+      // simulate user WIP code
+      color: 'bl,
+  }
+})
+`;
+      expect(() => parse(fixture, { from: 'fixture.styles.ts' })).toThrow('Unterminated string constant');
+    });
   });
 
   describe('makeResetStyles', () => {


### PR DESCRIPTION
Since the postcss-syntax is primarily used for linting with Stylelint, there are two areas where it can be used

1. CI pipeline check
2. IDE integration

For 1. we want to always throw but for 2. where users can be in the process of editing their code, it's not always parseable so we want to be able to silence here.