### PR TITLE
chore(e2e): use explicit workspace deps for internal @griffel/* packages

### DIFF
--- a/e2e/eslint/package.json
+++ b/e2e/eslint/package.json
@@ -2,5 +2,8 @@
   "name": "@griffel/e2e-eslint",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@griffel/e2e-utils": "workspace:*"
+  }
 }

--- a/e2e/rspack/package.json
+++ b/e2e/rspack/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "sideEffects": false,
   "dependencies": {
-    "@griffel/e2e-utils": "*",
+    "@griffel/e2e-utils": "workspace:*",
     "@griffel/react": "^1.7.4",
     "@griffel/webpack-extraction-plugin": "^0.5.19",
     "@griffel/webpack-loader": "^2.2.28",

--- a/e2e/typescript/package.json
+++ b/e2e/typescript/package.json
@@ -2,5 +2,8 @@
   "name": "@griffel/e2e-typescript",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@griffel/e2e-utils": "workspace:*"
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,6 @@
       "@griffel/babel-preset": ["packages/babel-preset/src/index.ts"],
       "@griffel/core": ["packages/core/src/index.ts"],
       "@griffel/devtools": ["packages/devtools/src/index.ts"],
-      "@griffel/e2e-utils": ["e2e/utils/src/index.ts"],
       "@griffel/eslint-plugin": ["packages/eslint-plugin/src/index.ts"],
       "@griffel/jest-serializer": ["packages/jest-serializer/src/index.ts"],
       "@griffel/postcss-syntax": ["packages/postcss-syntax/src/index.ts"],
@@ -32,7 +31,6 @@
       "@griffel/style-types": ["packages/style-types/src/index.ts"],
       "@griffel/transform": ["packages/transform/src/index.mts"],
       "@griffel/transform-shaker": ["packages/transform-shaker/src/index.ts"],
-      "@griffel/update-shorthands": ["tools/update-shorthands/src/index.ts"],
       "@griffel/webpack-extraction-plugin": ["packages/webpack-extraction-plugin/src/index.ts"],
       "@griffel/webpack-loader": ["packages/webpack-loader/src/index.ts"],
       "@griffel/webpack-plugin": ["packages/webpack-plugin/src/index.mts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3771,6 +3771,8 @@ __metadata:
 "@griffel/e2e-eslint@workspace:e2e/eslint":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-eslint@workspace:e2e/eslint"
+  dependencies:
+    "@griffel/e2e-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -3778,7 +3780,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-rspack@workspace:e2e/rspack"
   dependencies:
-    "@griffel/e2e-utils": "npm:*"
+    "@griffel/e2e-utils": "workspace:*"
     "@griffel/react": "npm:^1.7.4"
     "@griffel/webpack-extraction-plugin": "npm:^0.5.19"
     "@griffel/webpack-loader": "npm:^2.2.28"
@@ -3789,10 +3791,12 @@ __metadata:
 "@griffel/e2e-typescript@workspace:e2e/typescript":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-typescript@workspace:e2e/typescript"
+  dependencies:
+    "@griffel/e2e-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
-"@griffel/e2e-utils@npm:*, @griffel/e2e-utils@workspace:e2e/utils":
+"@griffel/e2e-utils@workspace:*, @griffel/e2e-utils@workspace:e2e/utils":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-utils@workspace:e2e/utils"
   languageName: unknown


### PR DESCRIPTION
## Summary

First slice of the larger workspaces + project-references migration explored in #774. This PR is intentionally minimal — it only touches **private** packages so it can land independently:

- `e2e/eslint`, `e2e/typescript`: add `@griffel/e2e-utils` as `devDependency` (`workspace:*`). Both already import from `@griffel/e2e-utils`; the resolution was implicit via the path alias in `tsconfig.base.json`.
- `e2e/rspack`: tighten the existing `"*"` `e2e-utils` dep to `workspace:*` for consistency.
- Drop `@griffel/e2e-utils` and `@griffel/update-shorthands` aliases from `tsconfig.base.json` — no consumer needs them now that the deps are declared explicitly.

Published `@griffel/*` packages keep their path aliases untouched; those migrate in follow-up PRs.

## Test plan

- [x] `yarn nx run-many --target=type-check --all` — passes (20/20)
- [x] `yarn nx run @griffel/e2e-eslint:test` — passes
- [x] `yarn nx run @griffel/e2e-typescript:test` — passes
- [x] `yarn check-dependencies` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)