### PR TITLE
chore(webpack-plugin): make package private

### DIFF
--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@griffel/webpack-plugin",
   "version": "1.0.0",
+  "private": true,
   "description": "Webpack plugin that performs CSS extraction for Griffel",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Make the package private temporary as it's not ready to be released yet.