### PR TITLE
fix(rspack): keep CSS alive under consumer "sideEffects": false

### DIFF
--- a/change/@griffel-webpack-extraction-plugin-33fbd71a-9aed-4b44-a670-eb4a28181499.json
+++ b/change/@griffel-webpack-extraction-plugin-33fbd71a-9aed-4b44-a670-eb4a28181499.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent Griffel CSS from being tree-shaken on Rspack under `sideEffects: false`",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-plugin-c913eef2-96cb-4d89-8d8b-f1e5b4df4ccb.json
+++ b/change/@griffel-webpack-plugin-c913eef2-96cb-4d89-8d8b-f1e5b4df4ccb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent Griffel CSS from being tree-shaken on Rspack under `sideEffects: false`",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/e2e/utils/src/installPackages.ts
+++ b/e2e/utils/src/installPackages.ts
@@ -48,6 +48,7 @@ export async function installPackages(options: {
   const packageJson = JSON.parse(await fs.promises.readFile(tempDir + '/package.json', 'utf8'));
   const newPackageJson = {
     ...packageJson,
+    sideEffects: false,
     dependencies: {
       ...Object.fromEntries(resolutions.map(pkg => [pkg.packageName, '*'])),
       ...packagesWithVersions,

--- a/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
+++ b/packages/webpack-extraction-plugin/src/GriffelCSSExtractionPlugin.ts
@@ -165,6 +165,18 @@ export class GriffelCSSExtractionPlugin {
       });
     }
 
+    // @ Rspack compat:
+    // Rspack ignores `createModule` setting mutations, so the webpack escape hatch above is a
+    // no-op there. A `module.rules` entry with `sideEffects: true` IS honored, and it pins the
+    // virtual `.griffel.css` modules as side-effectful so Rspack does not tree-shake their
+    // imports out when the consumer's `package.json` declares `"sideEffects": false`.
+    if (IS_RSPACK) {
+      compiler.options.module.rules.push({
+        test: /\.griffel\.css$/,
+        sideEffects: true,
+      });
+    }
+
     // WHAT?
     //  Forces all modules emitted by an extraction loader to be moved in a single chunk by SplitChunksPlugin config.
     // WHY?

--- a/packages/webpack-plugin/src/GriffelPlugin.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.mts
@@ -182,6 +182,18 @@ export class GriffelPlugin {
       });
     }
 
+    // @ Rspack compat:
+    // Since `createModule` setting mutations are ignored on Rspack, the webpack escape hatch above
+    // is a no-op there. A `module.rules` entry with `sideEffects: true` IS honored, and it pins
+    // the virtual `.griffel.css` modules as side-effectful so Rspack does not tree-shake their
+    // imports out when the consumer's `package.json` declares `"sideEffects": false`.
+    if (IS_RSPACK) {
+      compiler.options.module.rules.push({
+        test: /\.griffel\.css$/,
+        sideEffects: true,
+      });
+    }
+
     // WHAT?
     //  Forces all modules emitted by an extraction loader to be moved in a single chunk by SplitChunksPlugin config.
     // WHY?


### PR DESCRIPTION
## Summary

When a consumer's `package.json` declares `"sideEffects": false` (the common case for production apps), Rspack treats the loader-appended `import "...griffel.css"` as a side-effects-free import and tree-shakes it out. The virtual module is still created (visible in `compilation.modules`) but is never assigned to a chunk, splitChunks never sees it, and `CssExtractRspackPlugin` / `experiments.css` emit no CSS asset.

End result in production: the `griffel.css` file is either absent or contains only the small subset of rules whose parent modules happen to retain side-effects somehow. This is exactly the symptom reported by `teams-modular-packages`.

## Why the existing escape hatch doesn't cover Rspack

The plugins already have a webpack-only escape hatch:

```ts
compiler.hooks.normalModuleFactory.tap(PLUGIN_NAME, nmf => {
  nmf.hooks.createModule.tap(PLUGIN_NAME, (createData) => {
    if (createData.matchResource?.endsWith('.griffel.css')) {
      createData.settings.sideEffects = true;
    }
  });
});
```

This hook **does fire on Rspack** (the `if (!IS_RSPACK)` guard predates current Rspack), but Rspack silently discards `settings` mutations. The Rspack-compatible alternative is a `module.rules` entry with `sideEffects: true`, which Rspack honors.

## Fix

For both `@griffel/webpack-extraction-plugin` and `@griffel/webpack-plugin`, when running under Rspack, push:

```ts
compiler.options.module.rules.push({
  test: /\.griffel\.css$/,
  sideEffects: true,
});
```

Webpack already covers itself via the `createModule` hook, so no change is needed there.

## E2E regression net

`e2e/utils/installPackages` now injects `"sideEffects": false` into the temp `package.json` that every scenario builds against. Without this PR's fix in place, every Rspack scenario fails (verified locally: `legacy-rspack-1` errors with `Failed to find any matching CSS file in dist`, all four scenarios go red). With the fix, the existing snapshots match.

## Test plan

- [x] `yarn nx run @griffel/e2e-rspack:test` — all 4 scenarios pass with `sideEffects: false` injected
- [x] Reverting just this PR's plugin changes (keeping `installPackages`'s `sideEffects: false`) immediately reproduces the production failure mode
- [x] `yarn nx run @griffel/e2e-rspack:lint` — clean
- [x] `yarn nx run @griffel/e2e-rspack:type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)