### PR TITLE
fix: fix infinite loop caused by hydration errors in React 18

### DIFF
--- a/change/@griffel-core-f40a63ca-515a-4e89-af69-997821bf5130.json
+++ b/change/@griffel-core-f40a63ca-515a-4e89-af69-997821bf5130.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix infinite loop caused by hydration errors in React 18",
+  "packageName": "@griffel/core",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/renderer/getStyleSheetForBucket.ts
+++ b/packages/core/src/renderer/getStyleSheetForBucket.ts
@@ -81,7 +81,7 @@ export function getStyleSheetForBucket(
 
     renderer.stylesheets[stylesheetKey] = stylesheet;
 
-    if (targetDocument && tag) {
+    if (targetDocument?.head && tag) {
       targetDocument.head.insertBefore(
         tag,
         findInsertionPoint(targetDocument, insertionPoint, bucketName, renderer, metadata),


### PR DESCRIPTION
## Previous Behavior

Some frameworks like Remix/ReactRouter v7 perform full-document hydration on the client side. When the hydration fails, React attempts to recover by re-rendering the entire tree multiple times on the client side. During this process, FluentUI and Griffel enter an infinite loop because the `window.document` might not be fully ready; it exists but lacks head/body elements.

### Steps to reproduce:

- Clone the https://github.com/dmytrokirpa/fluentui-remix/blob/main
- Remove the `patches` directory
- Run `yarn install && yarn dev`
- Open the app in a browser with any extension that patches the DOM (e.g., DarkReader)

### Demo:

https://github.com/user-attachments/assets/6a8d3a06-7dc9-4cb0-b0ba-809af6aee340

## New Behavior

The style tag is added to the head only if `document.head` is actually available.

**Note:** There will be a similar patch to FluentUI https://github.com/microsoft/fluentui/pull/34194 to ensure it works properly.