### PR TITLE
Improve error message for hash salt mismatch; and allow for a filter

### DIFF
--- a/packages/webpack-extraction-plugin/src/schema.ts
+++ b/packages/webpack-extraction-plugin/src/schema.ts
@@ -8,6 +8,9 @@ export const configSchema: JSONSchema7 = {
     classNameHashSalt: {
       type: 'string',
     },
+    classNameHashFilter: {
+      type: 'object',
+    },
     unstable_keepOriginalCode: {
       type: 'boolean',
     },

--- a/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.test.ts
@@ -12,25 +12,61 @@ export const useStyles = makeStyles({
 /*@griffel:classNameHashSalt "salt"*/
 `;
 
+const FILE_PATH = 'c:\\repo\\node_modules\\some-package\\file.js';
+
 describe('webpackLoader', () => {
   it('should validate hash salt correctly', () => {
-    expect(() => validateHashSalt(SOURCE_CODE, 'salt')).not.toThrow();
+    expect(() => validateHashSalt(FILE_PATH, SOURCE_CODE, 'salt', undefined /* classNameHashFilter */)).not.toThrow();
   });
 
   it('should throw an error for invalid hash salt', () => {
-    expect(() => validateHashSalt(SOURCE_CODE, 'invalid-salt')).toThrowErrorMatchingInlineSnapshot(
-      `"GriffelCSSExtractionPlugin: classNameHashSalt is set to \\"invalid-salt\\", but the salt location comment contains \\"salt\\". Please ensure that all files use the same salt."`,
+    expect(() =>
+      validateHashSalt(FILE_PATH, SOURCE_CODE, 'invalid-salt', undefined /* classNameHashFilter */),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"GriffelCSSExtractionPlugin: classNameHashSalt is set to \\"invalid-salt\\", but the salt location comment in \\"c:/repo/node_modules/some-package/file.js\\" contains \\"salt\\". Please ensure that all files use the same salt."`,
     );
-    expect(() => validateHashSalt(SOURCE_CODE, 'sal')).toThrowErrorMatchingInlineSnapshot(
-      `"GriffelCSSExtractionPlugin: classNameHashSalt is set to \\"sal\\", but the salt location comment contains \\"salt\\". Please ensure that all files use the same salt."`,
+    expect(() =>
+      validateHashSalt(FILE_PATH, SOURCE_CODE, 'sal', undefined /* classNameHashFilter */),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"GriffelCSSExtractionPlugin: classNameHashSalt is set to \\"sal\\", but the salt location comment in \\"c:/repo/node_modules/some-package/file.js\\" contains \\"salt\\". Please ensure that all files use the same salt."`,
     );
   });
 
   it('should throw if "sourceCode" does not contain a comment', () => {
     expect(() =>
-      validateHashSalt('import { makeStyles } from "@griffel/react";', 'salt'),
+      validateHashSalt(
+        FILE_PATH,
+        'import { makeStyles } from "@griffel/react";',
+        'salt',
+        undefined /* classNameHashFilter */,
+      ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"GriffelCSSExtractionPlugin: classNameHashSalt is set to \\"salt\\", but no salt location comment was found in the source code."`,
+      `"GriffelCSSExtractionPlugin: classNameHashSalt is set to \\"salt\\", but no salt location comment was found in the source code of \\"c:/repo/node_modules/some-package/file.js\\"."`,
     );
+  });
+
+  it('should throw if "sourceCode" does not contain a comment, AND the classNameHashFilter returns true for everything', () => {
+    expect(() =>
+      validateHashSalt(
+        FILE_PATH,
+        'import { makeStyles } from "@griffel/react";',
+        'salt',
+        path => true /* classNameHashFilter */,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"GriffelCSSExtractionPlugin: classNameHashSalt is set to \\"salt\\", but no salt location comment was found in the source code of \\"c:/repo/node_modules/some-package/file.js\\"."`,
+    );
+  });
+
+  it('should NOT throw when an otherwise-throwing case (e.g., "sourceCode" does not contain a comment) is being filtered out by the classNameHashFilter', () => {
+    expect(() =>
+      validateHashSalt(FILE_PATH, 'import { makeStyles } from "@griffel/react";', 'salt', path => {
+        if (path.endsWith('/file.js')) {
+          // Skip validation for this file
+          return false;
+        }
+        return true;
+      }),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
PR #684 added `classNameHashSalt` validation; and PR #687 further expanded upon this.

However, in using this feature in our project, two things were missing for me:
1. The validation would throw an error like `classNameHashSalt is set to "<something>", but no salt location comment was found in the source code`, without specifying which specific file triggered the error. This PR fixes it.

2. For a codebase that is only gradually on-ramping to using `classNameHashSalt`, it can be useful to incrementally convert the codebase, without having the build process immediately fail in an all-or-nothing style of validation. This PR thus adds an optional `classNameHashFilter` parameter to the loader options, which can be used as follows in the webpack config:

```js
{
    loader: GriffelCSSExtractionPlugin.loader,
    options: {
        classNameHashSalt,
        classNameHashFilter: (filePath) => {
            if (filePath.includes('@fluentui-copilot/')) {
                // This is a temporary workaround until we have a fluentui-copilot hotfix.
                return false;
            }

            return true;
        }
    }
}
```

The PR updates the tests accordingly (accounting for the expanded string), and also adds two test cases for the classNameHashFilter functionality.