### PR TITLE
chore(eslint): tighten rules and clean up redundant directives

### DIFF
--- a/change/@griffel-babel-preset-daf9331b-da80-46f2-b531-8337754303bf.json
+++ b/change/@griffel-babel-preset-daf9331b-da80-46f2-b531-8337754303bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-core-38c41ebd-4c0e-467d-b86d-c9a7e0b3c493.json
+++ b/change/@griffel-core-38c41ebd-4c0e-467d-b86d-c9a7e0b3c493.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-devtools-1eceaa14-88b1-4595-9795-fdfdc5132441.json
+++ b/change/@griffel-devtools-1eceaa14-88b1-4595-9795-fdfdc5132441.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/devtools",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-eslint-plugin-db09172d-560e-40c3-977b-7815ab9ba816.json
+++ b/change/@griffel-eslint-plugin-db09172d-560e-40c3-977b-7815ab9ba816.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-jest-serializer-163396e4-de7e-4377-98f7-39ab7b9b1fa2.json
+++ b/change/@griffel-jest-serializer-163396e4-de7e-4377-98f7-39ab7b9b1fa2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/jest-serializer",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-postcss-syntax-0b81faa6-7c12-498d-9a0b-f4b35797d6fa.json
+++ b/change/@griffel-postcss-syntax-0b81faa6-7c12-498d-9a0b-f4b35797d6fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/postcss-syntax",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-react-39666d4d-b58b-4221-8cd0-da7b3ce8a393.json
+++ b/change/@griffel-react-39666d4d-b58b-4221-8cd0-da7b3ce8a393.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-style-types-c78a4dce-30ef-41e0-9b72-ea902320dc04.json
+++ b/change/@griffel-style-types-c78a4dce-30ef-41e0-9b72-ea902320dc04.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/style-types",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-transform-6a41cb16-5d55-46a7-a311-376c93df5828.json
+++ b/change/@griffel-transform-6a41cb16-5d55-46a7-a311-376c93df5828.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/transform",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-transform-shaker-380fcebb-3c69-430d-a582-83c7cd090464.json
+++ b/change/@griffel-transform-shaker-380fcebb-3c69-430d-a582-83c7cd090464.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/transform-shaker",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-extraction-plugin-d2d47bc9-8219-49df-a4fa-97d75b843365.json
+++ b/change/@griffel-webpack-extraction-plugin-d2d47bc9-8219-49df-a4fa-97d75b843365.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-loader-24eeaf63-68fd-48d4-9176-787d56509f55.json
+++ b/change/@griffel-webpack-loader-24eeaf63-68fd-48d4-9176-787d56509f55.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@griffel-webpack-plugin-3a322c91-ba8b-46e6-803f-cb8cdb569abb.json
+++ b/change/@griffel-webpack-plugin-3a322c91-ba8b-46e6-803f-cb8cdb569abb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: tighten ESLint rules and clean up redundant directives",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist', '**/out-tsc', '**/node_modules', '**/__fixtures__/**', '**/vite.config.*.timestamp*', '**/vitest.config.*.timestamp*'],
+    ignores: ['**/dist', '**/out-tsc', '**/node_modules', '**/__fixtures__/**', '**/bundle-size/**', '**/vite.config.*.timestamp*', '**/vitest.config.*.timestamp*'],
   },
   ...compat.extends('plugin:import/typescript', 'plugin:storybook/recommended'),
   ...nx.configs['flat/base'],
@@ -43,6 +43,11 @@ export default [
           prefer: 'type-imports',
         },
       ],
+      '@typescript-eslint/naming-convention': [
+        'error',
+        { selector: 'function', format: ['camelCase', 'PascalCase'], leadingUnderscore: 'forbid' },
+        { selector: 'objectLiteralMethod', format: ['camelCase'] },
+      ],
       'import/no-extraneous-dependencies': [
         'error',
         {
@@ -50,6 +55,12 @@ export default [
         },
       ],
       'jest/no-focused-tests': 'error',
+      eqeqeq: 'error',
+      'guard-for-in': 'error',
+      'max-classes-per-file': 'error',
+      'no-cond-assign': ['error', 'always'],
+      'no-console': 'error',
+      'no-useless-concat': 'error',
     },
   },
   {
@@ -77,6 +88,7 @@ export default [
     rules: {
       '@typescript-eslint/no-inferrable-types': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-require-imports': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       'no-redeclare': 'off',
     },
@@ -108,8 +120,17 @@ export default [
   {
     files: ['**/*.test.ts', '**/*.test.tsx', '**/*.test.mts', '**/*.spec.ts', '**/*.spec.tsx'],
     rules: {
+      '@typescript-eslint/naming-convention': 'off',
       '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-require-imports': 'off',
       'import/first': 'off',
+      'no-console': 'off',
+    },
+  },
+  {
+    files: ['tools/**/*', 'e2e/**/*'],
+    rules: {
+      'no-console': 'off',
     },
   },
   {

--- a/packages/babel-preset/eslint.config.mjs
+++ b/packages/babel-preset/eslint.config.mjs
@@ -13,6 +13,12 @@ export default [
     },
   },
   {
+    files: ['**/transformPlugin.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
     files: ['**/*.ts', '**/*.tsx'],
     // Override or add rules here
     rules: {},

--- a/packages/babel-preset/jest.config.ts
+++ b/packages/babel-preset/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'babel-preset',
   preset: '../../jest.preset.js',

--- a/packages/babel-preset/src/assets/replaceAssetsWithImports.ts
+++ b/packages/babel-preset/src/assets/replaceAssetsWithImports.ts
@@ -67,6 +67,7 @@ export function replaceAssetsWithImports(
   traverse(
     pathToUpdate.node,
     {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       StringLiteral(literalPath) {
         const value = literalPath.node.value;
 

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -470,21 +470,18 @@ export const transformPlugin = declare<Partial<BabelPluginOptions>, PluginObj<Ba
         },
       },
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       ImportDeclaration(path, state) {
         if (hasMakeStylesImport(path, pluginOptions.modules)) {
           state.importDeclarationPaths!.push(path);
         }
       },
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       VariableDeclarator(path, state) {
         if (isRequireDeclarator(path, pluginOptions.modules)) {
           state.requireDeclarationPath = path;
         }
       },
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       CallExpression(path, state) {
         /**
          * Handles case when `makeStyles()` is `CallExpression`.
@@ -512,7 +509,6 @@ export const transformPlugin = declare<Partial<BabelPluginOptions>, PluginObj<Ba
         }
       },
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       MemberExpression(expressionPath, state) {
         /**
          * Handles case when `makeStyles()` is inside `MemberExpression`.

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -8,6 +8,12 @@ export default [
   ...nx.configs['flat/react'],
   ...baseConfig,
   {
+    files: ['**/__*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
     files: ['**/*.ts', '**/*.tsx'],
     // Override or add rules here
     rules: {},

--- a/packages/core/src/devtools/react-render-tracker/stackTrace.ts
+++ b/packages/core/src/devtools/react-render-tracker/stackTrace.ts
@@ -33,7 +33,7 @@ function parseChrome(line: string): LineParseResult {
   const isEval = loc && loc.indexOf('eval') === 0; // start of line
 
   const submatch = chromeEvalRe.exec(loc);
-  if (isEval && submatch != null) {
+  if (isEval && submatch !== null) {
     // throw out eval line/column and use top-most line/column number
     loc = submatch[1]; // url
   }
@@ -59,7 +59,7 @@ function parseGecko(line: string): LineParseResult {
   const isEval = loc && loc.indexOf(' > eval') > -1;
 
   const submatch = geckoEvalRe.exec(loc);
-  if (isEval && submatch != null) {
+  if (isEval && submatch !== null) {
     // throw out eval line/column and use top-most line number
     loc = submatch[1];
   }

--- a/packages/core/src/makeResetStyles.ts
+++ b/packages/core/src/makeResetStyles.ts
@@ -28,6 +28,7 @@ export function makeResetStyles(styles: GriffelResetStyle, factory: GriffelInser
       if (process.env.NODE_ENV !== 'production') {
         if (renderer.classNameHashSalt) {
           if (classNameHashSalt !== renderer.classNameHashSalt) {
+            // eslint-disable-next-line no-console
             console.error(
               [
                 '@griffel/core:',

--- a/packages/core/src/makeStyles.ts
+++ b/packages/core/src/makeStyles.ts
@@ -38,6 +38,7 @@ export function makeStyles<Slots extends string | number>(
       if (process.env.NODE_ENV !== 'production') {
         if (renderer.classNameHashSalt) {
           if (classNameHashSalt !== renderer.classNameHashSalt) {
+            // eslint-disable-next-line no-console
             console.error(
               [
                 '@griffel/core:',

--- a/packages/core/src/mergeClasses.test.ts
+++ b/packages/core/src/mergeClasses.test.ts
@@ -117,7 +117,6 @@ describe('mergeClasses', () => {
   });
 
   it('warns if an unregistered sequence was passed', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const error = vi.spyOn(console, 'error').mockImplementationOnce(() => {});
     const className = makeStyles({ root: { display: 'block' } })(options).root;
 
@@ -130,7 +129,6 @@ describe('mergeClasses', () => {
   });
 
   it('warns if strings are not properly merged', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const error = vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const className1 = makeStyles({ root: { display: 'block' } })(options).root;
@@ -144,7 +142,6 @@ describe('mergeClasses', () => {
   });
 
   it('warns if classes with different directions are passed', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const error = vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const ltrClassName = makeStyles({ root: { display: 'block' } })(options).root;
@@ -155,7 +152,6 @@ describe('mergeClasses', () => {
   });
 
   it('warns if contains multiple classes from makeResetStyles', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const error = vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const className1 = makeResetStyles({ display: 'block' })(options);

--- a/packages/core/src/renderer/createIsomorphicStyleSheet.ts
+++ b/packages/core/src/renderer/createIsomorphicStyleSheet.ts
@@ -14,6 +14,7 @@ export function createIsomorphicStyleSheet(
   elementAttributes[DATA_PRIORITY_ATTR] = String(priority);
 
   if (styleElement) {
+    // eslint-disable-next-line guard-for-in
     for (const attrName in elementAttributes) {
       styleElement.setAttribute(attrName, elementAttributes[attrName]);
     }

--- a/packages/core/src/renderer/rehydrateRendererCache.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.ts
@@ -43,6 +43,7 @@ export function rehydrateRendererCache(
       let textContent = styleElement.textContent!;
 
       if (regex) {
+        // eslint-disable-next-line no-cond-assign
         while ((match = regex.exec(textContent))) {
           const [cssRule] = match;
 
@@ -55,6 +56,7 @@ export function rehydrateRendererCache(
       } else {
         // @scope rules can appear in any bucket, so extract them first to prevent
         // STYLES_HYDRATOR from spuriously matching class selectors inside @scope blocks.
+        // eslint-disable-next-line no-cond-assign
         while ((match = SCOPE_HYDRATOR.exec(textContent))) {
           const [cssRule] = match;
 
@@ -66,6 +68,7 @@ export function rehydrateRendererCache(
           }
         }
 
+        // eslint-disable-next-line no-cond-assign
         while ((match = STYLES_HYDRATOR.exec(textContent))) {
           const [cssRule] = match;
 

--- a/packages/core/src/runtime/resolveResetStyleRules.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.ts
@@ -76,6 +76,7 @@ function createStringFromStyles(styles: GriffelResetStyle, isInsideScope = false
       // not animationName property but array in the value => fallback values
       if (value.length === 0) {
         if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
           console.warn(
             `makeResetStyles(): An empty array was passed as input to "${property}", the property will be omitted in the styles.`,
           );
@@ -88,6 +89,7 @@ function createStringFromStyles(styles: GriffelResetStyle, isInsideScope = false
 
       if (!rtlPropertyConsistent) {
         if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
           console.error(
             'makeStyles(): mixing CSS fallback values which result in multiple CSS properties in RTL is not supported.',
           );

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -16,7 +16,6 @@ describe('resolveStyleRules', () => {
   describe('unsupported css properties', () => {
     let consoleSpy: ReturnType<typeof vi.spyOn>;
     beforeAll(() => {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
@@ -222,7 +221,6 @@ describe('resolveStyleRules', () => {
     });
 
     it('handles empty array of fallback values', () => {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       const warn = vi.spyOn(console, 'warn').mockImplementationOnce(() => {});
 
       const actual = resolveStyleRules({ color: [] });
@@ -378,7 +376,6 @@ describe('resolveStyleRules', () => {
     });
 
     it('errors if fallback values result in multiple properties in RTL, skips the property', () => {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       const error = vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
       expect(

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -245,6 +245,7 @@ export function resolveStyleRules(
       // not animationName property but array in the value => fallback values
       if (value.length === 0) {
         if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
           console.warn(
             `makeStyles(): An empty array was passed as input to "${property}", the property will be omitted in the styles.`,
           );
@@ -278,6 +279,7 @@ export function resolveStyleRules(
 
       if (!rtlPropertyConsistent) {
         if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
           console.error(
             'makeStyles(): mixing CSS fallback values which result in multiple CSS properties in RTL is not supported.',
           );

--- a/packages/core/src/runtime/utils/isObject.ts
+++ b/packages/core/src/runtime/utils/isObject.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isObject(val: any): val is Record<string, unknown> {
+  // eslint-disable-next-line eqeqeq
   return val != null && typeof val === 'object' && Array.isArray(val) === false;
 }

--- a/packages/core/src/runtime/warnings/logError-node.test.ts
+++ b/packages/core/src/runtime/warnings/logError-node.test.ts
@@ -7,7 +7,6 @@ import { logError } from './logError.js';
 
 describe('logError', () => {
   it('does not log in Node', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     logError('An error occurred');

--- a/packages/core/src/runtime/warnings/logError.test.ts
+++ b/packages/core/src/runtime/warnings/logError.test.ts
@@ -3,7 +3,6 @@ import { logError } from './logError.js';
 
 describe('logError', () => {
   it('logs in browser env', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     logError('An error occurred');

--- a/packages/core/src/runtime/warnings/logError.ts
+++ b/packages/core/src/runtime/warnings/logError.ts
@@ -1,5 +1,6 @@
 export function logError(...args: unknown[]): void {
   if (process.env.NODE_ENV !== 'production' && typeof document !== 'undefined') {
+    // eslint-disable-next-line no-console
     console.error(...args);
   }
 }

--- a/packages/core/src/shorthands/flex.test.ts
+++ b/packages/core/src/shorthands/flex.test.ts
@@ -99,7 +99,6 @@ describe('flex', () => {
   });
 
   it('for incorrect input', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(flex('hello', 'oh', 'no')).toEqual({});

--- a/packages/core/src/shorthands/gridArea.test.ts
+++ b/packages/core/src/shorthands/gridArea.test.ts
@@ -208,7 +208,6 @@ describe('gridArea(rowStart, columnStart, rowEnd, columnEnd)', () => {
   });
 
   it('for css var reference', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(gridArea('header', 'header', 'var(--my-var)', 'header')).toEqual({});
@@ -217,7 +216,6 @@ describe('gridArea(rowStart, columnStart, rowEnd, columnEnd)', () => {
   });
 
   it('for css var reference within string', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(gridArea('header', 'header', 'header var(--my-var) header', 'header')).toEqual({});
@@ -226,7 +224,6 @@ describe('gridArea(rowStart, columnStart, rowEnd, columnEnd)', () => {
   });
 
   it('for empty css var reference', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(gridArea('header', 'header', 'var()', 'header')).toEqual({});

--- a/packages/devtools/eslint.config.mjs
+++ b/packages/devtools/eslint.config.mjs
@@ -10,6 +10,12 @@ export default [
   ...baseConfig,
   { languageOptions: { globals: { ...globals.webextensions } } },
   {
+    files: ['**/pack-extension.js'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
       'import/no-extraneous-dependencies': [

--- a/packages/devtools/src/sourceMap/loadOriginalSourceLoc.ts
+++ b/packages/devtools/src/sourceMap/loadOriginalSourceLoc.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import type { MappedPosition, RawSourceMap } from 'source-map-js';
 import { getFilePath, getOriginalPosition, resources } from './sourceMapConsumer';
 

--- a/packages/devtools/src/sourceMap/sourceMapConsumer.ts
+++ b/packages/devtools/src/sourceMap/sourceMapConsumer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { SourceMapConsumer } from 'source-map-js';
 import type { MappedPosition, RawSourceMap } from 'source-map-js';
 

--- a/packages/eslint-plugin/eslint.config.mjs
+++ b/packages/eslint-plugin/eslint.config.mjs
@@ -6,6 +6,12 @@ export default [
   },
   ...baseConfig,
   {
+    files: ['**/rules/**/*.ts', '**/utils/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
     files: ['**/*.ts', '**/*.tsx'],
     // Override or add rules here
     rules: {},

--- a/packages/eslint-plugin/src/rules/no-invalid-shorthand-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-shorthand-argument.ts
@@ -36,7 +36,7 @@ export const noInvalidShorthandArgumentRule = ESLintUtils.RuleCreator(getDocsUrl
           if (shorthandLiteral) {
             const autoFixArguments = shorthandToArguments(shorthandName, shorthandLiteral.value);
 
-            if (autoFixArguments != null && autoFixArguments.length > 1) {
+            if (autoFixArguments !== null && autoFixArguments !== undefined && autoFixArguments.length > 1) {
               context.report({
                 node,
                 messageId: 'invalidShorthandArgument',

--- a/packages/eslint-plugin/src/rules/no-shorthands.ts
+++ b/packages/eslint-plugin/src/rules/no-shorthands.ts
@@ -63,7 +63,7 @@ export const noShorthandsRule = ESLintUtils.RuleCreator(getDocsUrl)({
               let fix: TSESLint.ReportFixFunction | undefined;
               if (shorthandLiteral) {
                 const autoFixArguments = shorthandToArguments(shorthandProperty.name, shorthandLiteral.value);
-                if (autoFixArguments != null) {
+                if (autoFixArguments !== null && autoFixArguments !== undefined) {
                   fix = fixer => {
                     const args = joinShorthandArguments(autoFixArguments, shorthandLiteral.quote);
                     return fixer.replaceText(propertyNode, `...shorthands.${shorthandProperty.name}(${args})`);

--- a/packages/jest-serializer/jest.config.ts
+++ b/packages/jest-serializer/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'jest-serializer',
   preset: '../../jest.preset.js',

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -16,6 +16,7 @@ export function print(val: unknown) {
 
   let result: RegExpExecArray | null = null;
 
+  // eslint-disable-next-line no-cond-assign
   while ((result = regex.exec(_val))) {
     const [name] = result;
 

--- a/packages/postcss-syntax/jest.config.ts
+++ b/packages/postcss-syntax/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'eslint-plugin',
   preset: '../../jest.preset.js',

--- a/packages/postcss-syntax/src/location-preset.ts
+++ b/packages/postcss-syntax/src/location-preset.ts
@@ -78,6 +78,7 @@ const plugin = declare<LocationPluginOptions, PluginObj<LocationPluginState>>((a
         },
       },
 
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       CallExpression(path, state) {
         const callee = path.get('callee');
         const declarator = path.findParent(p => p.isVariableDeclarator());

--- a/packages/postcss-syntax/src/parse.ts
+++ b/packages/postcss-syntax/src/parse.ts
@@ -114,7 +114,9 @@ function parseGriffelStyles(
 
     return metadata;
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.warn('Failed to parse Griffel styles');
+    // eslint-disable-next-line no-console
     console.warn(error);
     if (silenceParseErrors) {
       return null;
@@ -125,12 +127,9 @@ function parseGriffelStyles(
 }
 
 function getIgnoredRulesFromDirectives(commentDirectives: CommentDirective[]) {
-  return (
-    commentDirectives
-      .filter(([directive]) => directive === 'griffel-csslint-disable')
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      .map(([_, rulename]) => rulename)
-  );
+  return commentDirectives
+    .filter(([directive]) => directive === 'griffel-csslint-disable')
+    .map(([_, rulename]) => rulename);
 }
 
 const extractGriffelBabelPluginOptions = (opts: ParserOptions = {}) => {

--- a/packages/react/eslint.config.mjs
+++ b/packages/react/eslint.config.mjs
@@ -10,6 +10,12 @@ export default [
   ...baseConfig,
   { plugins: { 'react-compiler': eslintPluginReactCompiler } },
   {
+    files: ['**/__*.ts', '**/__*.tsx'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
     rules: {
       'react-compiler/react-compiler': 'error',
     },

--- a/packages/react/src/__css.ts
+++ b/packages/react/src/__css.ts
@@ -10,7 +10,6 @@ import { useTextDirection } from './TextDirectionContext.js';
  *
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function __css<Slots extends string>(classesMapBySlot: CSSClassesMapBySlot<Slots>) {
   const getStyles = vanillaCSS(classesMapBySlot);
 

--- a/packages/react/src/__resetCSS.ts
+++ b/packages/react/src/__resetCSS.ts
@@ -8,7 +8,6 @@ import { useTextDirection } from './TextDirectionContext.js';
  *
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function __resetCSS(ltrClassName: string, rtlClassName: string | null) {
   const getStyles = vanillaResetCSS(ltrClassName, rtlClassName);
 

--- a/packages/react/src/__resetStyles.ts
+++ b/packages/react/src/__resetStyles.ts
@@ -12,7 +12,6 @@ import { useTextDirection } from './TextDirectionContext.js';
  *
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function __resetStyles(
   ltrClassName: string,
   rtlClassName: string | null,

--- a/packages/react/src/__staticCSS.ts
+++ b/packages/react/src/__staticCSS.ts
@@ -7,7 +7,6 @@ import { __staticCSS as vanillaStaticCSS } from '@griffel/core';
  *
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function __staticCSS() {
   const getStyles = vanillaStaticCSS();
 

--- a/packages/react/src/__staticStyles.ts
+++ b/packages/react/src/__staticStyles.ts
@@ -11,7 +11,6 @@ import { useRenderer } from './RendererContext.js';
  *
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function __staticStyles(cssRules: CSSRulesByBucket) {
   const getStyles = vanillaStaticStyles(cssRules, insertionFactory);
 

--- a/packages/react/src/__styles.ts
+++ b/packages/react/src/__styles.ts
@@ -12,7 +12,6 @@ import { useTextDirection } from './TextDirectionContext.js';
  *
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function __styles<Slots extends string>(
   classesMapBySlot: CSSClassesMapBySlot<Slots>,
   cssRules: CSSRulesByBucket,

--- a/packages/react/src/makeResetStyles.test.tsx
+++ b/packages/react/src/makeResetStyles.test.tsx
@@ -11,7 +11,6 @@ describe('makeResetStyles', () => {
   });
 
   it('throws inside React components', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const Example: React.FC = () => {

--- a/packages/react/src/makeStyles.test.tsx
+++ b/packages/react/src/makeStyles.test.tsx
@@ -11,7 +11,6 @@ describe('makeStyles', () => {
   });
 
   it('throws inside React components', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const Example: React.FC = () => {

--- a/packages/react/src/stories/DOMRendererFilter.stories.tsx
+++ b/packages/react/src/stories/DOMRendererFilter.stories.tsx
@@ -28,6 +28,7 @@ const CustomRendererProvider: React.FC<{ children: React.ReactNode; filterEnable
 }) => {
   const customDOMRenderer = React.useMemo(() => {
     return createDOMRenderer(undefined, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       unstable_filterCSSRule: cssRule => {
         // Filter out background-color
         return !filterEnabled || cssRule.indexOf('{background-color:') === -1;

--- a/packages/style-types/jest.config.ts
+++ b/packages/style-types/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'style-types',
   preset: '../../jest.preset.js',

--- a/packages/transform-shaker/eslint.config.mjs
+++ b/packages/transform-shaker/eslint.config.mjs
@@ -12,6 +12,12 @@ export default [
     },
   },
   {
+    files: ['**/graphBuilder.ts', '**/Visitors.ts', '**/langs/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
     files: ['**/*.ts', '**/*.tsx'],
     // Override or add rules here
     rules: {},

--- a/packages/transform-shaker/src/scope.ts
+++ b/packages/transform-shaker/src/scope.ts
@@ -84,7 +84,6 @@ export default class ScopeManager {
     this.declare(ScopeManager.globalModuleIdentifier, false);
   }
 
-  // eslint-disable-next-line no-plusplus
   new(isFunction: boolean, scopeId: ScopeId = this.nextId++): Scope {
     const scope: Scope = new Map();
     if (isFunction) {

--- a/packages/transform-shaker/src/shaker.ts
+++ b/packages/transform-shaker/src/shaker.ts
@@ -125,7 +125,7 @@ function removeDeadCode(node: Node, alive: Set<Node>, s: MagicString, sourceCode
     const subNode = (node as any)[key];
 
     if (Array.isArray(subNode)) {
-      const elements = subNode.filter((el: unknown): el is Node => el != null && isNode(el));
+      const elements = subNode.filter((el: unknown): el is Node => el !== null && el !== undefined && isNode(el));
       if (elements.length === 0) continue;
 
       const hasDeadElements = elements.some(el => !alive.has(el));

--- a/packages/transform/src/evaluation/module.mts
+++ b/packages/transform/src/evaluation/module.mts
@@ -37,7 +37,7 @@ const NOOP = () => { /* noop */ };
 
 /** Checks if a value is an Error-like object (works across VM contexts where `instanceof Error` fails). */
 function isError(e: unknown): e is Error {
-  return e != null && typeof e === 'object' && 'message' in e && 'stack' in e;
+  return e !== null && e !== undefined && typeof e === 'object' && 'message' in e && 'stack' in e;
 }
 
 const createCustomDebug =

--- a/packages/transform/src/transformSync.mts
+++ b/packages/transform/src/transformSync.mts
@@ -156,6 +156,7 @@ function buildCSSEntriesMetadata(
 }
 
 function concatCSSRulesByBucket(bucketA: CSSRulesByBucket = {}, bucketB: CSSRulesByBucket) {
+  // eslint-disable-next-line guard-for-in
   for (const cssBucketName in bucketB) {
     const bucketName = cssBucketName as keyof CSSRulesByBucket;
     const bucketBEntries = bucketB[bucketName] ?? [];

--- a/packages/transform/src/transformSync.test.mts
+++ b/packages/transform/src/transformSync.test.mts
@@ -98,6 +98,7 @@ function normalizeAssetOutputs(
   const hashes: string[] = [];
   let match;
 
+  // eslint-disable-next-line no-cond-assign
   while ((match = hashRegex.exec(normalizedMeta)) !== null) {
     if (!hashes.includes(match[1])) {
       hashes.push(match[1]);
@@ -249,7 +250,6 @@ const TESTS: TestCase[] = [
     fixture: path.resolve(fixturesDir, 'config-evaluation-rules', 'code.ts'),
     outputFixture: path.resolve(fixturesDir, 'config-evaluation-rules', 'output.ts'),
     transformOptions: {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       evaluationRules: [{ action: require(path.resolve(fixturesDir, 'config-evaluation-rules', 'sampleEvaluator.cjs')).default }],
     },
   },

--- a/packages/webpack-extraction-plugin/jest.config.ts
+++ b/packages/webpack-extraction-plugin/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'webpack-extraction-plugin',
   preset: '../../jest.preset.js',

--- a/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/babelPluginStripGriffelRuntime.ts
@@ -114,6 +114,7 @@ function inlineAssetImports(argumentPath: NodePath<t.ObjectExpression> | NodePat
   const importsToRemove = new Set<NodePath<t.ImportDeclaration>>();
 
   argumentPath.traverse({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     TemplateLiteral(literalPath) {
       const expressionPaths = literalPath.get('expressions');
 
@@ -226,6 +227,7 @@ export const babelPluginStripGriffelRuntime = declare<
 
         exit(programPath, state) {
           programPath.traverse({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             ImportSpecifier(path) {
               const importedPath = path.get('imported');
 

--- a/packages/webpack-extraction-plugin/src/getBundlerRuntime.ts
+++ b/packages/webpack-extraction-plugin/src/getBundlerRuntime.ts
@@ -9,7 +9,7 @@ let bundlerRuntime: BundlerRuntime | null = null;
 
 export function getBundlerRuntime(type: 'webpack' | 'rspack'): BundlerRuntime {
   if (bundlerRuntime === null) {
-    // eslint-disable-next-line import/no-extraneous-dependencies
+    // eslint-disable-next-line import/no-extraneous-dependencies, @typescript-eslint/no-require-imports
     bundlerRuntime = type === 'webpack' ? require('webpack') : require('@rspack/core');
   }
 

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -13,6 +13,7 @@ export function getUniqueRulesFromSets(setOfCSSRules: CSSRulesByBucket[]): RuleE
   const uniqueCSSRules = new Map<string, RuleEntry>();
 
   for (const cssRulesByBucket of setOfCSSRules) {
+    // eslint-disable-next-line guard-for-in
     for (const _styleBucketName in cssRulesByBucket) {
       const styleBucketName = _styleBucketName as StyleBucketName;
 

--- a/packages/webpack-loader/jest.config.ts
+++ b/packages/webpack-loader/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'webpack-loader',
   preset: '../../jest.preset.js',

--- a/packages/webpack-plugin/src/GriffelPlugin.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.mts
@@ -340,6 +340,7 @@ export class GriffelPlugin {
             const fileCount = entries.length;
             const avgTime = fileCount > 0 ? totalTime / BigInt(fileCount) : 0n;
 
+            /* eslint-disable no-console */
             console.log('\nGriffel CSS extraction stats:');
 
             console.log('------------------------------------');
@@ -357,6 +358,7 @@ export class GriffelPlugin {
             }
 
             console.log();
+            /* eslint-enable no-console */
           }
 
           if (this.#collectPerfIssues && this.#perfIssues.size > 0) {
@@ -364,6 +366,7 @@ export class GriffelPlugin {
             const cjsCount = issues.filter(i => i.type === 'cjs-module').length;
             const barrelCount = issues.filter(i => i.type === 'barrel-export-star').length;
 
+            /* eslint-disable no-console */
             console.log('\nGriffel performance issues:');
             console.log('------------------------------------');
             console.log(`CJS modules (no tree-shaking): ${cjsCount}`);
@@ -377,6 +380,7 @@ export class GriffelPlugin {
             }
 
             console.log();
+            /* eslint-enable no-console */
           }
         },
       );

--- a/packages/webpack-plugin/src/GriffelPlugin.test.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.test.mts
@@ -205,6 +205,7 @@ function normalizeGriffelHashes(str: string): string {
   const hashes: string[] = [];
   let match;
 
+  // eslint-disable-next-line no-cond-assign
   while ((match = hashRegex.exec(str)) !== null) {
     if (!hashes.includes(match[1])) {
       hashes.push(match[1]);

--- a/packages/webpack-plugin/src/utils/resolveAssetPaths.mts
+++ b/packages/webpack-plugin/src/utils/resolveAssetPaths.mts
@@ -56,6 +56,7 @@ export function resolveAssetPathsInCSSRules(cssRulesByBucket: CSSRulesByBucket, 
   const sourceDir = path.dirname(sourceFile);
   const resolved: CSSRulesByBucket = {};
 
+  // eslint-disable-next-line guard-for-in
   for (const bucketName in cssRulesByBucket) {
     const entries = cssRulesByBucket[bucketName as StyleBucketName]!;
     resolved[bucketName as StyleBucketName] = entries.map(entry => resolveEntry(entry, sourceDir));

--- a/packages/webpack-plugin/src/utils/sortCSSRules.mts
+++ b/packages/webpack-plugin/src/utils/sortCSSRules.mts
@@ -18,6 +18,7 @@ export function getUniqueRulesFromSets(setOfCSSRules: CSSRulesByBucket[]): RuleE
   const uniqueCSSRules = new Map<string, RuleEntry>();
 
   for (const cssRulesByBucket of setOfCSSRules) {
+    // eslint-disable-next-line guard-for-in
     for (const _styleBucketName in cssRulesByBucket) {
       const styleBucketName = _styleBucketName as StyleBucketName;
 


### PR DESCRIPTION
## Summary

Enables a small set of stricter ESLint rules across the monorepo and adds per-package overrides + inline disables where the rule genuinely needs to be bypassed.

### Newly enabled rules
- `@typescript-eslint/naming-convention` (scoped to `function` + `objectLiteralMethod`)
- `@typescript-eslint/no-require-imports`
- `eqeqeq`
- `guard-for-in`
- `max-classes-per-file`
- `no-cond-assign` (`always`)
- `no-console`
- `no-useless-concat`

### Per-package adjustments
- `__*.ts(x)` files (`@griffel/core`, `@griffel/react`) and visitor-style files (`@griffel/babel-preset/transformPlugin.ts`, `@griffel/eslint-plugin/rules`/`utils`, `@griffel/transform-shaker/{graphBuilder,Visitors,langs/**}`) disable `naming-convention` because they intentionally use PascalCase visitor keys.
- Tests disable `naming-convention`, `no-empty-function`, `no-require-imports`, and `no-console`.
- `tools/**` and `e2e/**` disable `no-console`.
- Root config now also ignores `**/bundle-size/**` (the size fixtures intentionally `console.log`).

### Code-level adjustments
- Inline `eslint-disable` directives added where rules genuinely need to be bypassed (intentional warnings/errors, hidden iteration counters, regex `match = exec(...)` loops, dynamic `require()` for webpack/rspack split).
- `!= null` → `!== null && !== undefined` in `@griffel/eslint-plugin` (`no-invalid-shorthand-argument`, `no-shorthands`).
- Cleaned up redundant `@typescript-eslint/no-empty-function` disables that the new test override makes unnecessary.

This is one of three follow-ups split out from #872; the dependency bumps and the `eslint-plugin-import-x` migration land separately.

## Test plan
- [x] `nx run-many --target=lint --all` (15 projects) — clean
- [x] `nx run-many --target=type-check --all` (20 projects) — clean
- [x] `nx run-many --target=test --all` (18 projects) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)