### PR TITLE
chore(style-types): migrate to per-package dist/ build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist
+dist
 /tmp
 /out-tsc
 /packages/*/dist/bundle-size

--- a/e2e/eslint/package.json
+++ b/e2e/eslint/package.json
@@ -2,5 +2,8 @@
   "name": "@griffel/e2e-eslint",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@griffel/e2e-utils": "workspace:*"
+  }
 }

--- a/e2e/rspack/package.json
+++ b/e2e/rspack/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "sideEffects": false,
   "dependencies": {
-    "@griffel/e2e-utils": "*",
+    "@griffel/e2e-utils": "workspace:*",
     "@griffel/react": "^1.7.4",
     "@griffel/webpack-extraction-plugin": "^0.5.19",
     "@griffel/webpack-loader": "^2.2.28",

--- a/e2e/typescript/package.json
+++ b/e2e/typescript/package.json
@@ -2,5 +2,8 @@
   "name": "@griffel/e2e-typescript",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@griffel/e2e-utils": "workspace:*"
+  }
 }

--- a/packages/style-types/package.json
+++ b/packages/style-types/package.json
@@ -8,8 +8,23 @@
     "url": "https://github.com/microsoft/griffel"
   },
   "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "@griffel/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE.md",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "csstype": "^3.2.3"
-  },
-  "types": "src/index.d.ts"
+  }
 }

--- a/packages/style-types/project.json
+++ b/packages/style-types/project.json
@@ -6,22 +6,15 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
-      "outputs": ["{options.outputPath}"],
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/packages/style-types/dist"],
       "options": {
-        "outputPath": "dist/packages/style-types",
-        "tsConfig": "packages/style-types/tsconfig.lib.json",
-        "skipTypeField": true,
-        "packageJson": "packages/style-types/package.json",
-        "main": "packages/style-types/src/index.ts",
-        "assets": [
-          "packages/style-types/README.md",
-          {
-            "glob": "LICENSE.md",
-            "input": ".",
-            "output": "."
-          }
-        ]
+        "cwd": "packages/style-types",
+        "commands": [
+          "tsc --build tsconfig.lib.json --pretty",
+          "node ../../tools/copy-pkg-assets.mjs packages/style-types"
+        ],
+        "parallel": false
       }
     },
     "lint": {

--- a/packages/style-types/tsconfig.lib.json
+++ b/packages/style-types/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
+    "rootDir": "./src",
     "declaration": true,
     "types": ["node", "environment"]
   },
@@ -16,5 +17,5 @@
     "**/*.test.jsx",
     "jest.config.ts"
   ],
-  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/tools/copy-pkg-assets.mjs
+++ b/tools/copy-pkg-assets.mjs
@@ -1,0 +1,34 @@
+/**
+ * Copies a package's metadata files into its dist/ so the built tarball is
+ * self-contained:
+ *  - <pkg>/package.json (with scripts and devDependencies stripped)
+ *  - <pkg>/README.md if present, otherwise the workspace-root LICENSE.md
+ *  - <pkg>/LICENSE.md if present, otherwise the workspace-root LICENSE.md
+ *
+ * Usage: node tools/copy-pkg-assets.mjs <package-dir>
+ */
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const [pkgDir] = process.argv.slice(2);
+if (!pkgDir) {
+  console.error('Usage: node tools/copy-pkg-assets.mjs <package-dir>');
+  process.exit(1);
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const absPkg = resolve(repoRoot, pkgDir);
+const distDir = join(absPkg, 'dist');
+
+mkdirSync(distDir, { recursive: true });
+
+const pkgJson = JSON.parse(readFileSync(join(absPkg, 'package.json'), 'utf8'));
+delete pkgJson.scripts;
+delete pkgJson.devDependencies;
+writeFileSync(join(distDir, 'package.json'), JSON.stringify(pkgJson, null, 2) + '\n');
+
+for (const f of ['README.md', 'LICENSE.md']) {
+  const src = existsSync(join(absPkg, f)) ? join(absPkg, f) : join(repoRoot, f);
+  if (existsSync(src)) copyFileSync(src, join(distDir, f));
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,6 @@
       "@griffel/babel-preset": ["packages/babel-preset/src/index.ts"],
       "@griffel/core": ["packages/core/src/index.ts"],
       "@griffel/devtools": ["packages/devtools/src/index.ts"],
-      "@griffel/e2e-utils": ["e2e/utils/src/index.ts"],
       "@griffel/eslint-plugin": ["packages/eslint-plugin/src/index.ts"],
       "@griffel/jest-serializer": ["packages/jest-serializer/src/index.ts"],
       "@griffel/postcss-syntax": ["packages/postcss-syntax/src/index.ts"],
@@ -32,7 +31,6 @@
       "@griffel/style-types": ["packages/style-types/src/index.ts"],
       "@griffel/transform": ["packages/transform/src/index.mts"],
       "@griffel/transform-shaker": ["packages/transform-shaker/src/index.ts"],
-      "@griffel/update-shorthands": ["tools/update-shorthands/src/index.ts"],
       "@griffel/webpack-extraction-plugin": ["packages/webpack-extraction-plugin/src/index.ts"],
       "@griffel/webpack-loader": ["packages/webpack-loader/src/index.ts"],
       "@griffel/webpack-plugin": ["packages/webpack-plugin/src/index.mts"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,7 +28,6 @@
       "@griffel/jest-serializer": ["packages/jest-serializer/src/index.ts"],
       "@griffel/postcss-syntax": ["packages/postcss-syntax/src/index.ts"],
       "@griffel/react": ["packages/react/src/index.ts"],
-      "@griffel/style-types": ["packages/style-types/src/index.ts"],
       "@griffel/transform": ["packages/transform/src/index.mts"],
       "@griffel/transform-shaker": ["packages/transform-shaker/src/index.ts"],
       "@griffel/webpack-extraction-plugin": ["packages/webpack-extraction-plugin/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3771,6 +3771,8 @@ __metadata:
 "@griffel/e2e-eslint@workspace:e2e/eslint":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-eslint@workspace:e2e/eslint"
+  dependencies:
+    "@griffel/e2e-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -3778,7 +3780,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-rspack@workspace:e2e/rspack"
   dependencies:
-    "@griffel/e2e-utils": "npm:*"
+    "@griffel/e2e-utils": "workspace:*"
     "@griffel/react": "npm:^1.7.4"
     "@griffel/webpack-extraction-plugin": "npm:^0.5.19"
     "@griffel/webpack-loader": "npm:^2.2.28"
@@ -3789,10 +3791,12 @@ __metadata:
 "@griffel/e2e-typescript@workspace:e2e/typescript":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-typescript@workspace:e2e/typescript"
+  dependencies:
+    "@griffel/e2e-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
-"@griffel/e2e-utils@npm:*, @griffel/e2e-utils@workspace:e2e/utils":
+"@griffel/e2e-utils@workspace:*, @griffel/e2e-utils@workspace:e2e/utils":
   version: 0.0.0-use.local
   resolution: "@griffel/e2e-utils@workspace:e2e/utils"
   languageName: unknown


### PR DESCRIPTION
## Summary

Phase 2 of the workspaces + project-references migration (stacks on top of #962). Picks the smallest leaf package and replaces the workspace-rooted `@nx/js:tsc` build with a per-package `tsc` + asset-copy pipeline.

- Build output: `packages/style-types/dist/` (was `dist/packages/style-types`).
- New `tools/copy-pkg-assets.mjs` copies `package.json` (stripped of `scripts` + `devDependencies`), `README.md`, and `LICENSE.md` into the per-package `dist/`.
- `package.json` gets a published-style `exports` map: `@griffel/source` (no-op today, forward-compat with the `customConditions` in later phases), `types` pointing at `src/index.ts` so consumers can resolve types without first building, `default` at `dist/index.js` for runtime, and a `files: ["dist/", README, LICENSE, CHANGELOG]` field.
- Drop `@griffel/style-types` from `tsconfig.base.json` paths — consumers resolve via the yarn workspace symlink + the package.json above.
- `.gitignore`: drop the leading slash from `dist` so per-package `dist/` directories are also ignored.

## Test plan

- [x] `yarn nx run-many --target=type-check --all` — 20/20 pass
- [x] `yarn nx run-many --target=build --all` — 15/15 pass
- [x] `yarn nx run-many --target=test --all` — 16/16 pass (excluding the pre-existing e2e/rspack flake)
- [x] `yarn check-dependencies` — clean

## Stack

This PR builds on #962 — the diff above #962 is the style-types-only delta. Don't merge until #962 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)