### PR TITLE
feat(core): rehydrate @scope rules + add makeStyles browser tests

### DIFF
--- a/change/@griffel-core-7e44d1cf-cc3f-4cc2-8e76-1c78f7415ac8.json
+++ b/change/@griffel-core-7e44d1cf-cc3f-4cc2-8e76-1c78f7415ac8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat(core): rehydrate @scope rules + add makeStyles browser tests",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/core/src/common/browserHelpers.ts
+++ b/packages/core/src/common/browserHelpers.ts
@@ -18,6 +18,9 @@ export const COLORS = {
   YELLOW: 'rgb(255, 255, 0)',
   CYAN: 'rgb(0, 255, 255)',
   ORANGE: 'rgb(255, 165, 0)',
+  BLUE: 'rgb(0, 0, 255)',
+  RED: 'rgb(255, 0, 0)',
+  BLACK: 'rgb(0, 0, 0)',
 };
 
 export function render(html: string): void {
@@ -26,6 +29,10 @@ export function render(html: string): void {
 
 export function getComputedBackgroundColor(el: Element): string {
   return getComputedStyle(el).backgroundColor;
+}
+
+export function getColor(el: Element): string {
+  return getComputedStyle(el).color;
 }
 
 export function applyStyles<S extends string>(stylesBySlot: Record<S, GriffelStyle>): Record<S, string> {

--- a/packages/core/src/renderer/rehydrateRendererCache.test.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DATA_BUCKET_ATTR, DATA_PRIORITY_ATTR } from '../constants.js';
 import type { GriffelRenderer } from '../types.js';
 import { createDOMRenderer } from './createDOMRenderer.js';
@@ -30,6 +30,60 @@ describe('rehydrateRendererCache', () => {
     expect(renderer.insertionCache).toMatchInlineSnapshot(`
       {
         ".foo { color: red; }": "d",
+      }
+    `);
+  });
+
+  it('should rehydrate @scope rules in the d bucket', () => {
+    const styleElement = document.createElement('style');
+
+    styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
+    document.head.appendChild(styleElement);
+    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }';
+
+    rehydrateRendererCache(renderer, document);
+
+    expect(renderer.insertionCache).toMatchInlineSnapshot(`
+      {
+        "@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }": "d",
+      }
+    `);
+  });
+
+  it('should rehydrate @scope rules in the h bucket', () => {
+    const styleElement = document.createElement('style');
+
+    styleElement.setAttribute(DATA_BUCKET_ATTR, 'h');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
+    document.head.appendChild(styleElement);
+    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary) { :scope:hover{color:cyan;} }';
+
+    rehydrateRendererCache(renderer, document);
+
+    expect(renderer.insertionCache).toMatchInlineSnapshot(`
+      {
+        "@scope (.f1ewl1kl) to (.boundary) { :scope:hover{color:cyan;} }": "h",
+      }
+    `);
+  });
+
+  it('should rehydrate @scope rules with boundary selector', () => {
+    const styleElement = document.createElement('style');
+
+    styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
+    document.head.appendChild(styleElement);
+    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }';
+
+    rehydrateRendererCache(renderer, document);
+
+    expect(renderer.insertionCache).toMatchInlineSnapshot(`
+      {
+        "@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }": "d",
       }
     `);
   });

--- a/packages/core/src/renderer/rehydrateRendererCache.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.ts
@@ -1,12 +1,13 @@
+import { debugData, isDevToolsEnabled } from '../devtools/index.js';
 import type { GriffelRenderer, StyleBucketName } from '../types.js';
-import { isDevToolsEnabled, debugData } from '../devtools/index.js';
 import { createIsomorphicStyleSheetFromElement } from './createIsomorphicStyleSheet.js';
 import { getStyleSheetKeyFromElement } from './getStyleSheetForBucket.js';
 
 // Regexps to extract names of classes and animations
 // https://github.com/styletron/styletron/blob/e0fcae826744eb00ce679ac613a1b10d44256660/packages/styletron-engine-atomic/src/client/client.js#L8
 const KEYFRAMES_HYDRATOR = /@(-webkit-)?keyframes ([^{]+){((?:(?:from|to|(?:\d+\.?\d*%))\{(?:[^}])*})*)}/g;
-const AT_RULES_HYDRATOR = /@(media|supports|layer)[^{]+\{([\s\S]+?})\s*}/g;
+const AT_RULES_HYDRATOR = /@(media|supports|layer|scope)[^{]+\{([\s\S]+?})\s*}/g;
+const SCOPE_HYDRATOR = /@scope[^{]+\{([\s\S]+?})\s*}/g;
 const STYLES_HYDRATOR = /\.([^{:]+)(:[^{]+)?{(?:[^}]*;)?([^}]*?)}/g;
 
 const regexps: Partial<Record<StyleBucketName, RegExp>> = {
@@ -37,17 +38,42 @@ export function rehydrateRendererCache(
         renderer.stylesheets[stylesheetKey] = createIsomorphicStyleSheetFromElement(styleElement);
       }
 
-      const regex = regexps[bucketName] || STYLES_HYDRATOR;
+      const regex = regexps[bucketName];
       let match;
+      let textContent = styleElement.textContent!;
 
-      while ((match = regex.exec(styleElement.textContent!))) {
-        // "cacheKey" is either a class name or an animation name
-        const [cssRule] = match;
+      if (regex) {
+        while ((match = regex.exec(textContent))) {
+          const [cssRule] = match;
 
-        renderer.insertionCache[cssRule] = bucketName;
+          renderer.insertionCache[cssRule] = bucketName;
 
-        if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
-          debugData.addCSSRule(cssRule);
+          if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+            debugData.addCSSRule(cssRule);
+          }
+        }
+      } else {
+        // @scope rules can appear in any bucket, so extract them first to prevent
+        // STYLES_HYDRATOR from spuriously matching class selectors inside @scope blocks.
+        while ((match = SCOPE_HYDRATOR.exec(textContent))) {
+          const [cssRule] = match;
+
+          renderer.insertionCache[cssRule] = bucketName;
+          textContent = textContent.replace(cssRule, '');
+
+          if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+            debugData.addCSSRule(cssRule);
+          }
+        }
+
+        while ((match = STYLES_HYDRATOR.exec(textContent))) {
+          const [cssRule] = match;
+
+          renderer.insertionCache[cssRule] = bucketName;
+
+          if (process.env.NODE_ENV !== 'production' && isDevToolsEnabled) {
+            debugData.addCSSRule(cssRule);
+          }
         }
       }
     });

--- a/packages/core/src/runtime/scope-boundary.browser.test.ts
+++ b/packages/core/src/runtime/scope-boundary.browser.test.ts
@@ -1,0 +1,61 @@
+// Verifies Griffel's emitted `@scope` boundary behavior in a real browser.
+
+import { beforeEach, describe, expect, test } from 'vitest';
+import { applyStyles, COLORS, getColor, render, resetBrowserTestState } from '../common/browserHelpers.js';
+
+beforeEach(resetBrowserTestState);
+
+describe('@scope boundary isolation', () => {
+  test('descendant inside scope gets scoped styles; past boundary does not', () => {
+    const { root } = applyStyles({
+      root: {
+        '@scope to (.boundary)': {
+          '& p': { color: 'red' },
+        },
+      },
+    });
+    render(`
+      <div class="${root}">
+        <p data-testid="scoped">Inside scope</p>
+        <div class="boundary">
+          <p data-testid="outside">Past boundary</p>
+        </div>
+      </div>
+    `);
+
+    const scoped = document.querySelector('[data-testid=scoped]')!;
+    const outside = document.querySelector('[data-testid=outside]')!;
+
+    expect(getColor(scoped)).toBe(COLORS.RED);
+    expect(getColor(outside)).toBe(COLORS.BLACK);
+  });
+
+  test('nested scope root re-establishes scope past the boundary', () => {
+    const { root } = applyStyles({
+      root: {
+        '@scope to (.inner-boundary)': {
+          '& p': { color: 'blue' },
+        },
+      },
+    });
+    render(`
+      <div class="${root}">
+        <p data-testid="inside">Inside scope</p>
+        <div class="inner-boundary">
+          <p data-testid="past">Past boundary</p>
+          <div class="${root}">
+            <p data-testid="restart">Nested scope restart</p>
+          </div>
+        </div>
+      </div>
+    `);
+
+    const inside = document.querySelector('[data-testid=inside]')!;
+    const past = document.querySelector('[data-testid=past]')!;
+    const restart = document.querySelector('[data-testid=restart]')!;
+
+    expect(getColor(inside)).toBe(COLORS.BLUE);
+    expect(getColor(past)).toBe(COLORS.BLACK);
+    expect(getColor(restart)).toBe(COLORS.BLUE);
+  });
+});

--- a/packages/core/src/runtime/scope-lvfha.browser.test.ts
+++ b/packages/core/src/runtime/scope-lvfha.browser.test.ts
@@ -97,9 +97,7 @@ describe('@scope vs non-scoped cascade', () => {
   // Per CSS @scope spec, scoped rules win over non-scoped rules at equal
   // specificity due to scope proximity. Griffel currently emits both into
   // the same bucket (e.g. `d`) and relies on the browser's proximity
-  // tie-breaker for correctness. PR3 plans to place @scope atoms into a
-  // sub-bucket inserted right after the non-scope counterpart so the
-  // outcome is robust even in cascades where proximity does not apply.
+  // tie-breaker for correctness.
   test('@scope color wins over non-scoped color on the same element', () => {
     const { root } = applyStyles({
       root: {

--- a/packages/core/src/runtime/scope-lvfha.browser.test.ts
+++ b/packages/core/src/runtime/scope-lvfha.browser.test.ts
@@ -1,0 +1,115 @@
+// LVFHA cascade inside `@scope` rules, in a real browser.
+// See https://griffel.js.org/react/guides/atomic-css/#lvfha-order-of-pseudo-classes
+
+import { beforeEach, describe, expect, test } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
+import {
+  applyStyles,
+  COLORS,
+  commands,
+  getComputedBackgroundColor,
+  getColor,
+  render,
+  resetBrowserTestState,
+} from '../common/browserHelpers.js';
+
+beforeEach(resetBrowserTestState);
+
+describe('LVHA cascade inside @scope', () => {
+  test('@scope :hover wins over @scope :focus (authored hover-first)', async () => {
+    const { root } = applyStyles({
+      root: {
+        '@scope to (.never)': {
+          ':hover': { background: 'cyan' },
+          ':focus': { background: 'yellow' },
+        },
+      },
+    });
+    render(`<button class="${root}" data-testid="btn">scoped hover-first</button>`);
+    const btn = document.querySelector<HTMLButtonElement>('[data-testid=btn]')!;
+
+    btn.focus();
+    await userEvent.hover(btn);
+
+    expect(getComputedBackgroundColor(btn)).toBe(COLORS.CYAN);
+  });
+
+  test('@scope :hover wins over @scope :focus (authored focus-first)', async () => {
+    const { root } = applyStyles({
+      root: {
+        '@scope to (.never)': {
+          ':focus': { background: 'yellow' },
+          ':hover': { background: 'cyan' },
+        },
+      },
+    });
+    render(`<button class="${root}" data-testid="btn">scoped focus-first</button>`);
+    const btn = document.querySelector<HTMLButtonElement>('[data-testid=btn]')!;
+
+    btn.focus();
+    await userEvent.hover(btn);
+
+    expect(getComputedBackgroundColor(btn)).toBe(COLORS.CYAN);
+  });
+
+  test('@scope :active wins over @scope :hover (authored active-first)', async () => {
+    const { root } = applyStyles({
+      root: {
+        '@scope to (.never)': {
+          ':active': { background: 'orange' },
+          ':hover': { background: 'lightgreen' },
+        },
+      },
+    });
+    render(`<button class="${root}" data-testid="btn">scoped active-first</button>`);
+    const btn = document.querySelector<HTMLButtonElement>('[data-testid=btn]')!;
+
+    await userEvent.hover(btn);
+    await commands.mouseDown();
+
+    expect(getComputedBackgroundColor(btn)).toBe(COLORS.ORANGE);
+
+    await commands.mouseUp();
+  });
+
+  test('@scope :active wins over @scope :hover (authored hover-first)', async () => {
+    const { root } = applyStyles({
+      root: {
+        '@scope to (.never)': {
+          ':hover': { background: 'lightgreen' },
+          ':active': { background: 'orange' },
+        },
+      },
+    });
+    render(`<button class="${root}" data-testid="btn">scoped hover-before-active</button>`);
+    const btn = document.querySelector<HTMLButtonElement>('[data-testid=btn]')!;
+
+    await userEvent.hover(btn);
+    await commands.mouseDown();
+
+    expect(getComputedBackgroundColor(btn)).toBe(COLORS.ORANGE);
+
+    await commands.mouseUp();
+  });
+});
+
+describe('@scope vs non-scoped cascade', () => {
+  // Per CSS @scope spec, scoped rules win over non-scoped rules at equal
+  // specificity due to scope proximity. Griffel currently emits both into
+  // the same bucket (e.g. `d`) and relies on the browser's proximity
+  // tie-breaker for correctness. PR3 plans to place @scope atoms into a
+  // sub-bucket inserted right after the non-scope counterpart so the
+  // outcome is robust even in cascades where proximity does not apply.
+  test('@scope color wins over non-scoped color on the same element', () => {
+    const { root } = applyStyles({
+      root: {
+        '@scope to (.never)': { color: 'blue' },
+        color: 'red',
+      },
+    });
+    render(`<div class="${root}" data-testid="el">scope vs default</div>`);
+    const el = document.querySelector('[data-testid=el]')!;
+
+    expect(getColor(el)).toBe(COLORS.BLUE);
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #852, #853, #854, #855. The diff currently includes their content because those PRs haven't merged yet; once they do, this branch will be rebased and the diff will shrink to just the additions below.

## Summary

Now that the resolver emits `@scope` rules (#854 + #855), this PR teaches the SSR-rehydration path to recognize them and adds browser-mode coverage of the full runtime cascade for `@scope` inside `makeStyles`.

## What changes

- `src/renderer/rehydrateRendererCache.ts` — recognizes `@scope` rules when walking pre-rendered stylesheets and registers them under the correct bucket (`d`, `h`, etc.), mirroring the pseudo-class logic already in place
- `src/renderer/rehydrateRendererCache.test.ts` — unit tests for `@scope` rules in `d` and `h` buckets and with explicit boundary selectors
- `src/runtime/scope-lvfha.browser.test.ts` (new) — runtime cascade pinned in real Chromium:
  - LVHA still resolves correctly when rules are wrapped in `@scope`, both authoring orders
  - scope-vs-non-scope cascade with proximity tie-breaking
- `src/runtime/scope-boundary.browser.test.ts` (new):
  - descendants inside the scope receive scoped styles
  - descendants past `to (.boundary)` do not
  - nested scope roots re-establish the scope inside the boundary
- `src/testing/browserHelpers.ts` — adds `getColor`, `RED`, `BLUE`, `BLACK` for the new specs

## Why hydration matters

Without hydration support, SSR-rendered stylesheets lose their bucket metadata for `@scope` rules on the client and re-renders create duplicate atomic classes. The unit tests pin the round-trip.

## Stack position

| | Branch |
|---|---|
| | `chore/bump-nano-staged` (#852) |
| | `feat/browser-tests` (#853) |
| | `feat/scope-compile-atomic` (#854) |
| | `feat/scope-resolver-wiring` (#855) |
| **this** | `feat/scope-hydration-and-tests` |
| next | `feat/scope-reset` |
| | `feat/scope-extraction-fixtures` |
| | `docs/scope-support` (#859) |
| | `test/webpack-plugin-scope` (#861) |

> PR 3 in the original outline (bucket-ordering changes) was dropped — keeping reset's scope rules in the `r` bucket and letting `makeStyles`'s scope rules ride normal pseudo buckets means no reorder is needed. This PR fills the slot the original PR 4 occupied.

## Test plan

- [ ] `nx test @griffel/core` green (unit + browser projects)
- [ ] CI green
