### PR TITLE
chore: bump nano-staged to ~1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "monosize": "0.8.2",
     "monosize-bundler-webpack": "0.3.3",
     "monosize-storage-upstash": "0.0.25",
-    "nano-staged": "0.5.0",
+    "nano-staged": "~1.0.2",
     "nx": "22.6.5",
     "postcss": "8.4.47",
     "prettier": "2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15137,7 +15137,7 @@ __metadata:
     monosize: "npm:0.8.2"
     monosize-bundler-webpack: "npm:0.3.3"
     monosize-storage-upstash: "npm:0.0.25"
-    nano-staged: "npm:0.5.0"
+    nano-staged: "npm:~1.0.2"
     nx: "npm:22.6.5"
     oxc-parser: "npm:^0.116.0"
     oxc-resolver: "npm:^11.19.1"
@@ -19923,14 +19923,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nano-staged@npm:0.5.0":
-  version: 0.5.0
-  resolution: "nano-staged@npm:0.5.0"
-  dependencies:
-    picocolors: "npm:^1.0.0"
+"nano-staged@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "nano-staged@npm:1.0.2"
   bin:
     nano-staged: lib/bin.js
-  checksum: 10/4cd4ffacb3ab151f2e68a0d2b5ddd864745837dc133c1077012f59535f5b76c47ff04f554abe03b6f82ea497c1e261a8b659384abf58fe86ccf6c4263b06381e
+  checksum: 10/e6369d2a13b7a3c6ede165a3193eef341ed47f56f3b591a5a5ef2896631cb69d71b113843a76c65d86d7bc9d4745c66f4f39736849f132ac53e322342f7e4c57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps `nano-staged` 0.5.0 → ~1.0.2

## Motivation

`nano-staged@0.5.0` writes its backup patch to `.git/nano-staged.patch`. Inside a `git worktree` this fails because `.git` is a `gitlink` file, not a directory:

```
fatal: could not open '.../.git/nano-staged.patch' for writing: Not a directory
```

That blocks contributors from committing while working in a worktree. `nano-staged@1.0.0` resolves the real git directory via `git rev-parse --git-dir` before writing, which fixes the worktree case. Skipping 0.6 → 1.0 pulls in ~5 minor releases of fixes; the `prettier --write` / `doctoc -u` task config in `package.json` is unaffected.

## Acceptance test

The bump commit was authored **from a worktree** — the post-bump pre-commit hook ran cleanly, proving the fix.

## Stack position

Foundation for an 8-PR stack adding CSS `@scope` at-rule support to `@griffel/core`. Worktree-friendly tooling matters because the subsequent PRs were authored from sibling worktrees of one base branch.

| | Branch |
|---|---|
| **this** | `chore/bump-nano-staged` |
| next | `feat/browser-tests` |
| | `feat/scope-compile-atomic` |
| | `feat/scope-resolver-wiring` |
| | `feat/scope-hydration-and-tests` |
| | `feat/scope-reset` |
| | `feat/scope-extraction-fixtures` |
| | `docs/scope-support` (#859) |
| | `test/webpack-plugin-scope` (#861) |

This PR is independent of the `@scope` work and can merge on its own.

## Test plan

- [ ] Pre-commit hook runs cleanly from the main checkout
- [ ] Pre-commit hook runs cleanly from a `git worktree`
- [ ] CI green
