### PR TITLE
feat(webpack-plugin): initial release & minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Thumbs.db
 .nx/workspace-data
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+vite.config.*.timestamp*
+vitest.config.*.timestamp*

--- a/change/@griffel-transform-7493dd78-be7e-4f9e-a6fe-5ebf149ef279.json
+++ b/change/@griffel-transform-7493dd78-be7e-4f9e-a6fe-5ebf149ef279.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor: extract dedupeCSSRules result to a variable in transformSync",
+  "packageName": "@griffel/transform",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-extraction-plugin-105e413c-8ef1-43a4-90be-6701376044fd.json
+++ b/change/@griffel-webpack-extraction-plugin-105e413c-8ef1-43a4-90be-6701376044fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use Symbol.for() instead of Symbol() for GriffelCssLoaderContextKey",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-plugin-56092e3a-63c5-4936-af7b-5d028f83c0e9.json
+++ b/change/@griffel-webpack-plugin-56092e3a-63c5-4936-af7b-5d028f83c0e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: initial release of @griffel/webpack-plugin",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/nx.json
+++ b/nx.json
@@ -51,5 +51,12 @@
   "defaultBase": "main",
   "tui": {
     "enabled": false
+  },
+  "generators": {
+    "@nx/react": {
+      "library": {
+        "unitTestRunner": "none"
+      }
+    }
   }
 }

--- a/packages/transform/src/transformSync.mts
+++ b/packages/transform/src/transformSync.mts
@@ -326,14 +326,10 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
           const stylesBySlots = evaluationResult as Record<string, GriffelStyle>;
           // TODO fix naming
           const [classnamesMapping, cssRulesByBucketA] = resolveStyleRulesForSlots(stylesBySlots, classNameHashSalt);
+          const uniqueCSSRules = dedupeCSSRules(cssRulesByBucket);
 
           if (generateMetadata) {
-            buildCSSEntriesMetadata(
-              cssEntries,
-              classnamesMapping,
-              dedupeCSSRules(cssRulesByBucket),
-              styleCall.declaratorId,
-            );
+            buildCSSEntriesMetadata(cssEntries, classnamesMapping, uniqueCSSRules, styleCall.declaratorId);
           }
 
           // Replace the function call arguments

--- a/packages/webpack-extraction-plugin/src/constants.ts
+++ b/packages/webpack-extraction-plugin/src/constants.ts
@@ -1,7 +1,7 @@
 import type { LoaderContext } from 'webpack';
 
 export const PLUGIN_NAME = 'GriffelExtractPlugin';
-export const GriffelCssLoaderContextKey = Symbol(`${PLUGIN_NAME}/GriffelCssLoaderContextKey`);
+export const GriffelCssLoaderContextKey = Symbol.for(`${PLUGIN_NAME}/GriffelCssLoaderContextKey`);
 
 export interface GriffelLoaderContextSupplement {
   registerExtractedCss(css: string): void;

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -1,6 +1,16 @@
-# @griffel/webpack-plugin
+# Webpack plugin to perform CSS extraction in Griffel
 
-A unified Webpack plugin that performs build time transforms and CSS extraction for Griffel.
+A plugin for Webpack 5 that performs CSS extraction for [`@griffel/react`](../react).
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Install](#install)
+- [When to use it?](#when-to-use-it)
+- [Usage](#usage)
+- [Options](#options)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Install
 
@@ -10,20 +20,65 @@ yarn add --dev @griffel/webpack-plugin
 npm install --save-dev @griffel/webpack-plugin
 ```
 
+## When to use it?
+
+This is a replacement for `@griffel/webpack-loader` + `@griffel/webpack-extraction-plugin`. It combines both into a single plugin that handles CSS extraction without needing a separate loader setup.
+
 ## Usage
 
-```js
-const { GriffelPlugin } = require('@griffel/webpack-plugin');
+Webpack documentation:
 
-module.exports = {
-  plugins: [
-    new GriffelPlugin({
-      // plugin options
-    }),
-  ],
+- [Plugins](https://webpack.js.org/concepts/plugins/)
+- [Loaders](https://webpack.js.org/loaders/)
+
+Within your Webpack configuration, add the plugin along with `mini-css-extract-plugin`:
+
+```js
+import { GriffelPlugin } from '@griffel/webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|tsx)$/,
+        // Apply "exclude" only if your dependencies **do not use** Griffel
+        // exclude: /node_modules/,
+        use: {
+          loader: '@griffel/webpack-plugin/loader',
+        },
+      },
+      // "css-loader" and "mini-css-extract-plugin" are required to handle CSS assets produced by Griffel
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+  plugins: [new MiniCssExtractPlugin(), new GriffelPlugin()],
 };
 ```
 
-## Development
+The plugin automatically:
 
-This package is part of the Griffel monorepo and is built using the OXC toolkit to avoid Babel dependencies.
+- Transforms `makeStyles()`, `makeResetStyles()`, and `makeStaticStyles()` calls at build time
+- Extracts CSS into a dedicated chunk (named `griffel`) via `mini-css-extract-plugin`
+- Sorts CSS rules by specificity buckets and media queries
+
+## Options
+
+```js
+new GriffelPlugin({
+  // Compare function for sorting media queries (default: @griffel/core's defaultCompareMediaQueries)
+  compareMediaQueries: myCompareFunction,
+
+  // Override the resolver used to resolve imports inside evaluated modules
+  resolverFactory: myResolverFactory,
+
+  // Attach extracted CSS to a specific entry point chunk
+  unstable_attachToEntryPoint: 'main',
+
+  // Collect and log timing stats
+  collectStats: false,
+});
+```

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@griffel/webpack-plugin",
   "version": "1.0.0",
-  "private": true,
   "description": "Webpack plugin that performs CSS extraction for Griffel",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Closes #696

## Summary

- feat: initial release of `@griffel/webpack-plugin` (remove `private` flag, add README with usage docs)
- fix(webpack-extraction-plugin): use `Symbol.for()` instead of `Symbol()` for `GriffelCssLoaderContextKey`
- refactor(transform): extract `dedupeCSSRules` result to a variable in `transformSync`
- chore: add vite/vitest timestamp patterns to `.gitignore`
- chore: add `@nx/react` generator config to `nx.json`

## Test plan

- [x] `nx run @griffel/webpack-plugin:build` passes
- [x] `nx run @griffel/webpack-plugin:test` — 33 tests pass
- [x] `nx run @griffel/webpack-plugin:lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)