### PR TITLE
test(webpack-extraction-plugin): add @scope coverage to extraction fixtures

### DIFF
--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/code.ts
@@ -4,7 +4,11 @@ export const styles = __styles(
   {},
   // Classes in this test are intentionally not realistic to simplify snapshots
   {
-    d: ['.color-red { color: red; }', '.animation-name { animation-name: foo; }'],
+    d: [
+      '.color-red { color: red; }',
+      '.animation-name { animation-name: foo; }',
+      '@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}',
+    ],
     l: ['.color-orange:link { color: orange; }'],
     v: ['.color-purple:visited { color: purple; }'],
     w: ['.color-pink:focus-within { color: pink; }'],

--- a/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/output.css
+++ b/packages/webpack-extraction-plugin/__fixtures__/webpack/style-buckets/output.css
@@ -5,6 +5,11 @@
 .animation-name {
   animation-name: foo;
 }
+@scope (.f1ewl1kl) to (.boundary) {
+  :scope .child {
+    color: red;
+  }
+}
 .color-orange:link {
   color: orange;
 }

--- a/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/parseCSSRules.test.ts
@@ -90,4 +90,38 @@ describe('parseCSSRules', () => {
     `);
     expect(result.remainingCSS).toBe('.foo{color:red;}.bar{color:green;}');
   });
+
+  it('handles @scope rules', () => {
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}'],
+    };
+    const css = generateCSSRules(cssRulesByBucket);
+    const result = parseCSSRules(css);
+
+    expect(removeEmptyBuckets(result.cssRulesByBucket)).toMatchInlineSnapshot(`
+      Object {
+        "d": Array [
+          "@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}",
+        ],
+      }
+    `);
+    expect(result.remainingCSS).toBe('');
+  });
+
+  it('handles @scope rules with complex boundary selector', () => {
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['@scope (.f1ewl1kl) to (.boundary > *){:scope .child{color:red;}}'],
+    };
+    const css = generateCSSRules(cssRulesByBucket);
+    const result = parseCSSRules(css);
+
+    expect(removeEmptyBuckets(result.cssRulesByBucket)).toMatchInlineSnapshot(`
+      Object {
+        "d": Array [
+          "@scope (.f1ewl1kl) to (.boundary > *){:scope .child{color:red;}}",
+        ],
+      }
+    `);
+    expect(result.remainingCSS).toBe('');
+  });
 });


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #852, #853, #854, #855, #856, #857. The diff currently includes their content because those PRs haven't merged yet; once they do, this branch will be rebased and the diff will shrink to just the additions below.

> [!IMPORTANT]
> **This PR is purely tests + fixtures.** `parseCSSRules.ts` and the rest of the plugin source are untouched — the existing parser already handles `@scope (.className) to (...) { :scope … }` by walking rules generically. This PR is regression coverage to pin the build-time round-trip.

## Summary

Closes the loop on `@scope` by pinning the build-time extraction path. Authors a small `@scope to (...)` fixture, asserts the extracted output preserves the `@scope (.className) to (...) { :scope … }` shape that the runtime now emits, and adds `parseCSSRules` cases that walk @scope-wrapped declarations into the same bucket entries used by `rehydrateRendererCache`.

## What changes

- `__fixtures__/webpack/style-buckets/code.ts` — author a slot that uses `@scope to (.boundary)` via `makeStyles`
- `__fixtures__/webpack/style-buckets/output.css` — corresponding expected extracted CSS
- `src/parseCSSRules.test.ts` — `@scope`-wrapped cases routed to per-pseudo bucket entries

## Why

Build-time extraction (this plugin) and SSR rehydration (`rehydrateRendererCache`, in #856) need to agree on the bucket each rule belongs to. Without these tests, an extraction-vs-runtime divergence would only surface as silently-broken hydration in user apps.

## Stack position

| | Branch |
|---|---|
| | `chore/bump-nano-staged` (#852) |
| | `feat/browser-tests` (#853) |
| | `feat/scope-compile-atomic` (#854) |
| | `feat/scope-resolver-wiring` (#855) |
| | `feat/scope-hydration-and-tests` (#856) |
| | `feat/scope-reset` (#857) |
| **this** | `feat/scope-extraction-fixtures` |
| next | `docs/scope-support` (#859) |

## Test plan

- [ ] `nx test @griffel/webpack-extraction-plugin` green
- [ ] CI green
