### PR TITLE
fix(eslint-plugin): export top-level-styles rule and add missing rules to recommended config

### DIFF
--- a/change/@griffel-eslint-plugin-9633d117-1a2b-46d5-835f-b5d5f46c12b2.json
+++ b/change/@griffel-eslint-plugin-9633d117-1a2b-46d5-835f-b5d5f46c12b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export top-level-styles rule and add styles-file, top-level-styles to recommended config",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -6,6 +6,7 @@ import { noShorthandsRule } from './rules/no-shorthands.js';
 import { pseudoElementNamingRule } from './rules/pseudo-element-naming.js';
 import { stylesFileRule } from './rules/styles-file.js';
 import { noDeprecatedShorthandsRule } from './rules/no-deprecated-shorthands.js';
+import { stylesFileRule as topLevelStylesRule } from './rules/top-level-styles.js';
 
 const rules: Record<string, ESLintUtils.RuleModule<string, unknown[]>> = {
   'hook-naming': hookNamingRule,
@@ -14,6 +15,7 @@ const rules: Record<string, ESLintUtils.RuleModule<string, unknown[]>> = {
   'styles-file': stylesFileRule,
   'pseudo-element-naming': pseudoElementNamingRule,
   'no-deprecated-shorthands': noDeprecatedShorthandsRule,
+  'top-level-styles': topLevelStylesRule,
 };
 
 const plugin = {
@@ -31,6 +33,8 @@ plugin.configs['recommended'] = {
     '@griffel/no-shorthands': 'error',
     '@griffel/pseudo-element-naming': 'error',
     '@griffel/no-deprecated-shorthands': 'error',
+    '@griffel/styles-file': 'error',
+    '@griffel/top-level-styles': 'error',
   },
 };
 


### PR DESCRIPTION
## Summary

- Export `top-level-styles` rule from the plugin (was defined but never exported)
- Add `styles-file` and `top-level-styles` to the recommended config preset

Closes #746

## Test plan

- [x] All 62 eslint-plugin tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)