### PR TITLE
docs: add a note about using fontFamily in makeStaticStyles

### DIFF
--- a/apps/website/docs/react/api/make-static-styles.md
+++ b/apps/website/docs/react/api/make-static-styles.md
@@ -45,6 +45,27 @@ body {
 }
 ```
 
+:::note
+
+Be sure the correctly quote font family names with things like parentheses in them:
+
+```js
+// ✅ Correctly returns `font-family` in styles
+const useStaticStyles = makeStaticStyles({
+  '@font-face': {
+    fontFamily: '"Segoe UI Web (West European)"',
+    // ...
+  },
+});
+// 🔴 Will not return a `font-family` in styles
+const useStaticStyles = makeStaticStyles({
+  '@font-face': {
+    fontFamily: 'Segoe UI Web (West European)',
+    // ...
+  },
+});
+```
+
 :::caution Limited support for nested selectors
 
 Nested selectors are not supported for this scenario via nesting of JavaScript objects.


### PR DESCRIPTION
Clarifies that `fontFamily` may need to be quoted in certain cases. This is an easy thing to get wrong so I thought it best we document it.

[Correct usage](https://griffel.js.org/try-it-out/?code=JYWwDg9gTgLgBAbziAhgawKYGUYpsAYxwE8AbDAZzgF84AzKCEOAcgAEBzKYOujUgPQFoGFgG4AUBIwAPSLDgATDHRQBXUvFSYceQiXIUAFAglxWbOhAB2MALSqCogFyIz5%2BjZgAxFCGCkxK4sAERYGBwQGHAAqgCScADqGABGcEbJFDAYUNZwAKJqjGAYKNYAlCEsADTu5hRQBK4ABqQQBCikRmERUbFxIeXVcG0dXT2RGPGDtR4eReMAFjAwYBTOAkIAdBR2-gSMFBB0MFvCIAJZegQCVrYUl70YdmrAAgDulPYYRRAlZQJrNBUIJSHgvlt3sc6AAmQZ1OaeKCoGDdKG8OFDBHmBbdZardabAg7PaEQ7HU7nS64fA3O4wB4UJ4vN6fLJ2H7FUrWQHAzoCMHZLKQ6HwxEeKzIvBo0VY8W4kL4tYbba7fbkk5nJjU663LyM5mvD5fDm-f48oFS0Hg4UrOhi8VIlHdGBQNQYGDEEqDZqzCVeZLADjLVwAFgADOG4AIAFRwS0guAxgR%2B6i1ajlSRAA)

[Incorrect usage](https://griffel.js.org/try-it-out/?code=JYWwDg9gTgLgBAbziAhgawKYGUYpsAYxwE8AbDAZzgF84AzKCEOAcgAEBzKYOujUgPQFoGFgG4AUBIwAPSLDgATDHRQBXUvFSYceQiXIUAFAglxWbOhAB2MALSqCogFyIz5%2BjZgAxFCGCkxK4sWBgcEBhwAKoAknAA6hgARnBGiRQwGFDWcACiaoxgGCjWAJQsADTu5hRQBK4ABqQQBCikRgBEoeGRsR2lFXDNre1dYRF9A9UeBaMAFjAwYBTOAkIAdBR2-gSMFBB0MOvCIAIZegQCVrYUZ%2BMYdmrAAgDulPYYBRBFJQLW0KhBKQ8O91i8DnQAEz9aYeTxQVAwTrg3jQqZw8yzToLJYrNYETbbQh7A5HE5nXD4S7XGC3Cj3R7PN4ZOyfQrFax-AFtATAzIZMEQmEYjxWBF4ZFC9EYrEdHHLVYbLY7EmHY5MCkXK5eOkMp6vd6sr4-Tn-cVAkECxZ0YUi%2BGIzowKBqDAwYhFfoNKpwmmJYAcBauAAsAAYQ3ABAAqOBmwFwSMCb00KrUUqSIA)