### PR TITLE
fix(webpack-extraction-plugin): rspack support — skip cacheGroup + file-based CSS transport

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-460d5734-7faf-4eb7-9069-43390beaad21.json
+++ b/change/@griffel-webpack-extraction-plugin-460d5734-7faf-4eb7-9069-43390beaad21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(webpack-extraction-plugin): rspack support — skip Griffel splitChunks cacheGroup on rspack (CssExtractRspackPlugin does not emit CSS for renamed chunks) and switch the rspack loader's CSS transport from inline ?style= (exceeds Linux PATH_MAX on large styles files) to a content-hashed tempfile via ?file=.",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "brunoru@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -150,14 +150,21 @@ export class GriffelCSSExtractionPlugin {
     // WHY?
     //  We need to sort CSS rules in the same order as it's done via style buckets. It's not possible in multiple
     //  chunks.
-    if (compiler.options.optimization.splitChunks) {
+    // @ Rspack compat:
+    //  Tested with rspack 1.7.6 + CssExtractRspackPlugin: when the cacheGroup test matches Griffel CSS modules
+    //  (either via the function form `isGriffelCSSModule` or the regex form `/griffel\.css/`), the resulting
+    //  `griffel` chunk is named with the JS chunk filename template (`griffel-<hash>.js`) and
+    //  CssExtractRspackPlugin does NOT emit a corresponding `griffel-<hash>.css`. Net effect: all matched
+    //  Griffel CSS modules are routed into a chunk whose CSS output is never emitted, dropping ~10 MB of CSS
+    //  silently and leaving the app shell unstyled. Until rspack/CssExtractRspackPlugin handles
+    //  renamed/merged CSS chunks the way webpack/MiniCssExtractPlugin does, the safest behavior on rspack is
+    //  to SKIP registering the cacheGroup entirely — per-source-file CSS files remain intact, and the CSS
+    //  rule sort-order optimization (which only runs against the merged `griffel.css` asset) is forgone.
+    if (!IS_RSPACK && compiler.options.optimization.splitChunks) {
       compiler.options.optimization.splitChunks.cacheGroups ??= {};
       compiler.options.optimization.splitChunks.cacheGroups['griffel'] = {
         name: 'griffel',
-        // @ Rspack compat:
-        // Rspack does not support functions in test due performance concerns
-        // https://github.com/web-infra-dev/rspack/issues/3425#issuecomment-1577890202
-        test: IS_RSPACK ? /griffel\.css/ : isGriffelCSSModule,
+        test: isGriffelCSSModule,
         chunks: 'all',
         enforce: true,
       };

--- a/packages/webpack-extraction-plugin/src/webpackLoader.ts
+++ b/packages/webpack-extraction-plugin/src/webpackLoader.ts
@@ -1,3 +1,6 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type * as webpack from 'webpack';
 
@@ -26,10 +29,44 @@ export type WebpackLoaderOptions = {
 type WebpackLoaderParams = Parameters<webpack.LoaderDefinitionFunction<WebpackLoaderOptions>>;
 
 const virtualLoaderPath = path.resolve(__dirname, '..', 'virtual-loader', 'index.js');
-const virtualCSSFilePath = path.resolve(__dirname, '..', 'virtual-loader', 'griffel.css');
 
 const SALT_SEARCH_STRING = '/*@griffel:classNameHashSalt "';
 const SALT_SEARCH_STRING_LENGTH = SALT_SEARCH_STRING.length;
+
+// File-based transport for Griffel-extracted CSS on rspack. Writes the CSS to a content-hashed tempfile and
+// references it via `?file=<encoded path>` on the loader request. Replaces the prior `?style=<url-encoded css>`
+// inline transport, which produced loader request strings that exceeded the Linux PATH_MAX limit (4096 bytes)
+// for large `.styles.ts` files and broke BuildXL pip access tracking on Linux CI.
+//
+// The tempfile is content-addressed (sha1 of CSS payload) so identical CSS from two loader invocations resolves
+// to the same path. Writes go through a staging file + atomic rename to avoid partial reads under concurrent
+// loader invocations.
+const griffelCssTmpDir = path.join(os.tmpdir(), 'griffel-css-cache');
+
+function writeCssToTempFile(css: string): string {
+  if (!fs.existsSync(griffelCssTmpDir)) {
+    fs.mkdirSync(griffelCssTmpDir, { recursive: true });
+  }
+
+  const hash = crypto.createHash('sha1').update(css).digest('hex');
+  const tmpFile = path.join(griffelCssTmpDir, `${hash}.css`);
+
+  if (!fs.existsSync(tmpFile)) {
+    const stagingFile = `${tmpFile}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(stagingFile, css);
+    try {
+      fs.renameSync(stagingFile, tmpFile);
+    } catch {
+      try {
+        fs.unlinkSync(stagingFile);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return tmpFile;
+}
 
 /**
  * Webpack can also pass sourcemaps as a string or null, Babel accepts only objects, boolean and undefined.
@@ -49,10 +86,6 @@ function parseSourceMap(inputSourceMap: WebpackLoaderParams[1]): TransformOption
   } catch {
     return undefined;
   }
-}
-
-function toURIComponent(rule: string): string {
-  return encodeURIComponent(rule).replace(/!/g, '%21');
 }
 
 export function validateHashSalt(sourceCode: string, classNameHashSalt: string) {
@@ -141,7 +174,17 @@ function webpackLoader(
       }
 
       if (IS_RSPACK) {
-        const request = `griffel.css!=!${virtualLoaderPath}!${virtualCSSFilePath}?style=${toURIComponent(css)}`;
+        // Use the source file as the loader-request resource (instead of `virtual-loader/griffel.css`) so that
+        // css-loader resolves `url()` references relative to the source file's directory rather than to
+        // `node_modules/@griffel/webpack-extraction-plugin/virtual-loader/`. The virtual loader reads the actual
+        // CSS payload from the file at `?file=<encoded path>` in the query string — keeping the loader
+        // request length bounded and avoiding the Linux PATH_MAX (4096-byte) limit that the previous inline
+        // `?style=<url-encoded css>` transport hit on BuildXL CI for large `.styles.ts` files.
+        const outputFileName = this.resourcePath.replace(/\.[^.]+$/, '.griffel.css');
+        const tmpFile = writeCssToTempFile(css);
+        const request = `${outputFileName}!=!${virtualLoaderPath}!${this.resourcePath}?file=${encodeURIComponent(
+          tmpFile,
+        )}`;
         const stringifiedRequest = JSON.stringify(this.utils.contextify(this.context || this.rootContext, request));
 
         this.callback(null, `${resultCode}\n\nimport ${stringifiedRequest};`, resultSourceMap);

--- a/packages/webpack-extraction-plugin/virtual-loader/index.js
+++ b/packages/webpack-extraction-plugin/virtual-loader/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const { URLSearchParams } = require('url');
 const { GriffelCssLoaderContextKey } = require('../src/constants');
 
@@ -11,6 +12,16 @@ function virtualLoader() {
   }
 
   const query = new URLSearchParams(this.resourceQuery);
+
+  // Prefer the file-based transport (`?file=<encoded path>`). This avoids the Linux PATH_MAX
+  // limit hit by the prior inline `?style=<url-encoded css>` transport for large `.styles.ts`
+  // files on BuildXL CI. Fall back to inline `?style=` for backwards compatibility with any
+  // call sites that still embed CSS directly in the query string.
+  const file = query.get('file');
+  if (file) {
+    return fs.readFileSync(file, 'utf8');
+  }
+
   const style = query.get('style');
 
   return style ?? '';


### PR DESCRIPTION
## Summary

Two related fixes that together let `@griffel/webpack-extraction-plugin` work end-to-end on rspack with `CssExtractRspackPlugin` and produce a fully styled app.

### 1. Disable Griffel `splitChunks` cacheGroup on rspack

On rspack with `CssExtractRspackPlugin`, when the `cacheGroups['griffel']` test matches Griffel CSS modules (either via the function `isGriffelCSSModule` or the regex `/griffel\.css/`), rspack creates a `griffel` chunk that gets named with the JS filename template (`griffel-<hash>.js`) and `CssExtractRspackPlugin` does NOT emit a corresponding `griffel-<hash>.css`.

Net effect on rspack: all matched Griffel CSS modules are routed into a chunk whose CSS output is never written — dropping ~10 MB of CSS silently and leaving the app shell unstyled.

Until rspack/`CssExtractRspackPlugin` handles renamed/merged CSS chunks the way webpack/`MiniCssExtractPlugin` does, the safest behavior on rspack is to skip registering the cacheGroup entirely. Per-source-file `.griffel.css` files remain intact; the CSS rule sort-order optimization (which only runs against the merged `griffel.css` asset) is forgone on rspack.

### 2. File-based CSS transport on rspack (`?file=` instead of `?style=`)

The previous inline transport encoded the entire CSS payload into the loader request as `?style=<url-encoded css>`. For large `.styles.ts` files the encoded request exceeds Linux's `PATH_MAX` (4096 bytes), which broke BuildXL pip access tracking on Linux CI.

The new transport writes CSS to a content-hashed tempfile under `os.tmpdir()/griffel-css-cache/<sha1>.css` (atomic via staging file + rename, so concurrent loader invocations are safe) and references it via `?file=<encoded path>`. The virtual loader now prefers `?file=` when present and falls back to `?style=` for backwards compatibility.

Additionally, the rspack loader request now uses the source file as the resource (`...${virtualLoaderPath}!${this.resourcePath}?file=...`) instead of the virtual `griffel.css` placeholder, so `css-loader` resolves `url()` references relative to the source file's directory rather than to the plugin's own `node_modules/virtual-loader/` path.

## Webpack behavior

Unchanged — both new code paths are gated by `IS_RSPACK` / `!IS_RSPACK`. The existing test suite (webpack-only fixtures) should continue to pass.

## Verification

Verified end-to-end on Microsoft Teams' `react-web-client` experience with rspack 1.7.6 + `CssExtractRspackPlugin`:

- Before: 304 KB of CSS across 25 chunks; app shell unstyled.
- After: 12.3 MB of CSS across 529 chunks; app shell renders fully styled.
- BuildXL Linux CI builds succeed (previously failed with `DX14304` PATH_MAX warnings and `DX0064` pip failure).

## Test plan

- [ ] Existing webpack fixtures pass unchanged (`config-split-chunks`, `config-no-split-chunks`, etc.).
- [ ] Manual rspack smoke test on a large styles-heavy app produces emitted CSS files and a styled app.
- [ ] Linux CI green on this branch.