### PR TITLE
test(webpack-plugin): add @scope coverage to fixtures and parser tests

### DIFF
--- a/change/@griffel-webpack-plugin-1578dc01-31a8-450d-8d36-7c78f642b30b.json
+++ b/change/@griffel-webpack-plugin-1578dc01-31a8-450d-8d36-7c78f642b30b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test: add @scope coverage to fixtures and parser tests",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/webpack-plugin/__fixtures__/style-buckets-scope/code.ts
+++ b/packages/webpack-plugin/__fixtures__/style-buckets-scope/code.ts
@@ -1,0 +1,11 @@
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: {
+    color: 'red',
+    '@scope to (.boundary)': {
+      ':hover': { color: 'cyan' },
+      '& p': { color: 'red' },
+    },
+  },
+});

--- a/packages/webpack-plugin/__fixtures__/style-buckets-scope/fs.json
+++ b/packages/webpack-plugin/__fixtures__/style-buckets-scope/fs.json
@@ -1,0 +1,1 @@
+["bundle.js", "griffel.css"]

--- a/packages/webpack-plugin/__fixtures__/style-buckets-scope/output.css
+++ b/packages/webpack-plugin/__fixtures__/style-buckets-scope/output.css
@@ -1,0 +1,14 @@
+/** griffel.css **/
+.fe3e8s9 {
+  color: red;
+}
+@scope (.f7t33c5) to (.boundary) {
+  :scope p {
+    color: red;
+  }
+}
+@scope (.f1sje2gt) to (.boundary) {
+  :scope:hover {
+    color: cyan;
+  }
+}

--- a/packages/webpack-plugin/__fixtures__/style-buckets-scope/output.ts
+++ b/packages/webpack-plugin/__fixtures__/style-buckets-scope/output.ts
@@ -1,0 +1,5 @@
+import { __css } from '@griffel/react';
+
+export const useStyles = __css({ root: { sj55zd: 'fe3e8s9', J2wb9c: 'f1sje2gt', hth0cq: 'f7t33c5' } });
+
+import './code.griffel.css!=!../../src/virtual-loader/index.cjs!./code.ts';

--- a/packages/webpack-plugin/src/GriffelPlugin.test.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.test.mts
@@ -362,6 +362,7 @@ describe('GriffelCSSExtractionPlugin', () => {
 
   // Sorting rules by buckets
   testFixture('style-buckets');
+  testFixture('style-buckets-scope');
 
   // Assets
   // --------------------

--- a/packages/webpack-plugin/src/utils/parseCSSRules.test.mts
+++ b/packages/webpack-plugin/src/utils/parseCSSRules.test.mts
@@ -91,4 +91,38 @@ describe('parseCSSRules', () => {
     `);
     expect(result.remainingCSS).toBe('.foo{color:red;}.bar{color:green;}');
   });
+
+  it('handles @scope rules', () => {
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}'],
+    };
+    const css = generateCSSRules(cssRulesByBucket);
+    const result = parseCSSRules(css);
+
+    expect(removeEmptyBuckets(result.cssRulesByBucket)).toMatchInlineSnapshot(`
+      {
+        "d": [
+          "@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}",
+        ],
+      }
+    `);
+    expect(result.remainingCSS).toBe('');
+  });
+
+  it('handles @scope rules with complex boundary selector', () => {
+    const cssRulesByBucket: CSSRulesByBucket = {
+      d: ['@scope (.f1ewl1kl) to (.boundary > *){:scope .child{color:red;}}'],
+    };
+    const css = generateCSSRules(cssRulesByBucket);
+    const result = parseCSSRules(css);
+
+    expect(removeEmptyBuckets(result.cssRulesByBucket)).toMatchInlineSnapshot(`
+      {
+        "d": [
+          "@scope (.f1ewl1kl) to (.boundary > *){:scope .child{color:red;}}",
+        ],
+      }
+    `);
+    expect(result.remainingCSS).toBe('');
+  });
 });


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #852, #853, #854, #855, #856, #857, #858, #859. The diff currently includes their content because those PRs haven't merged yet; once they do, this branch will be rebased and the diff will shrink to just the additions below.

> [!IMPORTANT]
> **This PR is purely tests + fixtures.** The plugin source is untouched — the existing parser already handles `@scope (.className) to (...) { :scope … }` by walking rules generically. This PR is regression coverage requested by the reviewer to mirror #858's coverage of `@griffel/webpack-extraction-plugin` for the newer `@griffel/webpack-plugin`.

## Summary

`@griffel/webpack-plugin` is the recommended replacement for `@griffel/webpack-loader` + `@griffel/webpack-extraction-plugin` (per its README). PR #858 pinned `@scope` extraction for the older plugin; this PR does the same for the newer one so both supported integrations have their build-time round-trip locked in.

## What changes

- `__fixtures__/style-buckets-scope/` (new fixture):
  - `code.ts` authors `@scope to (.boundary)` inside `makeStyles`
  - `output.ts` pins the babel-transformed `__css({...})` form
  - `output.css` pins the extracted `@scope (.className) to (...) { :scope … }` CSS
  - `fs.json` matches the standard `["bundle.js", "griffel.css"]` shape
- `src/GriffelPlugin.test.mts`: registers `testFixture('style-buckets-scope')` next to the existing `style-buckets` fixture
- `src/utils/parseCSSRules.test.mts`: adds two cases mirroring #858 — `@scope` rule with simple boundary, and with complex (`> *`) boundary

## Why

Build-time extraction (this plugin) and SSR rehydration (`rehydrateRendererCache`, in #856) need to agree on the bucket each rule belongs to. Without these tests, an extraction-vs-runtime divergence in this plugin would silently break hydration in user apps using the recommended setup.

## Stack position

| | Branch |
|---|---|
| | `chore/bump-nano-staged` (#852) |
| | `feat/browser-tests` (#853) |
| | `feat/scope-compile-atomic` (#854) |
| | `feat/scope-resolver-wiring` (#855) |
| | `feat/scope-hydration-and-tests` (#856) |
| | `feat/scope-reset` (#857) |
| | `feat/scope-extraction-fixtures` (#858) |
| | `docs/scope-support` (#859) |
| **this** | `test/webpack-plugin-scope` |

## Test plan

- [ ] `nx test @griffel/webpack-plugin` green (existing 47 + 3 new = 50 tests)
- [ ] CI green
