### PR TITLE
fix(postcss-syntax): Silenced parse result should be stringifiable

### DIFF
--- a/change/@griffel-postcss-syntax-d160ba10-518b-4f99-8afa-1b6647679cfb.json
+++ b/change/@griffel-postcss-syntax-d160ba10-518b-4f99-8afa-1b6647679cfb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(postcss-syntax): Silenced parse result should be stringifiable",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/postcss-syntax/src/parse.test.ts
+++ b/packages/postcss-syntax/src/parse.test.ts
@@ -1,4 +1,4 @@
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import {
   GRIFFEL_DECLARATOR_LOCATION_RAW,
   GRIFFEL_DECLARATOR_RAW,

--- a/packages/postcss-syntax/src/parse.test.ts
+++ b/packages/postcss-syntax/src/parse.test.ts
@@ -1,3 +1,4 @@
+import postcss from 'postcss';
 import {
   GRIFFEL_DECLARATOR_LOCATION_RAW,
   GRIFFEL_DECLARATOR_RAW,
@@ -6,6 +7,7 @@ import {
   GRIFFEL_SRC_RAW,
 } from './constants';
 import { parse } from './parse';
+import { stringify } from './stringify';
 
 describe('parse', () => {
   describe('makeStyles', () => {
@@ -287,6 +289,7 @@ export const useStyles = makeStyles({
 `;
       const root = parse(fixture, { from: 'fixture.styles.ts', silenceParseErrors: true });
       expect(root.toString()).toMatchInlineSnapshot(`"/* Failed to parse griffel styles: fixture.styles.ts */"`);
+      expect(() => stringify(root, {} as postcss.Builder)).not.toThrow();
     });
 
     it('should throw on failure to parse JS code', () => {

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -35,7 +35,9 @@ export const parse = (css: string | { toString(): string }, opts?: ParserOptions
 
   const parseResult = parseGriffelStyles(code, filename, griffelPluginOptions, silenceParseErrors);
   if (!parseResult) {
-    return postcss.parse(`/* Failed to parse griffel styles: ${filename} */`, { from: filename });
+    const root = postcss.parse(`/* Failed to parse griffel styles: ${filename} */`, { from: filename });
+    root.raws[GRIFFEL_SRC_RAW] = code;
+    return root;
   }
 
   const {


### PR DESCRIPTION
If a result is silenced it should still be usable by the syntax `stringify`. This PR adds the `GRIFFEL_SRC_RAW` property to the root make that possible.