### PR TITLE
fix(core): route dev-only console errors through logError

### DIFF
--- a/packages/core/src/makeResetStyles.ts
+++ b/packages/core/src/makeResetStyles.ts
@@ -3,6 +3,7 @@ import type { GriffelResetStyle } from '@griffel/style-types';
 import { DEBUG_RESET_CLASSES } from './constants.js';
 import { insertionFactory } from './insertionFactory.js';
 import { resolveResetStyleRules } from './runtime/resolveResetStyleRules.js';
+import { logError } from './runtime/warnings/logError.js';
 import type { CSSRulesByBucket, GriffelRenderer, GriffelInsertionFactory } from './types.js';
 
 export interface MakeResetStylesOptions {
@@ -28,8 +29,7 @@ export function makeResetStyles(styles: GriffelResetStyle, factory: GriffelInser
       if (process.env.NODE_ENV !== 'production') {
         if (renderer.classNameHashSalt) {
           if (classNameHashSalt !== renderer.classNameHashSalt) {
-            // eslint-disable-next-line no-console
-            console.error(
+            logError(
               [
                 '@griffel/core:',
                 '\n\n',

--- a/packages/core/src/makeStyles.ts
+++ b/packages/core/src/makeStyles.ts
@@ -2,6 +2,7 @@ import { debugData, isDevToolsEnabled, getSourceURLfromError } from './devtools/
 import { insertionFactory } from './insertionFactory.js';
 import { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots.js';
 import { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots.js';
+import { logError } from './runtime/warnings/logError.js';
 import type { CSSClassesMapBySlot, CSSRulesByBucket, GriffelRenderer, StylesBySlots } from './types.js';
 import type { GriffelInsertionFactory } from './types.js';
 
@@ -38,8 +39,7 @@ export function makeStyles<Slots extends string | number>(
       if (process.env.NODE_ENV !== 'production') {
         if (renderer.classNameHashSalt) {
           if (classNameHashSalt !== renderer.classNameHashSalt) {
-            // eslint-disable-next-line no-console
-            console.error(
+            logError(
               [
                 '@griffel/core:',
                 '\n\n',

--- a/packages/core/src/mergeClasses.ts
+++ b/packages/core/src/mergeClasses.ts
@@ -9,6 +9,7 @@ import {
 } from './constants.js';
 import { hashSequence } from './runtime/utils/hashSequence.js';
 import { reduceToClassName } from './runtime/reduceToClassNameForSlots.js';
+import { logError } from './runtime/warnings/logError.js';
 import type { CSSClassesMap, SequenceHash } from './types.js';
 
 // Contains a mapping of previously resolved sequences of atomic classnames
@@ -60,8 +61,7 @@ export function mergeClasses(): string {
           className.split(' ').forEach(entry => {
             if (entry.startsWith(RESET_HASH_PREFIX) && DEBUG_RESET_CLASSES[entry]) {
               if (containsResetClassName) {
-                // eslint-disable-next-line no-console
-                console.error(
+                logError(
                   'mergeClasses(): a passed string contains multiple classes produced by makeResetStyles (' +
                     `${className} & ${resultClassName}, this will lead to non-deterministic behavior. Learn more:` +
                     'https://griffel.js.org/react/api/make-reset-styles#limitations' +
@@ -90,8 +90,7 @@ export function mergeClasses(): string {
 
       if (process.env.NODE_ENV !== 'production') {
         if (className.indexOf(SEQUENCE_PREFIX, sequenceIndex + 1) !== -1) {
-          // eslint-disable-next-line no-console
-          console.error(
+          logError(
             'mergeClasses(): a passed string contains multiple identifiers of atomic classes (classes that start ' +
               `with "${SEQUENCE_PREFIX}"), it's possible that passed classes were concatenated in a wrong way. ` +
               `Source string: ${className}`,
@@ -128,8 +127,7 @@ export function mergeClasses(): string {
 
         if (process.env.NODE_ENV !== 'production') {
           if (dir !== null && dir !== sequenceMapping[LOOKUP_DIR_INDEX]) {
-            // eslint-disable-next-line no-console
-            console.error(
+            logError(
               `mergeClasses(): a passed string contains an identifier (${sequenceId}) that has different direction ` +
                 `(dir="${sequenceMapping[1] ? 'rtl' : 'ltr'}") setting than other classes. This is not supported. ` +
                 `Source string: ${arguments[i]}`,
@@ -139,13 +137,10 @@ export function mergeClasses(): string {
 
         dir = sequenceMapping[LOOKUP_DIR_INDEX];
       } else {
-        if (process.env.NODE_ENV !== 'production') {
-          // eslint-disable-next-line no-console
-          console.error(
-            `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry ` +
-              `in cache. Source string: ${arguments[i]}`,
-          );
-        }
+        logError(
+          `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry ` +
+            `in cache. Source string: ${arguments[i]}`,
+        );
       }
     }
   }

--- a/packages/core/src/runtime/resolveResetStyleRules.ts
+++ b/packages/core/src/runtime/resolveResetStyleRules.ts
@@ -75,12 +75,9 @@ function createStringFromStyles(styles: GriffelResetStyle, isInsideScope = false
     if (Array.isArray(value)) {
       // not animationName property but array in the value => fallback values
       if (value.length === 0) {
-        if (process.env.NODE_ENV !== 'production') {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `makeResetStyles(): An empty array was passed as input to "${property}", the property will be omitted in the styles.`,
-          );
-        }
+        logError(
+          `makeResetStyles(): An empty array was passed as input to "${property}", the property will be omitted in the styles.`,
+        );
         continue;
       }
 
@@ -88,12 +85,9 @@ function createStringFromStyles(styles: GriffelResetStyle, isInsideScope = false
       const rtlPropertyConsistent = !rtlDefinitions.some(v => v.key !== rtlDefinitions[0].key);
 
       if (!rtlPropertyConsistent) {
-        if (process.env.NODE_ENV !== 'production') {
-          // eslint-disable-next-line no-console
-          console.error(
-            'makeStyles(): mixing CSS fallback values which result in multiple CSS properties in RTL is not supported.',
-          );
-        }
+        logError(
+          'makeStyles(): mixing CSS fallback values which result in multiple CSS properties in RTL is not supported.',
+        );
         continue;
       }
 

--- a/packages/core/src/runtime/resolveStyleRules.test.ts
+++ b/packages/core/src/runtime/resolveStyleRules.test.ts
@@ -221,12 +221,12 @@ describe('resolveStyleRules', () => {
     });
 
     it('handles empty array of fallback values', () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementationOnce(() => {});
+      const error = vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
       const actual = resolveStyleRules({ color: [] });
       expect(actual).toMatchInlineSnapshot(``); /* empty result */
 
-      expect(warn).toHaveBeenCalledWith(
+      expect(error).toHaveBeenCalledWith(
         expect.stringMatching(
           /makeStyles\(\): An empty array was passed as input to "color", the property will be omitted in the styles./,
         ),

--- a/packages/core/src/runtime/resolveStyleRules.ts
+++ b/packages/core/src/runtime/resolveStyleRules.ts
@@ -244,12 +244,9 @@ export function resolveStyleRules(
     } else if (Array.isArray(value)) {
       // not animationName property but array in the value => fallback values
       if (value.length === 0) {
-        if (process.env.NODE_ENV !== 'production') {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `makeStyles(): An empty array was passed as input to "${property}", the property will be omitted in the styles.`,
-          );
-        }
+        logError(
+          `makeStyles(): An empty array was passed as input to "${property}", the property will be omitted in the styles.`,
+        );
         continue;
       }
 
@@ -278,12 +275,9 @@ export function resolveStyleRules(
       const rtlPropertyConsistent = !rtlDefinitions.some(v => v.key !== rtlDefinitions[0].key);
 
       if (!rtlPropertyConsistent) {
-        if (process.env.NODE_ENV !== 'production') {
-          // eslint-disable-next-line no-console
-          console.error(
-            'makeStyles(): mixing CSS fallback values which result in multiple CSS properties in RTL is not supported.',
-          );
-        }
+        logError(
+          'makeStyles(): mixing CSS fallback values which result in multiple CSS properties in RTL is not supported.',
+        );
         continue;
       }
 

--- a/packages/core/src/shorthands/flex.ts
+++ b/packages/core/src/shorthands/flex.ts
@@ -1,6 +1,7 @@
 import type * as CSS from 'csstype';
 
 import type { GriffelStyle } from '@griffel/style-types';
+import { logError } from '../runtime/warnings/logError.js';
 import type { FlexInput } from './types.js';
 
 type FlexStyle = Pick<GriffelStyle, 'flexGrow' | 'flexShrink' | 'flexBasis'>;
@@ -113,11 +114,8 @@ export function flex(...values: FlexInput): FlexStyle {
     }
   }
 
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line no-console
-    console.error(
-      `The value passed to shorthands.flex did not match any flex property specs. The CSS styles were not generated. Please, check the flex documentation.`,
-    );
-  }
+  logError(
+    `The value passed to shorthands.flex did not match any flex property specs. The CSS styles were not generated. Please, check the flex documentation.`,
+  );
   return {} as FlexStyle;
 }

--- a/packages/core/src/shorthands/gridArea.ts
+++ b/packages/core/src/shorthands/gridArea.ts
@@ -1,4 +1,5 @@
 import type { GriffelStyle } from '@griffel/style-types';
+import { logError } from '../runtime/warnings/logError.js';
 import type { GridAreaInput } from './types.js';
 
 type GridAreaStyle = Pick<GriffelStyle, 'gridRowStart' | 'gridRowEnd' | 'gridColumnStart' | 'gridColumnEnd'>;
@@ -50,19 +51,16 @@ export function gridArea(
 export function gridArea(...values: GridAreaInput[]): GridAreaStyle {
   // if any value is not valid, then do not apply the CSS.
   if (values.some(value => !isValidGridAreaInput(value))) {
-    if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
-      console.error(
-        `The value passed to shorthands.gridArea() did not match any gridArea property specs. The CSS styles were not generated. Please, check the gridArea documentation.`,
-        [
-          'The value passed to shorthands.gridArea() did not match any gridArea property specs. ',
-          'The CSS styles were not generated.\n',
-          'Please, check the `grid-area` documentation:\n',
-          '- https://developer.mozilla.org/docs/Web/CSS/grid-area',
-          '- https://griffel.js.org/react/api/shorthands#shorthandsgridarea',
-        ].join(''),
-      );
-    }
+    logError(
+      `The value passed to shorthands.gridArea() did not match any gridArea property specs. The CSS styles were not generated. Please, check the gridArea documentation.`,
+      [
+        'The value passed to shorthands.gridArea() did not match any gridArea property specs. ',
+        'The CSS styles were not generated.\n',
+        'Please, check the `grid-area` documentation:\n',
+        '- https://developer.mozilla.org/docs/Web/CSS/grid-area',
+        '- https://griffel.js.org/react/api/shorthands#shorthandsgridarea',
+      ].join(''),
+    );
 
     return {} as GridAreaStyle;
   }


### PR DESCRIPTION
## Summary

Switches direct `console.error` / `console.warn` calls in `@griffel/core` to the `logError` helper, which already gates on `NODE_ENV !== 'production'` **and** `typeof document !== 'undefined'`. Net effect: SSR and production bundles stay quiet, dev still gets the warnings.

### Migrated callsites
- `makeStyles.ts:42`, `makeResetStyles.ts:32` — classNameHashSalt mismatch warning
- `mergeClasses.ts:64, 94, 132, 144` — reset-class collision, multiple sequence prefixes, RTL direction mix, missing definition lookup
- `runtime/resolveStyleRules.ts:249, 283` — empty fallback array, RTL fallback inconsistency
- `runtime/resolveResetStyleRules.ts:80, 93` — same as above for reset rules
- `shorthands/flex.ts:118`, `shorthands/gridArea.ts:55` — invalid input warnings

### Kept as `console.error`
- `renderer/safeInsertRule.ts:26` — insertion failures should still log in production where users may need to debug live issues.

### Env-check cleanup
Removes redundant `if (process.env.NODE_ENV !== 'production')` wrappers around plain `logError(...)` calls — `logError` already gates internally. Wrappers are kept where they gate adjacent dev-only work (RTL-mix path in `mergeClasses`, classNameHashSalt assignment in `makeStyles`/`makeResetStyles`, the `.split().forEach()` reset-class scan in `mergeClasses`).

### Test changes
`resolveStyleRules.test.ts` was spying on `console.warn` for the empty-array case; switched to `console.error` to match `logError`'s sink.

## Test plan
- [x] `nx run-many --target=lint --all` — clean
- [x] `nx run-many --target=type-check --all` — clean
- [x] `nx run-many --target=test --all` — passes (513 core tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)