### PR TITLE
chore: fix lint issues ahead of ESLint 9 migration

### DIFF
--- a/change/@griffel-core-186116da-72c9-4501-aefe-6506ae226d15.json
+++ b/change/@griffel-core-186116da-72c9-4501-aefe-6506ae226d15.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-devtools-9a8e300f-2758-40d8-ad4b-7fce82ef3513.json
+++ b/change/@griffel-devtools-9a8e300f-2758-40d8-ad4b-7fce82ef3513.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/devtools",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-postcss-syntax-5cf069c9-94cb-44c1-9707-88af93fe7e4f.json
+++ b/change/@griffel-postcss-syntax-5cf069c9-94cb-44c1-9707-88af93fe7e4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-react-c7639bb5-5b7e-4872-aa10-c23783a9653c.json
+++ b/change/@griffel-react-c7639bb5-5b7e-4872-aa10-c23783a9653c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-transform-16861b12-8896-4ce9-9660-ee33543072e3.json
+++ b/change/@griffel-transform-16861b12-8896-4ce9-9660-ee33543072e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/transform",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-extraction-plugin-02b43ba1-5e97-4c36-aa80-9ec5a06b0d88.json
+++ b/change/@griffel-webpack-extraction-plugin-02b43ba1-5e97-4c36-aa80-9ec5a06b0d88.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-loader-c532146c-ccb8-47c1-801b-dd14557850de.json
+++ b/change/@griffel-webpack-loader-c532146c-ccb8-47c1-801b-dd14557850de.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-plugin-d8c44cad-2f9a-4960-a380-97abe3483f60.json
+++ b/change/@griffel-webpack-plugin-d8c44cad-2f9a-4960-a380-97abe3483f60.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint issues ahead of ESLint 9 migration",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/core/src/common/snapshotSerializers.ts
+++ b/packages/core/src/common/snapshotSerializers.ts
@@ -87,7 +87,7 @@ export const griffelResetRulesSerializer: SnapshotSerializer = {
     const cssRulesByBucket: CSSRulesByBucket = Array.isArray(_value[2]) ? { r: _value[2] } : _value[2];
 
     return Object.entries(cssRulesByBucket)
-      .filter(([key, value]) => value.length > 0)
+      .filter(([_key, value]) => value.length > 0)
       .flatMap(([key, value]) => [`/** bucket "${key}" */`, format(value as string[])])
       .join('\n');
   },

--- a/packages/core/src/devtools/isDevToolsEnabled.ts
+++ b/packages/core/src/devtools/isDevToolsEnabled.ts
@@ -3,7 +3,7 @@ export const isDevToolsEnabled: boolean = (() => {
   // https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni
   try {
     return Boolean(typeof window !== 'undefined' && window.sessionStorage?.getItem('__GRIFFEL_DEVTOOLS__'));
-  } catch (e) {
+  } catch {
     return false;
   }
 })();

--- a/packages/devtools/src/sourceMap/loadOriginalSourceLoc.ts
+++ b/packages/devtools/src/sourceMap/loadOriginalSourceLoc.ts
@@ -101,7 +101,7 @@ async function extractAndLoadSourceMapJSON(sourceLoc: MappedPosition): Promise<M
 
           return getOriginalPosition(sourceMapJSON, sourceLoc);
         }
-      } catch (error) {
+      } catch {
         // We've likely encountered a string in the source code that looks like a source map but isn't.
         // Maybe the source code contains a "sourceMappingURL" comment or something similar.
         // In either case, let's skip this and keep looking.

--- a/packages/postcss-syntax/src/location-preset.ts
+++ b/packages/postcss-syntax/src/location-preset.ts
@@ -31,8 +31,7 @@ export interface LocationPluginMetadata {
   resetLocations: ResetLocationsByHookDeclarator;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface LocationPluginOptions extends Pick<BabelPluginOptions, 'modules'> {}
+export type LocationPluginOptions = Pick<BabelPluginOptions, 'modules'>;
 
 /**
  * A plugin that parses Griffel code and returns code locations mapped to respective styles and slots

--- a/packages/react/src/utils/isInsideComponent.ts
+++ b/packages/react/src/utils/isInsideComponent.ts
@@ -32,7 +32,7 @@ export function isInsideComponent() {
     // a call on the dispatcher wont
     dispatcher.useContext({});
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/packages/transform/src/evaluation/module.mts
+++ b/packages/transform/src/evaluation/module.mts
@@ -21,7 +21,7 @@ import { ASSET_TAG_OPEN, ASSET_TAG_CLOSE } from '../constants.mjs';
 import { convertESMtoCJS } from '../utils/convertESMtoCJS.mjs';
 import * as EvalCache from './evalCache.mjs';
 import * as mockProcess from './process.mjs';
-import type { Evaluator, EvalRule } from './types.mjs';
+import type { EvalRule } from './types.mjs';
 
 export type TransformResolver = (
   id: string,
@@ -33,7 +33,7 @@ const debug = createDebug('griffel:module');
 // Separate cache for evaluated modules
 let cache: Record<string, Module> = {};
 
-const NOOP = () => {};
+const NOOP = () => { /* noop */ };
 
 /** Checks if a value is an Error-like object (works across VM contexts where `instanceof Error` fails). */
 function isError(e: unknown): e is Error {

--- a/packages/transform/src/evaluation/process.mts
+++ b/packages/transform/src/evaluation/process.mts
@@ -19,7 +19,7 @@ export const binding = function binding(): never {
 
 export const cwd = (): string => '/';
 
-const noop = (): void => {};
+const noop = (): void => { /* noop */ };
 
 export const exit = noop;
 export const kill = noop;

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -46,7 +46,7 @@ function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOption
     }
 
     return inputSourceMap as TransformOptions['inputSourceMap'];
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -49,7 +49,7 @@ function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOption
     }
 
     return inputSourceMap as TransformOptions['inputSourceMap'];
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/webpack-plugin/src/GriffelPlugin.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.mts
@@ -323,7 +323,7 @@ export class GriffelPlugin {
         },
         () => {
           if (this.#collectStats) {
-            function logTime(time: bigint): string {
+            const logTime = (time: bigint): string => {
               if (time > 1_000_000n) {
                 return (time / 1_000_000n).toString() + 'ms';
               }
@@ -333,7 +333,7 @@ export class GriffelPlugin {
               }
 
               return time.toString() + 'ns';
-            }
+            };
 
             const entries = Object.entries(this.#stats).sort(([, a], [, b]) => Number(b.time - a.time));
             const totalTime = entries.reduce((acc, cur) => acc + cur[1].time, 0n);

--- a/packages/webpack-plugin/src/GriffelPlugin.test.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.test.mts
@@ -201,7 +201,7 @@ function fixLineEndings(value: string) {
  * `f___0`, the second `f___1`, etc.
  */
 function normalizeGriffelHashes(str: string): string {
-  const hashRegex = /(?<=[\.\'\"])([fr][a-z0-9]{4,})(?=[{:\s\'\"\,\[\]])/g;
+  const hashRegex = /(?<=[.'"])([fr][a-z0-9]{4,})(?=[{:\s'",[\]])/g;
   const hashes: string[] = [];
   let match;
 

--- a/packages/webpack-plugin/src/resolver/createResolverFactory.mts
+++ b/packages/webpack-plugin/src/resolver/createResolverFactory.mts
@@ -15,7 +15,7 @@ const RESOLVE_OPTIONS_DEFAULTS: NapiResolveOptions = {
 export type TransformResolverFactory = (compilation: Compilation) => TransformResolver;
 
 export function createResolverFactory(): TransformResolverFactory {
-  return function (compilation: Compilation): TransformResolver {
+  return function (_compilation: Compilation): TransformResolver {
     // ⚠ "this._compilation" limits loaders compatibility, however there seems to be no other way to access Webpack's
     // resolver.
     // There is this.resolve(), but it's asynchronous. Another option is to read the webpack.config.js, but it won't work


### PR DESCRIPTION
## Summary

Fixes lint issues that will surface when upgrading to ESLint 9 / typescript-eslint v8. Extracted from #840 to keep the config migration PR focused.

- Remove unused catch binding parameters (`catch (e)` → `catch`)
- Replace empty interface with type alias (`no-empty-object-type`)
- Convert inner function declaration to arrow function (`no-inner-declarations`)
- Clean up unnecessary regex escapes (`no-useless-escape`)
- Use `/* noop */` comment in empty arrow functions (`no-empty-function`)
- Prefix unused variables with underscore

## Test plan

- [ ] CI passes — no behavioral changes, only lint fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)