### PR TITLE
Use capital H in GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   </a>
   <img alt="MIT License" src="https://img.shields.io/github/license/microsoft/griffel"/>
   <a href="https://github.com/microsoft/griffel/discussions">
-    <img alt="Github discussions" src="https://img.shields.io/github/discussions/microsoft/griffel" />
+    <img alt="GitHub discussions" src="https://img.shields.io/github/discussions/microsoft/griffel" />
   </a>
 </p>
 

--- a/apps/website/docusaurus.config.js
+++ b/apps/website/docusaurus.config.js
@@ -101,7 +101,7 @@ const config = {
             href: 'https://github.com/microsoft/griffel',
             position: 'right',
             className: 'navbar-github-link',
-            html: 'Github <span aria-hidden="true" />',
+            html: 'GitHub <span aria-hidden="true" />',
           },
         ],
       },

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ pr: none
 trigger: none
 
 variables:
-  - group: 'GitHub and NPM secrets'
+  - group: 'Github and NPM secrets'
   - name: tags
     value: production,externalfacing
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ pr: none
 trigger: none
 
 variables:
-  - group: 'Github and NPM secrets'
+  - group: 'GitHub and NPM secrets'
   - name: tags
     value: production,externalfacing
 


### PR DESCRIPTION
GitHub is spelled with a capital H. This fixes user-facing usage of `Github` by changing it to `GitHub`.
