### PR TITLE
fix(transform): parse ESM files as modules in convertESMtoCJS

### DIFF
--- a/change/@griffel-transform-dafd809d-07b7-48c3-87a8-3de2f2705360.json
+++ b/change/@griffel-transform-dafd809d-07b7-48c3-87a8-3de2f2705360.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: parse ESM files as modules in convertESMtoCJS",
+  "packageName": "@griffel/transform",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transform/src/utils/convertESMtoCJS.mts
+++ b/packages/transform/src/utils/convertESMtoCJS.mts
@@ -35,7 +35,7 @@ function extractDeclaredNames(node: Node): string[] {
  * which cannot contain ESM syntax.
  */
 export function convertESMtoCJS(code: string, filename: string): string {
-  const parseResult = parseSync(filename, code);
+  const parseResult = parseSync(filename, code, { sourceType: 'module' });
 
   if (parseResult.errors.length > 0) {
     throw new Error(

--- a/packages/transform/src/utils/convertESMtoCJS.test.mts
+++ b/packages/transform/src/utils/convertESMtoCJS.test.mts
@@ -144,4 +144,16 @@ describe('convertESMtoCJS', () => {
       exports["ns"] = require("./foo");"
     `);
   });
+
+  it('handles "use strict" directive with ESM exports', () => {
+    const code = '"use strict";\nexport const foo = 1;\nexport class Bar {}';
+    expect(convertESMtoCJS(code, '/test.js')).toMatchInlineSnapshot(`
+      "Object.defineProperty(exports, "__esModule", { value: true });
+      "use strict";
+      const foo = 1;
+      class Bar {}
+      exports.foo = foo;
+      exports.Bar = Bar;"
+    `);
+  });
 });


### PR DESCRIPTION
## Summary

- `convertESMtoCJS` calls `oxc-parser`'s `parseSync` without specifying `sourceType`, which defaults to `script` for `.js` files
- Files that mix `"use strict"` with `export` statements (valid ESM) fail to parse because `export` is not valid in script mode
- Fix: pass `{ sourceType: 'module' }` since this function is only called for files already identified as ESM (`moduleKind === 'esm'`)

## Test plan

- [x] Added test case for `"use strict"` + ESM exports
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)