### PR TITLE
feat: allow opting out of AOT for specific Griffel literals

### DIFF
--- a/change/@griffel-babel-preset-bb9c68e5-cbdb-47ef-beb3-ad681bc7f84f.json
+++ b/change/@griffel-babel-preset-bb9c68e5-cbdb-47ef-beb3-ad681bc7f84f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: allow opting out of AOT transformation per Griffel literal by setting `importName`, `resetImportName`, or `staticImportName` to `null` on a module entry",
+  "packageName": "@griffel/babel-preset",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-loader-0514ad49-7101-4389-9bf7-c2b792874c33.json
+++ b/change/@griffel-webpack-loader-0514ad49-7101-4389-9bf7-c2b792874c33.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: allow opting out of AOT transformation per Griffel literal by setting `importName`, `resetImportName`, or `staticImportName` to `null` on a module entry",
+  "packageName": "@griffel/webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-loader-0514ad49-7101-4389-9bf7-c2b792874c33.json
+++ b/change/@griffel-webpack-loader-0514ad49-7101-4389-9bf7-c2b792874c33.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
-  "comment": "feat: allow opting out of AOT transformation per Griffel literal by setting `importName`, `resetImportName`, or `staticImportName` to `null` on a module entry",
+  "type": "none",
+  "comment": "feat: pass AOT opt-out config through to @griffel/babel-preset",
   "packageName": "@griffel/webpack-loader",
   "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/babel-preset/__fixtures__/opt-out/code.ts
+++ b/packages/babel-preset/__fixtures__/opt-out/code.ts
@@ -1,0 +1,15 @@
+import { makeStyles, makeResetStyles, makeStaticStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { color: 'red' },
+});
+
+export const useResetStyles = makeResetStyles({
+  color: 'blue',
+});
+
+export const useStaticStyles = makeStaticStyles({
+  body: {
+    background: 'green',
+  },
+});

--- a/packages/babel-preset/__fixtures__/opt-out/output.ts
+++ b/packages/babel-preset/__fixtures__/opt-out/output.ts
@@ -1,0 +1,14 @@
+import { makeStyles, makeResetStyles, makeStaticStyles } from '@griffel/react';
+export const useStyles = makeStyles({
+  root: {
+    color: 'red',
+  },
+});
+export const useResetStyles = makeResetStyles({
+  color: 'blue',
+});
+export const useStaticStyles = makeStaticStyles({
+  body: {
+    background: 'green',
+  },
+});

--- a/packages/babel-preset/src/schema.ts
+++ b/packages/babel-preset/src/schema.ts
@@ -22,10 +22,13 @@ export const configSchema: JSONSchema7 = {
             type: 'string',
           },
           importName: {
-            type: 'string',
+            type: ['string', 'null'],
+          },
+          resetImportName: {
+            type: ['string', 'null'],
           },
           staticImportName: {
-            type: 'string',
+            type: ['string', 'null'],
           },
         },
       },

--- a/packages/babel-preset/src/transformPlugin.test.ts
+++ b/packages/babel-preset/src/transformPlugin.test.ts
@@ -253,6 +253,21 @@ pluginTester({
       },
     },
     {
+      title: 'imports: opt-out for specific literals',
+      fixture: path.resolve(fixturesDir, 'opt-out', 'code.ts'),
+      outputFixture: path.resolve(fixturesDir, 'opt-out', 'output.ts'),
+      pluginOptions: {
+        modules: [
+          {
+            moduleSource: '@griffel/react',
+            importName: null,
+            resetImportName: null,
+            staticImportName: null,
+          },
+        ],
+      },
+    },
+    {
       title: 'imports: require()',
       fixture: path.resolve(fixturesDir, 'require', 'code.ts'),
       outputFixture: path.resolve(fixturesDir, 'require', 'output.ts'),

--- a/packages/babel-preset/src/transformPlugin.ts
+++ b/packages/babel-preset/src/transformPlugin.ts
@@ -73,15 +73,21 @@ function getCalleeFunctionKind(
   modules: NonNullable<BabelPluginOptions['modules']>,
 ): FunctionKinds | null {
   for (const module of modules) {
-    if (path.referencesImport(module.moduleSource, module.importName)) {
+    if (module.importName !== null && path.referencesImport(module.moduleSource, module.importName)) {
       return 'makeStyles';
     }
 
-    if (path.referencesImport(module.moduleSource, module.resetImportName || 'makeResetStyles')) {
+    if (
+      module.resetImportName !== null &&
+      path.referencesImport(module.moduleSource, module.resetImportName || 'makeResetStyles')
+    ) {
       return 'makeResetStyles';
     }
 
-    if (path.referencesImport(module.moduleSource, module.staticImportName || 'makeStaticStyles')) {
+    if (
+      module.staticImportName !== null &&
+      path.referencesImport(module.moduleSource, module.staticImportName || 'makeStaticStyles')
+    ) {
       return 'makeStaticStyles';
     }
   }
@@ -440,11 +446,17 @@ export const transformPlugin = declare<Partial<BabelPluginOptions>, PluginObj<Ba
                     continue;
                   }
 
-                  if (importedPath.isIdentifier({ name: module.importName })) {
+                  if (module.importName !== null && importedPath.isIdentifier({ name: module.importName })) {
                     specifier.replaceWith(t.identifier('__styles'));
-                  } else if (importedPath.isIdentifier({ name: module.resetImportName || 'makeResetStyles' })) {
+                  } else if (
+                    module.resetImportName !== null &&
+                    importedPath.isIdentifier({ name: module.resetImportName ?? 'makeResetStyles' })
+                  ) {
                     specifier.replaceWith(t.identifier('__resetStyles'));
-                  } else if (importedPath.isIdentifier({ name: module.staticImportName || 'makeStaticStyles' })) {
+                  } else if (
+                    module.staticImportName !== null &&
+                    importedPath.isIdentifier({ name: module.staticImportName ?? 'makeStaticStyles' })
+                  ) {
                     specifier.replaceWith(t.identifier('__staticStyles'));
                   }
                 }

--- a/packages/babel-preset/src/types.ts
+++ b/packages/babel-preset/src/types.ts
@@ -12,9 +12,9 @@ export type BabelPluginOptions = {
   /** Defines set of modules and imports handled by a transformPlugin. */
   modules?: {
     moduleSource: string;
-    importName: string;
-    resetImportName?: string;
-    staticImportName?: string;
+    importName: string | null;
+    resetImportName?: string | null;
+    staticImportName?: string | null;
   }[];
 
   /**

--- a/packages/webpack-loader/__fixtures__/opt-out/code.ts
+++ b/packages/webpack-loader/__fixtures__/opt-out/code.ts
@@ -1,0 +1,15 @@
+import { makeStyles, makeResetStyles, makeStaticStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({
+  root: { color: 'red' },
+});
+
+export const useResetStyles = makeResetStyles({
+  color: 'blue',
+});
+
+export const useStaticStyles = makeStaticStyles({
+  body: {
+    background: 'green',
+  },
+});

--- a/packages/webpack-loader/__fixtures__/opt-out/output.ts
+++ b/packages/webpack-loader/__fixtures__/opt-out/output.ts
@@ -1,0 +1,14 @@
+import { makeStyles, makeResetStyles, makeStaticStyles } from '@griffel/react';
+export const useStyles = makeStyles({
+  root: {
+    color: 'red',
+  },
+});
+export const useResetStyles = makeResetStyles({
+  color: 'blue',
+});
+export const useStaticStyles = makeStaticStyles({
+  body: {
+    background: 'green',
+  },
+});

--- a/packages/webpack-loader/src/webpackLoader.test.ts
+++ b/packages/webpack-loader/src/webpackLoader.test.ts
@@ -252,6 +252,18 @@ describe('webpackLoader', () => {
   testFixture('function');
   testFixture('reset');
   testFixture('empty');
+  testFixture('opt-out', {
+    loaderOptions: {
+      modules: [
+        {
+          moduleSource: '@griffel/react',
+          importName: null,
+          resetImportName: null,
+          staticImportName: null,
+        },
+      ],
+    },
+  });
 
   const fakeColorModulePath = path.resolve(__dirname, '..', '__fixtures__', 'webpack-resolve-plugins', 'fake-color.ts');
   const colorModulePath = path.resolve(__dirname, '..', '__fixtures__', 'webpack-resolve-plugins', 'color.ts');

--- a/packages/webpack-loader/src/webpackLoader.ts
+++ b/packages/webpack-loader/src/webpackLoader.ts
@@ -28,7 +28,13 @@ export function shouldTransformSourceCode(
 ): boolean {
   // Fallback to "makeStyles" if options were not provided
   const imports = modules
-    ? modules.flatMap(module => [module.importName, module.resetImportName || 'makeResetStyles']).join('|')
+    ? modules
+        .flatMap(module => [
+          module.importName,
+          module.resetImportName === null ? null : module.resetImportName || 'makeResetStyles',
+        ])
+        .filter((name): name is string => typeof name === 'string')
+        .join('|')
     : 'makeStyles|makeResetStyles';
 
   return new RegExp(`\\b(${imports}|makeResetStyles)`).test(sourceCode);


### PR DESCRIPTION
## Summary
- New API on `modules` entries: set `importName`, `resetImportName`, or `staticImportName` to `null` to skip both the import-specifier rename and the call-expression transform for that literal. The other literals on the same module entry still transform.
- Fixes a regression in the working tree where the `Program.exit` specifier-replacement block used truthy `&&` guards (broke the default fallback for `undefined` `resetImportName` / `staticImportName`).
- `schema.ts`: adds the missing `resetImportName` entry and accepts `null` on all three name fields.
- `webpack-loader`'s `shouldTransformSourceCode` filters `null` names so they don't get injected as the literal string `"null"` into the regex.
- New `opt-out` fixture in both `babel-preset` and `webpack-loader` exercising the all-three-opted-out case.

## Test plan
- [x] `yarn nx test babel-preset` (69/69)
- [x] `yarn nx test webpack-loader` (14/14)
- [ ] Verify behavior end-to-end in a downstream consumer that uses partial opt-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)