### PR TITLE
chore(e2e): add ESLint e2e test for eslint-plugin with flat config

### DIFF
--- a/e2e/eslint/eslint.config.mjs
+++ b/e2e/eslint/eslint.config.mjs
@@ -1,0 +1,16 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  {
+    ignores: ['**/dist', '**/out-tsc'],
+  },
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];

--- a/e2e/eslint/package.json
+++ b/e2e/eslint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@griffel/e2e-eslint",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/eslint/project.json
+++ b/e2e/eslint/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "@griffel/e2e-eslint",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "e2e/eslint/src",
+  "projectType": "library",
+  "implicitDependencies": ["@griffel/eslint-plugin"],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": [{ "target": "build", "dependencies": true }],
+      "options": {
+        "cwd": "e2e/eslint",
+        "commands": [{ "command": "node src/test.ts" }]
+      },
+      "outputs": []
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "e2e/eslint",
+        "commands": [{ "command": "tsc -b --pretty" }],
+        "outputPath": []
+      }
+    }
+  },
+  "tags": []
+}

--- a/e2e/eslint/src/assets/eslint.config.mjs
+++ b/e2e/eslint/src/assets/eslint.config.mjs
@@ -1,0 +1,20 @@
+import { fixupPluginRules } from '@eslint/compat';
+import griffelPlugin from '@griffel/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+    plugins: {
+      '@griffel': fixupPluginRules(griffelPlugin),
+    },
+    rules: {
+      '@griffel/hook-naming': 'error',
+    },
+  },
+];

--- a/e2e/eslint/src/assets/fixture.ts
+++ b/e2e/eslint/src/assets/fixture.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@griffel/react';
+
+// This should trigger @griffel/hook-naming error:
+// makeStyles returns a hook, must start with "use"
+const getStyles = makeStyles({
+  root: { color: 'red' },
+});
+
+export { getStyles };

--- a/e2e/eslint/src/test.ts
+++ b/e2e/eslint/src/test.ts
@@ -1,0 +1,57 @@
+import { configureYarn, copyAssets, createTempDir, installPackages, packLocalPackage, sh } from '@griffel/e2e-utils';
+import logSymbols from 'log-symbols';
+import path from 'path';
+
+async function performTest() {
+  let tempDir: string;
+
+  try {
+    const rootDir = path.resolve(import.meta.dirname, '..', '..', '..');
+    const assetsPath = path.resolve(import.meta.dirname, 'assets');
+
+    tempDir = createTempDir('eslint');
+
+    await copyAssets({ assetsPath, tempDir });
+    await configureYarn({ tempDir, rootDir });
+
+    const resolutions = [
+      await packLocalPackage(rootDir, tempDir, '@griffel/eslint-plugin'),
+      await packLocalPackage(rootDir, tempDir, '@griffel/react'),
+    ];
+
+    await installPackages({
+      packages: [['eslint', '^9'], ['@eslint/compat', '^1'], ['@typescript-eslint/parser', '^8'], 'typescript'],
+      resolutions,
+      tempDir,
+      rootDir,
+    });
+  } catch (e) {
+    console.error(logSymbols.error, 'Something went wrong setting up the test:');
+    console.error((e as Error)?.stack ?? e);
+    process.exit(1);
+  }
+
+  // ESLint should exit with code 1 because fixture.ts has a hook-naming violation
+  try {
+    await sh('npx eslint .', tempDir, true);
+
+    // If we get here, ESLint exited with code 0 (no errors found) — that's a failure
+    console.error(
+      logSymbols.error,
+      'ESLint should have reported an error for the hook-naming violation, but it did not.',
+    );
+    process.exit(1);
+  } catch (e) {
+    const output = (e as Error).message;
+
+    if (output.includes('@griffel/hook-naming')) {
+      console.log(logSymbols.success, 'ESLint with flat config correctly reported @griffel/hook-naming violation');
+    } else {
+      console.error(logSymbols.error, 'ESLint failed but not with the expected @griffel/hook-naming error:');
+      console.error(output);
+      process.exit(1);
+    }
+  }
+}
+
+performTest();

--- a/e2e/eslint/tsconfig.json
+++ b/e2e/eslint/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/e2e/eslint/tsconfig.lib.json
+++ b/e2e/eslint/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "environment"]
+  },
+  "include": ["**/*.ts", "**/*.js"],
+  "exclude": ["src/assets"]
+}

--- a/e2e/utils/src/installPackages.ts
+++ b/e2e/utils/src/installPackages.ts
@@ -5,7 +5,7 @@ import logSymbols from 'log-symbols';
 import { sh } from './sh.ts';
 
 export async function installPackages(options: {
-  packages: string[];
+  packages: (string | [name: string, version: string])[];
   resolutions: { file?: string; version?: string; packageName: string }[];
   rootDir: string;
   tempDir: string;
@@ -19,10 +19,21 @@ export async function installPackages(options: {
     throw new Error(`A "package.json" in a temporary directory does not exist`);
   }
 
-  let packagesWithVersions = {};
+  let packagesWithVersions: Record<string, string> = {};
 
-  if (packages.length > 0) {
-    const yarnOutput = await sh(`yarn info ${packages.join(' ')} --json`, rootDir, true);
+  const workspacePackages: string[] = [];
+  const versionedPackages: Record<string, string> = {};
+
+  for (const pkg of packages) {
+    if (Array.isArray(pkg)) {
+      versionedPackages[pkg[0]] = pkg[1];
+    } else {
+      workspacePackages.push(pkg);
+    }
+  }
+
+  if (workspacePackages.length > 0) {
+    const yarnOutput = await sh(`yarn info ${workspacePackages.join(' ')} --json`, rootDir, true);
     const parsedYarnOutput = yarnOutput
       .split('\n')
       .filter(Boolean)
@@ -32,6 +43,8 @@ export async function installPackages(options: {
       parsedYarnOutput.map(info => [info.value.split('@patch')[0].split('@npm')[0], info.children.Version]),
     );
   }
+
+  packagesWithVersions = { ...packagesWithVersions, ...versionedPackages };
 
   const packageJson = JSON.parse(await fs.promises.readFile(tempDir + '/package.json', 'utf8'));
   const newPackageJson = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3561,6 +3561,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@griffel/e2e-eslint@workspace:e2e/eslint":
+  version: 0.0.0-use.local
+  resolution: "@griffel/e2e-eslint@workspace:e2e/eslint"
+  languageName: unknown
+  linkType: soft
+
 "@griffel/e2e-rspack@workspace:e2e/rspack":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-rspack@workspace:e2e/rspack"


### PR DESCRIPTION
## Summary

- Adds an e2e test project (`@griffel/e2e-eslint`) that validates `@griffel/eslint-plugin` works correctly with ESLint flat config
- The test packs the local `@griffel/eslint-plugin`, installs it in a temp directory with ESLint and `@typescript-eslint/parser`, and asserts the `@griffel/hook-naming` rule correctly reports violations

## Test plan

- [ ] CI passes — the new e2e test runs successfully
- [ ] Verify the test correctly detects the `@griffel/hook-naming` violation in the fixture file

🤖 Generated with [Claude Code](https://claude.com/claude-code)