### PR TITLE
feat(core): wrap atomic rules in @scope when AtRules.scope is set

### DIFF
--- a/change/@griffel-core-ffcddcbb-64d8-470c-a308-514f6c997c17.json
+++ b/change/@griffel-core-ffcddcbb-64d8-470c-a308-514f6c997c17.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat(core): wrap atomic rules in @scope when AtRules.scope is set",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/core/src/runtime/compileAtomicCSSRule.test.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.test.ts
@@ -269,6 +269,134 @@ describe('compileAtomicCSSRule', () => {
       `);
     });
   });
+
+  describe('@scope', () => {
+    it('wraps the rule in @scope and substitutes the class with :scope', () => {
+      expect(
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            property: 'color',
+            value: 'red',
+          },
+          { ...defaultAtRules, scope: 'to (.boundary)' },
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          "@scope (.foo) to (.boundary){:scope{color:red;}}",
+        ]
+      `);
+    });
+
+    it('preserves pseudos under @scope', () => {
+      expect(
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            selectors: [':hover'],
+            property: 'color',
+            value: 'red',
+          },
+          { ...defaultAtRules, scope: 'to (.boundary)' },
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          "@scope (.foo) to (.boundary){:scope:hover{color:red;}}",
+        ]
+      `);
+    });
+
+    it('emits separate @scope blocks for LTR and RTL with direction-specific roots', () => {
+      expect(
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            property: 'paddingLeft',
+            value: '10px',
+
+            rtlProperty: 'paddingRight',
+            rtlValue: '10px',
+          },
+          { ...defaultAtRules, scope: 'to (.boundary)' },
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          "@scope (.foo) to (.boundary){:scope{padding-left:10px;}}",
+          "@scope (.rtl-foo) to (.boundary){:scope{padding-right:10px;}}",
+        ]
+      `);
+    });
+
+    it('places @scope as the innermost wrapper under @media', () => {
+      expect(
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            property: 'color',
+            value: 'red',
+          },
+          { ...defaultAtRules, media: '(max-width: 100px)', scope: 'to (.boundary)' },
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          "@media (max-width: 100px){@scope (.foo) to (.boundary){:scope{color:red;}}}",
+        ]
+      `);
+    });
+
+    it('places @scope as the innermost wrapper under @layer', () => {
+      expect(
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            property: 'color',
+            value: 'red',
+          },
+          { ...defaultAtRules, layer: 'utilities', scope: 'to (.boundary)' },
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          "@layer utilities{@scope (.foo) to (.boundary){:scope{color:red;}}}",
+        ]
+      `);
+    });
+
+    it('rebases nested descendant selectors onto :scope', () => {
+      expect(
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            selectors: ['& .baz'],
+            property: 'color',
+            value: 'red',
+          },
+          { ...defaultAtRules, scope: 'to (.boundary)' },
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          "@scope (.foo) to (.boundary){:scope .baz{color:red;}}",
+        ]
+      `);
+    });
+
+    it('handles :hover with a nested class descendant', () => {
+      expect(
+        compileAtomicCSSRule(
+          {
+            ...defaultOptions,
+            selectors: [':hover .nested'],
+            property: 'color',
+            value: 'red',
+          },
+          { ...defaultAtRules, scope: 'to (.boundary)' },
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          "@scope (.foo) to (.boundary){:scope:hover .nested{color:red;}}",
+        ]
+      `);
+    });
+  });
 });
 
 describe('normalizePseudoSelector', () => {

--- a/packages/core/src/runtime/compileAtomicCSSRule.test.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.test.ts
@@ -13,6 +13,7 @@ const defaultAtRules: AtRules = {
   layer: '',
   media: '',
   supports: '',
+  scope: '',
 };
 
 describe('compileAtomicCSSRule', () => {

--- a/packages/core/src/runtime/compileAtomicCSSRule.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.ts
@@ -1,7 +1,7 @@
+import { compileCSSRules } from './compileCSSRules.js';
 import { hyphenateProperty } from './utils/hyphenateProperty.js';
 import { normalizeNestedProperty } from './utils/normalizeNestedProperty.js';
 import type { AtRules } from './utils/types.js';
-import { compileCSSRules } from './compileCSSRules.js';
 
 export interface CompileAtomicCSSOptions {
   className: string;
@@ -54,14 +54,15 @@ export function compileAtomicCSSRule(
   atRules: AtRules,
 ): [string? /* ltr definition */, string? /* rtl definition */] {
   const { className, selectors, property, rtlClassName, rtlProperty, rtlValue, value } = options;
-  const { container, layer, media, supports } = atRules;
+  const { container, layer, media, scope, supports } = atRules;
 
   const classNameSelector = `.${className}`;
   const cssDeclaration = Array.isArray(value)
     ? `${value.map(v => `${hyphenateProperty(property)}: ${v}`).join(';')};`
     : `${hyphenateProperty(property)}: ${value};`;
 
-  let cssRule = createCSSRule(classNameSelector, cssDeclaration, selectors);
+  let ltrRule = createCSSRule(classNameSelector, cssDeclaration, selectors);
+  let rtlRule = '';
 
   if (rtlProperty && rtlClassName) {
     const rtlClassNameSelector = `.${rtlClassName}`;
@@ -69,21 +70,35 @@ export function compileAtomicCSSRule(
       ? `${rtlValue.map(v => `${hyphenateProperty(rtlProperty)}: ${v}`).join(';')};`
       : `${hyphenateProperty(rtlProperty)}: ${rtlValue};`;
 
-    cssRule += createCSSRule(rtlClassNameSelector, rtlCSSDeclaration, selectors);
+    rtlRule = createCSSRule(rtlClassNameSelector, rtlCSSDeclaration, selectors);
   }
+
+  if (scope) {
+    // @scope is applied as the innermost at-rule wrapper, so that outer
+    // at-rules (@media, @supports, etc.) wrap around it naturally.
+    // Separate @scope blocks for LTR and RTL because the scope root
+    // selector references the direction-specific atomic class.
+    ltrRule = ltrRule.split(classNameSelector).join(':scope');
+    ltrRule = `@scope (${classNameSelector}) ${scope} { ${ltrRule} }`;
+
+    if (rtlRule) {
+      const rtlClassNameSelector = `.${rtlClassName}`;
+      rtlRule = rtlRule.split(rtlClassNameSelector).join(':scope');
+      rtlRule = `@scope (${rtlClassNameSelector}) ${scope} { ${rtlRule} }`;
+    }
+  }
+
+  let cssRule = ltrRule + rtlRule;
 
   if (media) {
     cssRule = `@media ${media} { ${cssRule} }`;
   }
-
   if (layer) {
     cssRule = `@layer ${layer} { ${cssRule} }`;
   }
-
   if (supports) {
     cssRule = `@supports ${supports} { ${cssRule} }`;
   }
-
   if (container) {
     cssRule = `@container ${container} { ${cssRule} }`;
   }

--- a/packages/core/src/runtime/compileAtomicCSSRule.ts
+++ b/packages/core/src/runtime/compileAtomicCSSRule.ts
@@ -37,16 +37,8 @@ export function normalizePseudoSelector(pseudoSelector: string): string {
   );
 }
 
-function createCSSRule(classNameSelector: string, cssDeclaration: string, pseudos: string[]): string {
-  let cssRule = cssDeclaration;
-
-  if (pseudos.length > 0) {
-    cssRule = pseudos.reduceRight((acc, selector) => {
-      return `${normalizePseudoSelector(selector)} { ${acc} }`;
-    }, cssDeclaration);
-  }
-
-  return `${classNameSelector}{${cssRule}}`;
+function createCSSDeclaration(cssDeclaration: string, pseudos: string[]): string {
+  return pseudos.reduceRight((acc, selector) => `${normalizePseudoSelector(selector)} { ${acc} }`, cssDeclaration);
 }
 
 export function compileAtomicCSSRule(
@@ -61,8 +53,15 @@ export function compileAtomicCSSRule(
     ? `${value.map(v => `${hyphenateProperty(property)}: ${v}`).join(';')};`
     : `${hyphenateProperty(property)}: ${value};`;
 
-  let ltrRule = createCSSRule(classNameSelector, cssDeclaration, selectors);
-  let rtlRule = '';
+  // Under @scope, the rule body is anchored on :scope (the spec-defined
+  // alias for the scope root set via the (.className) prelude). @scope
+  // wraps innermost so outer at-rules (@media, @supports, etc.) compose
+  // around it. Separate blocks for LTR and RTL because the prelude
+  // references the direction-specific atomic class.
+  const ltrBody = createCSSDeclaration(cssDeclaration, selectors);
+  let cssRule = scope
+    ? `@scope (${classNameSelector}) ${scope} { :scope{${ltrBody}} }`
+    : `${classNameSelector}{${ltrBody}}`;
 
   if (rtlProperty && rtlClassName) {
     const rtlClassNameSelector = `.${rtlClassName}`;
@@ -70,25 +69,11 @@ export function compileAtomicCSSRule(
       ? `${rtlValue.map(v => `${hyphenateProperty(rtlProperty)}: ${v}`).join(';')};`
       : `${hyphenateProperty(rtlProperty)}: ${rtlValue};`;
 
-    rtlRule = createCSSRule(rtlClassNameSelector, rtlCSSDeclaration, selectors);
+    const rtlBody = createCSSDeclaration(rtlCSSDeclaration, selectors);
+    cssRule += scope
+      ? `@scope (${rtlClassNameSelector}) ${scope} { :scope{${rtlBody}} }`
+      : `${rtlClassNameSelector}{${rtlBody}}`;
   }
-
-  if (scope) {
-    // @scope is applied as the innermost at-rule wrapper, so that outer
-    // at-rules (@media, @supports, etc.) wrap around it naturally.
-    // Separate @scope blocks for LTR and RTL because the scope root
-    // selector references the direction-specific atomic class.
-    ltrRule = ltrRule.split(classNameSelector).join(':scope');
-    ltrRule = `@scope (${classNameSelector}) ${scope} { ${ltrRule} }`;
-
-    if (rtlRule) {
-      const rtlClassNameSelector = `.${rtlClassName}`;
-      rtlRule = rtlRule.split(rtlClassNameSelector).join(':scope');
-      rtlRule = `@scope (${rtlClassNameSelector}) ${scope} { ${rtlRule} }`;
-    }
-  }
-
-  let cssRule = ltrRule + rtlRule;
 
   if (media) {
     cssRule = `@media ${media} { ${cssRule} }`;

--- a/packages/core/src/runtime/getStyleBucketName.test.ts
+++ b/packages/core/src/runtime/getStyleBucketName.test.ts
@@ -3,29 +3,57 @@ import { getStyleBucketName } from './getStyleBucketName.js';
 
 describe('getStyleBucketName', () => {
   it('returns bucketName based on mapping', () => {
-    expect(getStyleBucketName([], { container: '', media: '', supports: '', layer: '' })).toBe('d');
-    expect(getStyleBucketName(['.foo'], { container: '', media: '', supports: '', layer: '' })).toBe('d');
+    expect(getStyleBucketName([], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe('d');
+    expect(getStyleBucketName(['.foo'], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe('d');
 
-    expect(getStyleBucketName([' :link'], { container: '', media: '', supports: '', layer: '' })).toBe('l');
-    expect(getStyleBucketName([' :hover '], { container: '', media: '', supports: '', layer: '' })).toBe('h');
+    expect(getStyleBucketName([' :link'], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe('l');
+    expect(getStyleBucketName([' :hover '], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe(
+      'h',
+    );
 
-    expect(getStyleBucketName([':link'], { container: '', media: '', supports: '', layer: '' })).toBe('l');
-    expect(getStyleBucketName([':visited'], { container: '', media: '', supports: '', layer: '' })).toBe('v');
-    expect(getStyleBucketName([':focus-within'], { container: '', media: '', supports: '', layer: '' })).toBe('w');
-    expect(getStyleBucketName([':focus'], { container: '', media: '', supports: '', layer: '' })).toBe('f');
-    expect(getStyleBucketName([':focus-visible'], { container: '', media: '', supports: '', layer: '' })).toBe('i');
-    expect(getStyleBucketName([':hover'], { container: '', media: '', supports: '', layer: '' })).toBe('h');
-    expect(getStyleBucketName([':active'], { container: '', media: '', supports: '', layer: '' })).toBe('a');
-
-    expect(getStyleBucketName([':active'], { container: '', media: '', supports: '', layer: 'theme' })).toBe('t');
+    expect(getStyleBucketName([':link'], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe('l');
+    expect(getStyleBucketName([':visited'], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe(
+      'v',
+    );
     expect(
-      getStyleBucketName([':active'], { container: '', media: '(max-width: 100px)', supports: '', layer: '' }),
+      getStyleBucketName([':focus-within'], { container: '', media: '', supports: '', layer: '', scope: '' }),
+    ).toBe('w');
+    expect(getStyleBucketName([':focus'], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe('f');
+    expect(
+      getStyleBucketName([':focus-visible'], { container: '', media: '', supports: '', layer: '', scope: '' }),
+    ).toBe('i');
+    expect(getStyleBucketName([':hover'], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe('h');
+    expect(getStyleBucketName([':active'], { container: '', media: '', supports: '', layer: '', scope: '' })).toBe('a');
+
+    expect(getStyleBucketName([':active'], { container: '', media: '', supports: '', layer: 'theme', scope: '' })).toBe(
+      't',
+    );
+    expect(
+      getStyleBucketName([':active'], {
+        container: '',
+        media: '(max-width: 100px)',
+        supports: '',
+        layer: '',
+        scope: '',
+      }),
     ).toBe('m');
     expect(
-      getStyleBucketName([':active'], { container: '', media: '', supports: '(display: table-cell)', layer: '' }),
+      getStyleBucketName([':active'], {
+        container: '',
+        media: '',
+        supports: '(display: table-cell)',
+        layer: '',
+        scope: '',
+      }),
     ).toBe('t');
     expect(
-      getStyleBucketName([':active'], { container: 'foo (max-width: 1px)', media: '', supports: '', layer: '' }),
+      getStyleBucketName([':active'], {
+        container: 'foo (max-width: 1px)',
+        media: '',
+        supports: '',
+        layer: '',
+        scope: '',
+      }),
     ).toBe('c');
   });
 });

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -93,6 +93,7 @@ export function resolveStyleRules(
     layer: '',
     media: '',
     supports: '',
+    scope: '',
   },
   cssClassesMap: CSSClassesMap = {},
   cssRulesByBucket: CSSRulesByBucket = {},

--- a/packages/core/src/runtime/utils/hashClassName.test.ts
+++ b/packages/core/src/runtime/utils/hashClassName.test.ts
@@ -13,6 +13,7 @@ const defaultAtRules = {
   media: '',
   layer: '',
   supports: '',
+  scope: '',
 };
 
 describe('hashClassName', () => {

--- a/packages/core/src/runtime/utils/hashPropertyKey.test.ts
+++ b/packages/core/src/runtime/utils/hashPropertyKey.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { hashPropertyKey } from './hashPropertyKey.js';
 
-const defaultAtRules = { container: '', media: '', supports: '', layer: '' };
+const defaultAtRules = { container: '', media: '', supports: '', layer: '', scope: '' };
 
 describe('hashPropertyKey', () => {
   it('generates hashes that always start with letters', () => {

--- a/packages/core/src/runtime/utils/isScopeSelector.test.ts
+++ b/packages/core/src/runtime/utils/isScopeSelector.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { isScopeSelector } from './isScopeSelector';
+
+describe('isScopeSelector', () => {
+  it('returns true for @scope selectors', () => {
+    expect(isScopeSelector('@scope to (.boundary)')).toBe(true);
+    expect(isScopeSelector('@scope to (.boundary > *)')).toBe(true);
+    // isScopeSelector only detects the @scope prefix; resolveStyleRules
+    // validates the full syntax and rejects these unsupported forms
+    expect(isScopeSelector('@scope (&)')).toBe(true);
+    expect(isScopeSelector('@scope (&) to (&)')).toBe(true);
+    expect(isScopeSelector('@scope (.foo)')).toBe(true);
+  });
+
+  it('returns false for non-scope selectors', () => {
+    expect(isScopeSelector('@media screen')).toBe(false);
+    expect(isScopeSelector('@container foo')).toBe(false);
+    expect(isScopeSelector('@supports (display: grid)')).toBe(false);
+    expect(isScopeSelector(':hover')).toBe(false);
+    expect(isScopeSelector('& .child')).toBe(false);
+  });
+});

--- a/packages/core/src/runtime/utils/isScopeSelector.ts
+++ b/packages/core/src/runtime/utils/isScopeSelector.ts
@@ -1,0 +1,3 @@
+export function isScopeSelector(property: string): boolean {
+  return property.substring(0, 6) === '@scope';
+}

--- a/packages/core/src/runtime/utils/types.ts
+++ b/packages/core/src/runtime/utils/types.ts
@@ -3,4 +3,5 @@ export type AtRules = {
   media: string;
   layer: string;
   supports: string;
+  scope: string;
 };


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #852 and #853. The diff currently includes their content because those PRs haven't merged yet; once they do, this branch will be rebased and the diff will shrink to just the additions below.

## Summary

The first crucial chunk of `@scope` support: `compileAtomicCSSRule` learns to wrap atomic rules in an `@scope (.className) <query> { :scope … }` block when `AtRules.scope` is set. Foundation only — the resolver doesn't yet *set* `atRules.scope`; that wiring is in #PR2.

## What changes

- `src/runtime/utils/types.ts` — adds `scope: string` to the `AtRules` slot. Default initializers across the runtime (and one test fixture) gain `scope: ''` to satisfy the new required field; no logic change
- `src/runtime/compileAtomicCSSRule.ts` — when `atRules.scope` is non-empty:
  - replaces `.className` in the rule body with `:scope` (so pseudos attach to the scope root, matching the @scope spec)
  - wraps with `@scope (.className) <query> { … }`
  - emits a separate scope wrap for RTL so the prelude references the direction-specific class
  - outer at-rules (`@media`, `@layer`, `@supports`, `@container`) continue to wrap around the `@scope` block
- `src/runtime/utils/isScopeSelector.ts` — small `isScopeSelector(property)` utility used by the resolver wiring (#PR2)

## Why explicit prelude + `:scope` substitution

Chromium requires an explicit scope-root prelude for `@scope` to apply reliably. The `:scope` substitution mirrors the spec form (`@scope (.x) { :scope:hover { ... } }`) and avoids re-emitting the class selector inside the body, which keeps the rule legible and matches the proximity-tie-break behavior at the spec level.

## Stack position

| | Branch |
|---|---|
| | `chore/bump-nano-staged` (#852) |
| | `feat/browser-tests` (#853) |
| **this** | `feat/scope-compile-atomic` |
| next | `feat/scope-resolver-wiring` |
| | `feat/scope-hydration-and-tests` |
| | `feat/scope-reset` |
| | `feat/scope-extraction-fixtures` |
| | `docs/scope-support` (#859) |
| | `test/webpack-plugin-scope` (#861) |

## Test plan

- [ ] `nx test @griffel/core` green (existing tests + the new `compileAtomicCSSRule` and `isScopeSelector` cases)
- [ ] `nx type-check @griffel/core` green
- [ ] `nx build @griffel/core` green
- [ ] CI green
