### PR TITLE
chore: ignore .claude/ and .vitest-attachments/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,10 @@ Thumbs.db
 
 vite.config.*.timestamp*
 vitest.config.*.timestamp*
-.claude/worktrees
-.claude/settings.local.json
+.claude/
 
 # Vitest browser-mode failure captures
 **/__screenshots__/
+**/.vitest-attachments/
 .nx/polygraph
 .nx/self-healing


### PR DESCRIPTION
## Summary

- Replace the per-file `.claude/worktrees` and `.claude/settings.local.json` entries with a blanket `.claude/` ignore — covers all Claude Code local state.
- Add `**/.vitest-attachments/` to ignore vitest browser-mode attachments that get written next to vitest configs during test runs.

## Test plan
- [x] `git status` clean after deleting both directories from the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)