### PR TITLE
docs: document @scope support in makeStyles and makeResetStyles

### DIFF
--- a/apps/website/docs/react/api/make-styles.md
+++ b/apps/website/docs/react/api/make-styles.md
@@ -196,6 +196,46 @@ const useClasses = makeStyles({
 }
 ```
 
+### `@scope` at-rule
+
+[`@scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope) rules are supported. Each scope-wrapped declaration produces its own atomic class with the class as the scope root:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    '@scope to (.boundary)': {
+      ':hover': { color: 'cyan' },
+      '& p': { color: 'red' },
+    },
+  },
+});
+```
+
+<OutputTitle>Produces following CSS...</OutputTitle>
+
+```css
+@scope (.f1abc123) to (.boundary) {
+  :scope:hover {
+    color: cyan;
+  }
+}
+@scope (.f1def456) to (.boundary) {
+  :scope p {
+    color: red;
+  }
+}
+```
+
+The atomic class is emitted as the scope-root prelude and `:scope` references it inside the body, mirroring the [`@scope` spec](https://drafts.csswg.org/css-cascade-6/#scope-atrule). Pseudo-classes nested inside `@scope` keep their normal LVFHA bucket so cascade ordering is preserved across scoped and non-scoped rules.
+
+:::caution
+
+Only `@scope to (SELECTOR)` is supported. Bare `@scope` and forms with an explicit prelude root (`@scope (...) to (...)`) are rejected — Griffel needs to control the scope-root selector to keep proximity tie-breaking deterministic across atomic classes.
+
+:::
+
 ### `@keyframes` (animations)
 
 `keyframes` are supported via `animationName` property that can be defined as an object:

--- a/apps/website/docs/react/guides/atomic-css.md
+++ b/apps/website/docs/react/guides/atomic-css.md
@@ -76,6 +76,27 @@ To ensure that results are deterministic Griffel performs automatic ordering of 
 
 The last defined pseudo wins.
 
+## `@scope` rules
+
+[CSS `@scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope) rules are supported via the same atomic pipeline as other at-rules. Each scope-wrapped declaration retains its pseudo-class bucket, so LVFHA ordering still applies inside a scope:
+
+```js
+import { makeStyles } from '@griffel/react';
+
+const useClasses = makeStyles({
+  root: {
+    '@scope to (.boundary)': {
+      ':focus': { color: 'yellow' },
+      ':hover': { color: 'cyan' }, // still wins over :focus on focus+hover
+    },
+  },
+});
+```
+
+Scope rules emit with an explicit prelude — `@scope (.atomicClass) to (.boundary)` — so [scope proximity](https://drafts.csswg.org/css-cascade-6/#scope-proximity) tie-breaking applies as authored. Per the spec, a scoped rule wins over a non-scoped rule at equal specificity, which is worth keeping in mind when overriding base styles authored with [`makeResetStyles`](/react/api/make-reset-styles).
+
+Only `@scope to (SELECTOR)` syntax is accepted — see the [`makeStyles` reference](/react/api/make-styles#scope-at-rule) for details.
+
 ## Trade-offs
 
 ### Larger classes

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -79,6 +79,10 @@ const useClasses = makeStyles({
     '@container foo (max-width: 992px)': { color: 'orange' },
     '@supports (display: grid)': { color: 'red' },
     '@layer utility': { marginBottom: '1em' },
+    '@scope to (.boundary)': {
+      ':hover': { color: 'cyan' },
+      '& p': { color: 'red' },
+    },
   },
 });
 ```


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #852, #853, #854, #855, #856, #857, #858. The diff currently includes their content because those PRs haven't merged yet; once they do, this branch will be rebased and the diff will shrink to just the additions below.

## Summary

Documents `@scope` at-rule support — the runtime feature added in #854/#855 and the reset parity in #857.

## What changes

- `apps/website/docs/react/guides/atomic-css.md` — new `@scope rules` section after LVFHA, explaining bucket-routing and proximity-tie semantics
- `apps/website/docs/react/api/make-styles.md` — new `@scope at-rule` subsection with input/output CSS and a callout that only `@scope to (SELECTOR)` is accepted
- `packages/react/README.md` — extends the at-rule example to include `@scope to (.boundary)`

## Why

The runtime support landed in earlier PRs but the public docs didn't mention `@scope` at all. New users would have no way to discover the supported syntax (`@scope to (...)` only) or that the feature exists.

## Stack position

| | Branch |
|---|---|
| | `chore/bump-nano-staged` (#852) |
| | `feat/browser-tests` (#853) |
| | `feat/scope-compile-atomic` (#854) |
| | `feat/scope-resolver-wiring` (#855) |
| | `feat/scope-hydration-and-tests` (#856) |
| | `feat/scope-reset` (#857) |
| | `feat/scope-extraction-fixtures` (#858) |
| | `docs/scope-support` (#859) |
| | `test/webpack-plugin-scope` (#861) |
| **this** | `docs/scope-support` |

## Test plan

- [ ] `nx build @griffel/website` green (docusaurus picks up the new content)
- [ ] CI green
