### PR TITLE
fix(webpack-plugin): fix webpack plugin loader dirname path construction

### DIFF
--- a/change/@griffel-webpack-plugin-fix-windows-path.json
+++ b/change/@griffel-webpack-plugin-fix-windows-path.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "fix: use fileURLToPath for Windows path compatibility",
   "packageName": "@griffel/webpack-plugin",
-  "email": "nicerobot@users.noreply.github.com",
+  "email": "hy.liu@berkeley.edu",
   "dependentChangeType": "patch"
 }

--- a/change/@griffel-webpack-plugin-fix-windows-path.json
+++ b/change/@griffel-webpack-plugin-fix-windows-path.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use fileURLToPath for Windows path compatibility",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "nicerobot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-plugin/src/webpackLoader.mts
+++ b/packages/webpack-plugin/src/webpackLoader.mts
@@ -1,6 +1,7 @@
 import { EvalCache, transformSync, type TransformOptions, type TransformResult } from '@griffel/transform';
 import type * as webpack from 'webpack';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { GriffelCssLoaderContextKey, type SupplementedLoaderContext } from './constants.mjs';
 import { generateCSSRules } from './utils/generateCSSRules.mjs';
@@ -10,7 +11,7 @@ export type WebpackLoaderOptions = Omit<TransformOptions, 'filename' | 'generate
 
 type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLoaderOptions>>;
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // TODO: do something better, define via exports?
 const virtualLoaderPath = path.resolve(__dirname, 'virtual-loader', 'index.cjs');
 const virtualCSSFilePath = path.resolve(__dirname, 'virtual-loader', 'griffel.css');


### PR DESCRIPTION
The loader in the webpack plugin seems to have an issue on Windows when the path contains spaces. Specifically, `new URL(import.meta.url).pathname` returns URL-encoded strings (e.g., `%20` for spaces), causing webpack to fail when the project path contains spaces. This PR updates the line to use `fileURLToPath`, which should correctly handle path decoding on all platforms.

In `packages/webpack-plugin/src/webpackLoader.mts`:
* Added import for `fileURLToPath` from `'node:url'`
* Changed `const __dirname = path.dirname(new URL(import.meta.url).pathname);` → `const __dirname = path.dirname(fileURLToPath(import.meta.url));`