### PR TITLE
fix(react): emit interop-free types

### DIFF
--- a/change/@griffel-react-1000e3be-4b8a-4ff6-9741-ac721219a25e.json
+++ b/change/@griffel-react-1000e3be-4b8a-4ff6-9741-ac721219a25e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react): emit interop-free types so consumers without esModuleInterop can compile",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/RendererContext.tsx
+++ b/packages/react/src/RendererContext.tsx
@@ -2,7 +2,7 @@
 
 import { createDOMRenderer, rehydrateRendererCache } from '@griffel/core';
 import type { GriffelRenderer } from '@griffel/core';
-import React from 'react';
+import { createContext, useContext, useMemo, type FC, type ReactNode } from 'react';
 
 import { canUseDOM } from './utils/canUseDOM.js';
 
@@ -18,19 +18,19 @@ export interface RendererProviderProps {
   /**
    * Content wrapped by the RendererProvider
    */
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 /**
  * @private
  */
-const RendererContext = /*#__PURE__*/ React.createContext<GriffelRenderer>(/*#__PURE__*/ createDOMRenderer());
+const RendererContext = /*#__PURE__*/ createContext<GriffelRenderer>(/*#__PURE__*/ createDOMRenderer());
 
 /**
  * @public
  */
-export const RendererProvider: React.FC<RendererProviderProps> = ({ children, renderer, targetDocument }) => {
-  React.useMemo(() => {
+export const RendererProvider: FC<RendererProviderProps> = ({ children, renderer, targetDocument }) => {
+  useMemo(() => {
     if (canUseDOM()) {
       // "rehydrateCache()" can't be called in effects as it needs to be called before any component will be rendered to
       // avoid double insertion of classes
@@ -47,5 +47,5 @@ export const RendererProvider: React.FC<RendererProviderProps> = ({ children, re
  * @private Exported as "useRenderer_unstable" use it on own risk. Can be changed or removed without a notice.
  */
 export function useRenderer(): GriffelRenderer {
-  return React.useContext(RendererContext);
+  return useContext(RendererContext);
 }

--- a/packages/react/src/TextDirectionContext.tsx
+++ b/packages/react/src/TextDirectionContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import { createContext, useContext, type FC, type ReactNode } from 'react';
 
 export interface TextDirectionProviderProps {
   /** Indicates the directionality of the element's text. */
@@ -9,18 +9,18 @@ export interface TextDirectionProviderProps {
   /**
    * Content wrapped by the TextDirectionProvider.
    */
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 /**
  * @private
  */
-const TextDirectionContext = /*#__PURE__*/ React.createContext<'ltr' | 'rtl'>('ltr');
+const TextDirectionContext = /*#__PURE__*/ createContext<'ltr' | 'rtl'>('ltr');
 
 /**
  * @public
  */
-export const TextDirectionProvider: React.FC<TextDirectionProviderProps> = ({ children, dir }) => {
+export const TextDirectionProvider: FC<TextDirectionProviderProps> = ({ children, dir }) => {
   return <TextDirectionContext.Provider value={dir}>{children}</TextDirectionContext.Provider>;
 };
 
@@ -30,5 +30,5 @@ export const TextDirectionProvider: React.FC<TextDirectionProviderProps> = ({ ch
  * @private
  */
 export function useTextDirection() {
-  return React.useContext(TextDirectionContext);
+  return useContext(TextDirectionContext);
 }

--- a/packages/react/src/useInsertionEffect.ts
+++ b/packages/react/src/useInsertionEffect.ts
@@ -1,7 +1,10 @@
 'use client';
 
-import React from 'react';
+import * as React from 'react';
 
+/**
+ * @internal
+ */
 export const useInsertionEffect: typeof React.useInsertionEffect | undefined =
   // @ts-expect-error Hack to make sure that `useInsertionEffect` will not cause bundling issues in older React versions
   // eslint-disable-next-line no-useless-concat

--- a/packages/react/src/useInsertionEffect.ts
+++ b/packages/react/src/useInsertionEffect.ts
@@ -1,12 +1,11 @@
 'use client';
 
-// @ts-ignore — default import is intentional (avoids the webpack namespace helper that `import * as` adds); this file is `@internal` and is stripped from the published `.d.ts`.
 import React from 'react';
 
 /**
  * @internal
  */
 export const useInsertionEffect: typeof React.useInsertionEffect | undefined =
-  // @ts-ignore — Hack to make sure that `useInsertionEffect` will not cause bundling issues in older React versions
+  // @ts-expect-error Hack to make sure that `useInsertionEffect` will not cause bundling issues in older React versions
   // eslint-disable-next-line no-useless-concat
   React['useInsertion' + 'Effect'] ? React['useInsertion' + 'Effect'] : undefined;

--- a/packages/react/src/useInsertionEffect.ts
+++ b/packages/react/src/useInsertionEffect.ts
@@ -1,11 +1,12 @@
 'use client';
 
-import * as React from 'react';
+// @ts-ignore — default import is intentional (avoids the webpack namespace helper that `import * as` adds); this file is `@internal` and is stripped from the published `.d.ts`.
+import React from 'react';
 
 /**
  * @internal
  */
 export const useInsertionEffect: typeof React.useInsertionEffect | undefined =
-  // @ts-expect-error Hack to make sure that `useInsertionEffect` will not cause bundling issues in older React versions
+  // @ts-ignore — Hack to make sure that `useInsertionEffect` will not cause bundling issues in older React versions
   // eslint-disable-next-line no-useless-concat
   React['useInsertion' + 'Effect'] ? React['useInsertion' + 'Effect'] : undefined;

--- a/packages/react/src/utils/canUseDOM.ts
+++ b/packages/react/src/utils/canUseDOM.ts
@@ -1,5 +1,7 @@
 /**
  * Verifies if an application can use DOM.
+ *
+ * @internal
  */
 export function canUseDOM(): boolean {
   return typeof window !== 'undefined' && !!(window.document && window.document.createElement);

--- a/packages/react/src/utils/isInsideComponent.ts
+++ b/packages/react/src/utils/isInsideComponent.ts
@@ -1,6 +1,5 @@
 'use client';
 
-// @ts-ignore — default import is intentional (avoids the webpack namespace helper that `import * as` adds); this file is `@internal` and is stripped from the published `.d.ts`.
 import React from 'react';
 
 function getDispatcher() {

--- a/packages/react/src/utils/isInsideComponent.ts
+++ b/packages/react/src/utils/isInsideComponent.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import * as React from 'react';
 
 function getDispatcher() {
   try {
@@ -17,6 +17,9 @@ function getDispatcher() {
   }
 }
 
+/**
+ * @internal
+ */
 export function isInsideComponent() {
   // React 18 always logs errors if a dispatcher is not present:
   // https://github.com/facebook/react/blob/42f15b324f50d0fd98322c21646ac3013e30344a/packages/react/src/ReactHooks.js#L26-L36

--- a/packages/react/src/utils/isInsideComponent.ts
+++ b/packages/react/src/utils/isInsideComponent.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import * as React from 'react';
+// @ts-ignore — default import is intentional (avoids the webpack namespace helper that `import * as` adds); this file is `@internal` and is stripped from the published `.d.ts`.
+import React from 'react';
 
 function getDispatcher() {
   try {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "allowJs": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowJs": true
   },
   "files": [],
   "include": [],

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "../../dist/out-tsc",
     "declaration": true,
+    "stripInternal": true,
     "types": ["node", "environment"]
   },
   "exclude": [

--- a/packages/react/tsconfig.spec.json
+++ b/packages/react/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "allowSyntheticDefaultImports": true,
     "typeRoots": ["../../node_modules", "../../node_modules/@types", "../../typings"],
     "types": ["vitest/importMeta", "vite/client", "node", "vitest", "environment"]
   },

--- a/packages/react/tsconfig.storybook.json
+++ b/packages/react/tsconfig.storybook.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
     "noEmit": true,
     "outDir": ""
   },


### PR DESCRIPTION
## Summary

Fixes #863.

Consumers of `@griffel/react` who compile their app **without** `esModuleInterop` (or `allowSyntheticDefaultImports`) currently see TypeScript errors against our published `.d.ts`:

```
node_modules/@griffel/react/src/RendererContext.d.ts(2,8): error TS1259:
  Module '".../node_modules/@types/react/index"' can only be default-imported
  using the 'esModuleInterop' flag
```

This PR makes `@griffel/react` interop-free at the `.d.ts` level.

> Builds on #865 (modern JSX runtime), which lets the public source files compile without `React` in scope.

## Changes

### Package config

- **`packages/react/tsconfig.json`** — drop `esModuleInterop` and `allowSyntheticDefaultImports`. Consumers no longer need to enable those flags to type-check our `.d.ts`.
- **`packages/react/tsconfig.lib.json`** — enable `stripInternal` so `@internal`-tagged exports are removed from the published types.
- **`packages/react/tsconfig.spec.json`, `tsconfig.storybook.json`** — re-add `allowSyntheticDefaultImports` only here. The lib build (NodeNext module) accepts `import React from 'react'` natively via Node's CJS interop, but the spec/storybook contexts (esnext / bundler module) do not. Adding the flag in those local configs avoids `@ts-ignore` boilerplate in source.

### Source

- **`RendererContext.tsx`, `TextDirectionContext.tsx`** — replace `import React from 'react'` with named imports (`{ createContext, useContext, useMemo, type FC, type ReactNode }`).
- **`useInsertionEffect.ts`, `utils/isInsideComponent.ts`, `utils/canUseDOM.ts`** — tagged `@internal`. Per `stripInternal`, they now emit `export {};` in the published `.d.ts`. The first two retain `import React from 'react'` (default import) — see "Why default imports here" below.

### Why default imports in the `@internal` helpers

Both `useInsertionEffect.ts` and `isInsideComponent.ts` access React internals via dynamic property names (`React['useInsertion' + 'Effect']`, `__SECRET_INTERNALS_*`), so they need the React namespace at runtime, not a named import.

`import * as React from 'react'` would work but adds webpack's namespace-creation runtime helper (`__webpack_require__.t` + the prototype walk) to every bundle that reaches these files. Measured against `main`:

| Fixture                    | `import * as React`  | `import React`        |
|----------------------------|----------------------|-----------------------|
| `__styles`                 | **+22%** (over threshold) | +0.4% (within noise) |
| `makeStaticStyles` runtime | +10%                 | +0.07%                |
| `makeResetStyles` runtime  | +5%                  | +0.08%                |
| `makeStyles` runtime       | +4%                  | +0.06%                |

Default import sidesteps the helper. These files are `@internal` and stripped from the published `.d.ts`, so the consumer-visible interop fix is unaffected.

## Resulting `.d.ts` (consumer-facing)

```ts
// before
import React from 'react';
export interface RendererProviderProps { children: React.ReactNode; ... }
export declare const RendererProvider: React.FC<RendererProviderProps>;

// after
import { type FC, type ReactNode } from 'react';
export interface RendererProviderProps { children: ReactNode; ... }
export declare const RendererProvider: FC<RendererProviderProps>;
```

`useInsertionEffect.d.ts`, `isInsideComponent.d.ts`, and `canUseDOM.d.ts` reduce to `export {};` after `stripInternal`.

## Test plan

- [x] `yarn build` passes for all 15 projects
- [x] `yarn type-check` passes for all 20 projects
- [x] `yarn lint` passes for `@griffel/react` (0 errors)
- [x] `yarn test` passes for all 18 projects (+ 7 dependent tasks)
- [x] `monosize compare-reports --branch main` — all fixtures within 0.5% of `main`
- [x] Inspected `dist/packages/react/src/*.d.ts`:
  - `RendererContext.d.ts`, `TextDirectionContext.d.ts` use `import { type FC, type ReactNode } from 'react'`
  - `useInsertionEffect.d.ts`, `isInsideComponent.d.ts`, `canUseDOM.d.ts` are `export {};`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
