### PR TITLE
fix(transform): deduplicate CSS rules from resolveStyleRulesForSlots

### DIFF
--- a/change/@griffel-transform-ea9a7111-fbc4-4893-b2e5-34abb0f1788e.json
+++ b/change/@griffel-transform-ea9a7111-fbc4-4893-b2e5-34abb0f1788e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: deduplicate CSS rules from resolveStyleRulesForSlots",
+  "packageName": "@griffel/transform",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transform/__fixtures__/at-rules/output.meta.json
+++ b/packages/transform/__fixtures__/at-rules/output.meta.json
@@ -8,17 +8,8 @@
         {
           "m": "(min-width: 600px)"
         }
-      ],
-      [
-        "@media (min-width: 600px){.f1h4p6a1{padding-right:4px;}.fgefjy{padding-left:4px;}}",
-        {
-          "m": "(min-width: 600px)"
-        }
       ]
     ],
-    "t": [
-      "@supports (display: flex){.f1dyc5nu{padding-left:4px;}.f1kq3x14{padding-right:4px;}}",
-      "@supports (display: flex){.f1dyc5nu{padding-left:4px;}.f1kq3x14{padding-right:4px;}}"
-    ]
+    "t": ["@supports (display: flex){.f1dyc5nu{padding-left:4px;}.f1kq3x14{padding-right:4px;}}"]
   }
 }

--- a/packages/transform/__fixtures__/keyframes/output.meta.json
+++ b/packages/transform/__fixtures__/keyframes/output.meta.json
@@ -5,8 +5,6 @@
     "k": [
       "@keyframes f1q8eu9e{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}",
       "@keyframes f55c0se{from{transform:rotate(0deg);}to{transform:rotate(-360deg);}}",
-      "@keyframes f1q8eu9e{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}",
-      "@keyframes f55c0se{from{transform:rotate(0deg);}to{transform:rotate(-360deg);}}",
       "@keyframes f19fnzg9{from{height:100px;}to{height:200px;}}"
     ],
     "d": [

--- a/packages/transform/__fixtures__/object-mixins/output.meta.json
+++ b/packages/transform/__fixtures__/object-mixins/output.meta.json
@@ -7,8 +7,6 @@
       ".f1vx9l62{flex-direction:column;}",
       ".figsok6{font-weight:var(--fontWeightRegular);}",
       ".f16wzh4i{font-weight:bold;}",
-      ".f22iagw{display:flex;}",
-      ".f1vx9l62{flex-direction:column;}",
       ".fe3e8s9{color:red;}",
       ".f13qh94s{display:grid;}",
       ".f85kjgz{grid-row-gap:10px;}",

--- a/packages/transform/src/transformSync.mts
+++ b/packages/transform/src/transformSync.mts
@@ -347,7 +347,7 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
         {
           const stylesBySlots = evaluationResult as Record<string, GriffelStyle>;
           const [classnamesMapping, resolvedCSSRules] = resolveStyleRulesForSlots(stylesBySlots, classNameHashSalt);
-          const uniqueCSSRules = dedupeCSSRules(cssRulesByBucket);
+          const uniqueCSSRules = dedupeCSSRules(resolvedCSSRules);
 
           if (generateMetadata) {
             buildCSSEntriesMetadata(cssEntries, classnamesMapping, uniqueCSSRules, styleCall.declaratorId);
@@ -355,7 +355,7 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
 
           // Replace the function call arguments
           magicString.overwrite(styleCall.argumentStart, styleCall.argumentEnd, `${JSON.stringify(classnamesMapping)}`);
-          cssRulesByBucket = concatCSSRulesByBucket(cssRulesByBucket, resolvedCSSRules);
+          cssRulesByBucket = concatCSSRulesByBucket(cssRulesByBucket, uniqueCSSRules);
         }
 
         break;


### PR DESCRIPTION
## Summary

- `dedupeCSSRules()` was being called on the previously accumulated `cssRulesByBucket` instead of the freshly resolved `resolvedCSSRules`. This meant duplicates within each `makeStyles` call were never removed from the intermediate result.
- The deduplicated result (`uniqueCSSRules`) was only used for metadata — the raw un-deduplicated `resolvedCSSRules` was appended to the output bucket.

This does **not** affect the final generated CSS (the webpack plugin deduplicates when collecting CSS across modules), but it does cause the `cssRulesByBucket` returned by `transformSync()` to contain duplicate entries — LTR/RTL pairs and cross-slot duplicates.

## Fix

```diff
- const uniqueCSSRules = dedupeCSSRules(cssRulesByBucket);
+ const uniqueCSSRules = dedupeCSSRules(resolvedCSSRules);
  ...
- cssRulesByBucket = concatCSSRulesByBucket(cssRulesByBucket, resolvedCSSRules);
+ cssRulesByBucket = concatCSSRulesByBucket(cssRulesByBucket, uniqueCSSRules);
```

This matches how `@griffel/babel-preset` handles deduplication (line 341 of `transformPlugin.ts`).

## Test plan

- [x] All 79 transform tests pass (3 snapshots updated to remove duplicate entries)
