### PR TITLE
fix: tag babel-emitted helpers as @private not @internal

### DIFF
--- a/change/@griffel-core-0e231651-ac5d-4917-9c3f-5c9be9c42a9a.json
+++ b/change/@griffel-core-0e231651-ac5d-4917-9c3f-5c9be9c42a9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: tag babel-emitted helpers as @private not @internal so they survive stripInternal and remain re-exportable from index.d.ts",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-react-7b87f3ef-cd67-405b-a85f-8573f407b5b7.json
+++ b/change/@griffel-react-7b87f3ef-cd67-405b-a85f-8573f407b5b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: tag babel-emitted helpers as @private not @internal so they survive stripInternal and remain re-exportable from index.d.ts",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/__css.ts
+++ b/packages/core/src/__css.ts
@@ -6,7 +6,7 @@ import type { CSSClassesMapBySlot } from './types.js';
 /**
  * A version of makeStyles() that accepts build output as an input and skips all runtime transforms & DOM insertion.
  *
- * @internal
+ * @private
  */
 export function __css<Slots extends string>(classesMapBySlot: CSSClassesMapBySlot<Slots>) {
   let ltrClassNamesForSlots: Record<Slots, string> | null = null;

--- a/packages/core/src/__resetCSS.ts
+++ b/packages/core/src/__resetCSS.ts
@@ -2,7 +2,7 @@ import { DEBUG_RESET_CLASSES } from './constants.js';
 import type { MakeResetStylesOptions } from './makeResetStyles.js';
 
 /**
- * @internal
+ * @private
  */
 export function __resetCSS(ltrClassName: string, rtlClassName: string | null) {
   function computeClassName(options: Pick<MakeResetStylesOptions, 'dir'>): string {

--- a/packages/core/src/__resetStyles.ts
+++ b/packages/core/src/__resetStyles.ts
@@ -4,7 +4,7 @@ import type { MakeResetStylesOptions } from './makeResetStyles.js';
 import type { CSSRulesByBucket, GriffelInsertionFactory } from './types.js';
 
 /**
- * @internal
+ * @private
  */
 export function __resetStyles(
   ltrClassName: string,

--- a/packages/core/src/__staticCSS.ts
+++ b/packages/core/src/__staticCSS.ts
@@ -1,7 +1,7 @@
 /**
  * A version of makeStaticStyles() that accepts build output as an input and skips all runtime transforms & DOM insertion.
  *
- * @internal
+ * @private
  */
 export function __staticCSS() {
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/core/src/__staticStyles.ts
+++ b/packages/core/src/__staticStyles.ts
@@ -5,7 +5,7 @@ import type { MakeStaticStylesOptions } from './makeStaticStyles.js';
 /**
  * A version of makeStaticStyles() that accepts build output as an input and skips all runtime transforms.
  *
- * @internal
+ * @private
  */
 export function __staticStyles(cssRules: CSSRulesByBucket, factory: GriffelInsertionFactory = insertionFactory) {
   const insertStyles = factory();

--- a/packages/core/src/__styles.ts
+++ b/packages/core/src/__styles.ts
@@ -7,7 +7,7 @@ import type { MakeStylesOptions } from './makeStyles.js';
 /**
  * A version of makeStyles() that accepts build output as an input and skips all runtime transforms.
  *
- * @internal
+ * @private
  */
 export function __styles<Slots extends string>(
   classesMapBySlot: CSSClassesMapBySlot<Slots>,

--- a/packages/react/src/__css.ts
+++ b/packages/react/src/__css.ts
@@ -8,7 +8,7 @@ import { useTextDirection } from './TextDirectionContext.js';
 /**
  * A version of makeStyles() that accepts build output as an input and skips all runtime transforms & DOM insertion.
  *
- * @internal
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __css<Slots extends string>(classesMapBySlot: CSSClassesMapBySlot<Slots>) {

--- a/packages/react/src/__resetCSS.ts
+++ b/packages/react/src/__resetCSS.ts
@@ -6,7 +6,7 @@ import { useTextDirection } from './TextDirectionContext.js';
 /**
  * A version of makeResetStyles() that accepts build output as an input and skips all runtime transforms & DOM insertion.
  *
- * @internal
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __resetCSS(ltrClassName: string, rtlClassName: string | null) {

--- a/packages/react/src/__resetStyles.ts
+++ b/packages/react/src/__resetStyles.ts
@@ -10,7 +10,7 @@ import { useTextDirection } from './TextDirectionContext.js';
 /**
  * A version of makeResetStyles() that accepts build output as an input and skips all runtime transforms.
  *
- * @internal
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __resetStyles(

--- a/packages/react/src/__staticCSS.ts
+++ b/packages/react/src/__staticCSS.ts
@@ -5,7 +5,7 @@ import { __staticCSS as vanillaStaticCSS } from '@griffel/core';
 /**
  * A version of makeStaticStyles() that accepts build output as an input and skips all runtime transforms & DOM insertion.
  *
- * @internal
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __staticCSS() {

--- a/packages/react/src/__staticStyles.ts
+++ b/packages/react/src/__staticStyles.ts
@@ -9,7 +9,7 @@ import { useRenderer } from './RendererContext.js';
 /**
  * A version of makeStaticStyles() that accepts build output as an input and skips all runtime transforms.
  *
- * @internal
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __staticStyles(cssRules: CSSRulesByBucket) {

--- a/packages/react/src/__styles.ts
+++ b/packages/react/src/__styles.ts
@@ -10,7 +10,7 @@ import { useTextDirection } from './TextDirectionContext.js';
 /**
  * A version of makeStyles() that accepts build output as an input and skips all runtime transforms.
  *
- * @internal
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __styles<Slots extends string>(


### PR DESCRIPTION
## Summary

Follow-up to #864. The previous PR tagged the babel-emitted helpers (`__css`, `__styles`, `__resetCSS`, `__resetStyles`, `__staticCSS`, `__staticStyles`) as `@internal`. Combined with `stripInternal: true`, TypeScript scrubbed them from the published `.d.ts` — but `index.ts` still re-exports them, so consumers see:

```
node_modules/@griffel/react/src/index.d.ts(9,10): error TS2305:
  Module '"./__css.js"' has no exported member '__css'.
... (same for __styles, __resetCSS, __resetStyles, __staticCSS, __staticStyles)
```

These helpers are runtime-public — `@griffel/babel-preset` rewrites user `makeStyles()` calls into `__styles(...)` calls, so the symbols must be visible in the published types.

## Fix

Switch the JSDoc tag from `@internal` to `@private` in both `@griffel/core` and `@griffel/react`. `@private` has no `tsc` semantic, so `stripInternal` ignores it — the exports survive while still signalling "don't use directly" to readers and IDEs.

The genuinely-internal helpers stay `@internal` and continue to collapse to `export {};` in the published types:

- `useInsertionEffect.d.ts`
- `utils/isInsideComponent.d.ts`
- `utils/canUseDOM.d.ts`

## Resulting `.d.ts`

```ts
// dist/packages/react/src/__css.d.ts (after)
export declare function __css<Slots extends string>(
  classesMapBySlot: CSSClassesMapBySlot<Slots>,
): () => Record<Slots, string>;
```

`index.d.ts` re-exports resolve cleanly. `useInsertionEffect.d.ts` etc. remain `export {};`.

## Test plan

- [x] `yarn nx run @griffel/react:build` passes
- [x] Inspected `dist/packages/{core,react}/src/__*.d.ts` — all six emit their `export declare function` signatures
- [x] Inspected `dist/packages/react/src/{useInsertionEffect,utils/isInsideComponent,utils/canUseDOM}.d.ts` — still `export {};`

🤖 Generated with [Claude Code](https://claude.com/claude-code)