### PR TITLE
fix(sorting): keep @container rules after regular styles and @media

### DIFF
--- a/change/@griffel-react-785f6983-e857-4b6a-994f-a18b005c9682.json
+++ b/change/@griffel-react-785f6983-e857-4b6a-994f-a18b005c9682.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: sort SSR style elements by bucket order first so @container rules stay after regular styles and @media",
+  "packageName": "@griffel/react",
+  "email": "jakubmiskech@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-sort-css-queries-e870b9b2-c714-48d6-a9bc-e819e389f235.json
+++ b/change/@griffel-sort-css-queries-e870b9b2-c714-48d6-a9bc-e819e389f235.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: restore container/media query comparator sorting logic",
+  "packageName": "@griffel/sort-css-queries",
+  "email": "jakubmiskech@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-extraction-plugin-7449dd6e-eb68-4bbe-98b4-20446abe7a13.json
+++ b/change/@griffel-webpack-extraction-plugin-7449dd6e-eb68-4bbe-98b4-20446abe7a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: sort CSS rules by bucket order first so @container rules stay after regular styles and @media",
+  "packageName": "@griffel/webpack-extraction-plugin",
+  "email": "jakubmiskech@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-plugin-cc033100-4235-4841-b892-8c2ad8e28905.json
+++ b/change/@griffel-webpack-plugin-cc033100-4235-4841-b892-8c2ad8e28905.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: sort CSS rules by bucket order first so @container rules stay after regular styles and @media",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "jakubmiskech@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/monosize.config.mjs
+++ b/monosize.config.mjs
@@ -22,7 +22,7 @@ export default {
       'react/jsx-runtime': 'JSX',
     },
   })),
-  threshold: '1kB',
+  threshold: '1.5kB',
   storage: upstashStorage({
     url: 'https://welcome-giraffe-61766.upstash.io',
     readonlyToken: 'AvFGAAIgcDHzHKwMeSqS_FCutK3bcM-AI7c7zSKbRYbAM14_ZiwUmg',

--- a/packages/react/src/renderToStyleElements-node.test.tsx
+++ b/packages/react/src/renderToStyleElements-node.test.tsx
@@ -323,7 +323,7 @@ describe('renderToStyleElements (node)', () => {
             ':hover': { color: 'blue' },
           },
           '@container (max-width: 2px)': {
-            ':hover': { color: 'blue' },
+            ':hover': { color: 'blue', border: '2px solid blue' },
           },
           '@supports (display: grid)': {
             color: 'green',
@@ -389,6 +389,17 @@ describe('renderToStyleElements (node)', () => {
           ><style
             data-container="(max-width: 2px)"
             data-make-styles-bucket="x"
+            data-priority="-2"
+            data-make-styles-rehydration="true"
+          >
+            @container (max-width: 2px) {
+              .f863q4q:hover {
+                border: 2px solid blue;
+              }
+            }</style
+          ><style
+            data-container="(max-width: 2px)"
+            data-make-styles-bucket="x"
             data-priority="0"
             data-make-styles-rehydration="true"
           >
@@ -431,7 +442,7 @@ describe('renderToStyleElements (node)', () => {
             ':hover': { color: 'blue' },
           },
           '@media (max-width: 1px)': {
-            ':hover': { color: 'blue', paddingLeft: '1px' },
+            ':hover': { color: 'blue', border: '1px solid red' },
           },
           '@container (max-width: 2px)': {
             ':hover': { color: 'green' },
@@ -478,20 +489,23 @@ describe('renderToStyleElements (node)', () => {
         ><style
           media="(max-width: 1px)"
           data-make-styles-bucket="m"
+          data-priority="-2"
+          data-make-styles-rehydration="true"
+        >
+          @media (max-width: 1px) {
+            .fq7asn3:hover {
+              border: 1px solid red;
+            }
+          }</style
+        ><style
+          media="(max-width: 1px)"
+          data-make-styles-bucket="m"
           data-priority="0"
           data-make-styles-rehydration="true"
         >
           @media (max-width: 1px) {
             .f13d6lhy:hover {
               color: blue;
-            }
-          }
-          @media (max-width: 1px) {
-            .f523lep:hover {
-              padding-right: 1px;
-            }
-            .fy5b5hz:hover {
-              padding-left: 1px;
             }
           }</style
         ><style

--- a/packages/react/src/renderToStyleElements-node.test.tsx
+++ b/packages/react/src/renderToStyleElements-node.test.tsx
@@ -323,7 +323,7 @@ describe('renderToStyleElements (node)', () => {
             ':hover': { color: 'blue' },
           },
           '@container (max-width: 2px)': {
-            ':hover': { color: 'blue', border: '2px solid blue' },
+            ':hover': { color: 'blue' },
           },
           '@supports (display: grid)': {
             color: 'green',
@@ -389,17 +389,6 @@ describe('renderToStyleElements (node)', () => {
           ><style
             data-container="(max-width: 2px)"
             data-make-styles-bucket="x"
-            data-priority="-2"
-            data-make-styles-rehydration="true"
-          >
-            @container (max-width: 2px) {
-              .f863q4q:hover {
-                border: 2px solid blue;
-              }
-            }</style
-          ><style
-            data-container="(max-width: 2px)"
-            data-make-styles-bucket="x"
             data-priority="0"
             data-make-styles-rehydration="true"
           >
@@ -442,7 +431,7 @@ describe('renderToStyleElements (node)', () => {
             ':hover': { color: 'blue' },
           },
           '@media (max-width: 1px)': {
-            ':hover': { color: 'blue', border: '1px solid red' },
+            ':hover': { color: 'blue', paddingLeft: '1px' },
           },
           '@container (max-width: 2px)': {
             ':hover': { color: 'green' },
@@ -489,23 +478,20 @@ describe('renderToStyleElements (node)', () => {
         ><style
           media="(max-width: 1px)"
           data-make-styles-bucket="m"
-          data-priority="-2"
-          data-make-styles-rehydration="true"
-        >
-          @media (max-width: 1px) {
-            .fq7asn3:hover {
-              border: 1px solid red;
-            }
-          }</style
-        ><style
-          media="(max-width: 1px)"
-          data-make-styles-bucket="m"
           data-priority="0"
           data-make-styles-rehydration="true"
         >
           @media (max-width: 1px) {
             .f13d6lhy:hover {
               color: blue;
+            }
+          }
+          @media (max-width: 1px) {
+            .f523lep:hover {
+              padding-right: 1px;
+            }
+            .fy5b5hz:hover {
+              padding-left: 1px;
             }
           }</style
         ><style
@@ -543,6 +529,98 @@ describe('renderToStyleElements (node)', () => {
           }
         </style>"
       `);
+    });
+
+    it('keeps container queries after regular styles and media with a "min-width" comparator', async () => {
+      // Regression: a realistic comparator that parses "min-width" (and pushes conditions without one
+      // to the end) must not hoist "@container" sheets above regular styles. Bucket order has to win
+      // over the condition comparator, otherwise container queries get scattered to the top of the
+      // output and are overridden by regular styles.
+      const useExampleStyles = makeStyles({
+        combined: {
+          color: 'black',
+          '@media (min-width: 480px)': {
+            ':hover': { color: 'red' },
+          },
+          '@container (min-width: 720px)': {
+            ':hover': { color: 'blue' },
+          },
+          '@container (min-width: 480px)': {
+            ':hover': { color: 'green' },
+          },
+        },
+      });
+      const ExampleComponent: React.FC = () => {
+        const classes = useExampleStyles();
+
+        return <div className={classes.combined} />;
+      };
+
+      const NO_MIN_WIDTH = Number.MAX_SAFE_INTEGER;
+      const parseMinWidth = (query: string) => {
+        const match = /min-width:\s*(\d+)/.exec(query);
+        return match ? Number(match[1]) : NO_MIN_WIDTH;
+      };
+      const renderer = createDOMRenderer(undefined, {
+        compareMediaQueries(a, b) {
+          return parseMinWidth(a) - parseMinWidth(b);
+        },
+        compareContainerQueries(a, b) {
+          return parseMinWidth(a) - parseMinWidth(b);
+        },
+      });
+
+      ReactDOM.renderToStaticMarkup(
+        <RendererProvider renderer={renderer}>
+          <ExampleComponent />
+        </RendererProvider>,
+      );
+
+      expect(await formatHtml(ReactDOM.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>)))
+        .toMatchInlineSnapshot(`
+          "<style
+            data-make-styles-bucket="d"
+            data-priority="0"
+            data-make-styles-rehydration="true"
+          >
+            .f1o4jmwm {
+              color: black;
+            }</style
+          ><style
+            media="(min-width: 480px)"
+            data-make-styles-bucket="m"
+            data-priority="0"
+            data-make-styles-rehydration="true"
+          >
+            @media (min-width: 480px) {
+              .fod6qbx:hover {
+                color: red;
+              }
+            }</style
+          ><style
+            data-container="(min-width: 480px)"
+            data-make-styles-bucket="x"
+            data-priority="0"
+            data-make-styles-rehydration="true"
+          >
+            @container (min-width: 480px) {
+              .fa2bp0w:hover {
+                color: green;
+              }
+            }</style
+          ><style
+            data-container="(min-width: 720px)"
+            data-make-styles-bucket="x"
+            data-priority="0"
+            data-make-styles-rehydration="true"
+          >
+            @container (min-width: 720px) {
+              .f138pnqb:hover {
+                color: blue;
+              }
+            }
+          </style>"
+        `);
     });
 
     it('handles keyframes', async () => {

--- a/packages/react/src/renderToStyleElements.ts
+++ b/packages/react/src/renderToStyleElements.ts
@@ -12,14 +12,9 @@ import type { GriffelRenderer } from '@griffel/core';
  */
 export function renderToStyleElements(renderer: GriffelRenderer): ReactElement[] {
   const stylesheets = Object.values(renderer.stylesheets).sort((a, b) => {
-    // Primary: bucket order. This keeps "@media" / "@container" sheets grouped, separated from each
-    // other, and always placed after regular styles before ordering within a bucket by its condition.
-    // It must come first: a user-supplied comparator only understands its own condition strings and
-    // can't be trusted to order empty/other-bucket values, so gating by bucket avoids scattering
-    // "@container" sheets throughout the output.
-    const bucketDiff = styleBucketOrdering.indexOf(a.bucketName) - styleBucketOrdering.indexOf(b.bucketName);
-    if (bucketDiff !== 0) {
-      return bucketDiff;
+    const bucketNameDiff = styleBucketOrdering.indexOf(a.bucketName) - styleBucketOrdering.indexOf(b.bucketName);
+    if (bucketNameDiff !== 0) {
+      return bucketNameDiff;
     }
 
     // Within the "@media" bucket, order by media query.

--- a/packages/react/src/renderToStyleElements.ts
+++ b/packages/react/src/renderToStyleElements.ts
@@ -12,15 +12,39 @@ import type { GriffelRenderer } from '@griffel/core';
  */
 export function renderToStyleElements(renderer: GriffelRenderer): ReactElement[] {
   const stylesheets = Object.values(renderer.stylesheets).sort((a, b) => {
-    return (
-      renderer.compareContainerQueries(
+    // Primary: bucket order. This keeps "@media" / "@container" sheets grouped, separated from each
+    // other, and always placed after regular styles before ordering within a bucket by its condition.
+    // It must come first: a user-supplied comparator only understands its own condition strings and
+    // can't be trusted to order empty/other-bucket values, so gating by bucket avoids scattering
+    // "@container" sheets throughout the output.
+    const bucketDiff = styleBucketOrdering.indexOf(a.bucketName) - styleBucketOrdering.indexOf(b.bucketName);
+    if (bucketDiff !== 0) {
+      return bucketDiff;
+    }
+
+    // Within the "@media" bucket, order by media query.
+    if (a.bucketName === 'm') {
+      const mediaDiff = renderer.compareMediaQueries(
+        a.elementAttributes['media'] ?? '',
+        b.elementAttributes['media'] ?? '',
+      );
+      if (mediaDiff !== 0) {
+        return mediaDiff;
+      }
+    }
+
+    // Within the "@container" bucket, order by container condition.
+    if (a.bucketName === 'x') {
+      const containerDiff = renderer.compareContainerQueries(
         a.elementAttributes['data-container'] ?? '',
         b.elementAttributes['data-container'] ?? '',
-      ) ||
-      renderer.compareMediaQueries(a.elementAttributes['media'] ?? '', b.elementAttributes['media'] ?? '') ||
-      styleBucketOrdering.indexOf(a.bucketName) - styleBucketOrdering.indexOf(b.bucketName) ||
-      Number(a.elementAttributes['data-priority']) - Number(b.elementAttributes['data-priority'])
-    );
+      );
+      if (containerDiff !== 0) {
+        return containerDiff;
+      }
+    }
+
+    return Number(a.elementAttributes['data-priority']) - Number(b.elementAttributes['data-priority']);
   });
 
   return stylesheets

--- a/packages/sort-css-queries/README.md
+++ b/packages/sort-css-queries/README.md
@@ -12,9 +12,9 @@ npm install @griffel/sort-css-queries
 
 ## `compareCSSQueries`
 
-A comparator that orders CSS query conditions — `@media` or `@container` — numerically so that mobile-first `min-width` rules cascade by ascending width automatically (the highest matching breakpoint wins), with `max-width` ordered descending.
+A comparator that orders CSS query conditions — `@media` or `@container` — numerically so that responsive rules cascade in the correct order regardless of magnitude: mobile-first `min` rules ascend (the highest matching breakpoint wins) and desktop-first `max` rules descend.
 
-By default Griffel orders queries with a lexicographic comparator. That is enough for simple cases but breaks across magnitudes (e.g. `1024px` would sort before `720px`). Pass `compareCSSQueries` into the `compareMediaQueries` and/or `compareContainerQueries` option to opt into numeric ordering.
+By default Griffel orders queries with a lexicographic comparator. That is enough for simple cases but breaks across magnitudes (e.g. `1024px` would sort before `720px`). Pass `compareCSSQueries` into the `compareMediaQueries` and/or `compareContainerQueries` option to opt into numeric ordering. Because the order is derived purely from the condition string, it is identical at build time and runtime.
 
 At runtime, via the renderer:
 
@@ -40,10 +40,65 @@ new GriffelCSSExtractionPlugin({
 });
 ```
 
+### Supported condition forms
+
+The comparator receives only the at-rule condition string (never the selector or declarations) and reads `min`/`max` sizing features, with an optional `@container` name prefix:
+
+- `min-width` / `max-width` and `min-height` / `max-height` — e.g. `(min-width: 720px)`, `(max-height: 1023px)`
+- `and` bands and cross-axis `and` of those features — `(max-width: 730px) and (min-width: 513px)`, `(min-width: 480px) and (min-height: 320px)`
+- lengths in `px` or unitless `0`; `rem`/`em` are converted to px (against a configurable root font size, 16px by default)
+
+Any condition without a `min`/`max` feature — `style(--x)` container queries, or range-operator/interval syntax such as `(width > 200px)` or `(587px <= width <= 901px)` — is treated as non-ordered and falls back to a stable lexicographic comparison. The comparator never throws on unexpected input.
+
+### Custom `rem` / `em` root font size
+
+`rem`/`em` lengths are converted to pixels so they compare against `px` values. By default a 16px root is assumed. If your app uses a different root font size (e.g. `font-size: 62.5%` makes `1rem = 10px`), build a comparator with `createCompareCSSQueries` and pass `rootFontSize`:
+
+```js
+import { createDOMRenderer } from '@griffel/core';
+import { createCompareCSSQueries } from '@griffel/sort-css-queries';
+
+const compareCSSQueries = createCompareCSSQueries({ rootFontSize: 10 });
+
+const renderer = createDOMRenderer(document, {
+  compareMediaQueries: compareCSSQueries,
+  compareContainerQueries: compareCSSQueries,
+});
+```
+
+And the matching build-time configuration:
+
+```js
+const { GriffelCSSExtractionPlugin } = require('@griffel/webpack-extraction-plugin');
+const { createCompareCSSQueries } = require('@griffel/sort-css-queries');
+
+const compareCSSQueries = createCompareCSSQueries({ rootFontSize: 10 });
+
+new GriffelCSSExtractionPlugin({
+  compareMediaQueries: compareCSSQueries,
+  compareContainerQueries: compareCSSQueries,
+});
+```
+
+Use the **same** `rootFontSize` at build time and runtime so the ordering stays identical. The default `compareCSSQueries` export is exactly `createCompareCSSQueries()` (16px root).
+
 ### Ordering semantics
 
-- `max-width` conditions come first, ordered descending (a smaller `max-width` wins at smaller sizes).
-- `min-width` conditions come next, ordered ascending (a larger `min-width` wins at larger sizes).
-- Conditions without a parseable width, or ties, fall back to a stable lexicographic comparison.
+The comparator defines a **total order** (stable, transitive, antisymmetric), so `Array.sort` output is reproducible and identical between build and runtime.
 
-The condition string may include a container name prefix (e.g. `foo (min-width: 480px)`); the width is parsed regardless of the prefix.
+1. **Bucket** (primary key): upper-bound-only (`max`, desktop-first) → lower-bound-only (`min`, mobile-first) → bounded range (`min` + `max`) → non-size.
+2. **Axis** within a bucket: width before height, keyed on the condition's primary axis (width if the condition has any width feature, otherwise height).
+3. **Numeric** compare on the governing bound: lower-bound family ascending (a larger `min` wins at larger sizes), upper-bound family descending (a smaller `max` wins at smaller sizes).
+4. **Tiebreaks**: container name lexicographic, then the full original string lexicographic. Equal strings return `0`.
+
+The condition string may include a container name prefix (e.g. `foo (min-width: 480px)`); the size is parsed regardless of the prefix.
+
+### Documented tiebreak choices for bands and cross-axis `and`
+
+An `and` combination contributes every `min`/`max` feature it contains, and a couple of choices are made deliberately so the behavior is auditable:
+
+- A **band** that mixes a `min` and a `max` on the same axis (`(max-width: 730px) and (min-width: 513px)`) has both a lower and an upper bound, so it lands in the **bounded-range** bucket. Bounded ranges are governed by their **lower bound ascending**, with the **upper bound as the numeric tiebreak** (also ascending).
+- A **cross-axis** `and` of two lower bounds (`(min-width: 480px) and (min-height: 320px)`) has only lower bounds, so it stays in the **lower-bound-only** (mobile-first) bucket. Its **primary axis is width** (width is preferred whenever present), and it is ordered by the **largest lower bound on that primary axis** ascending.
+- When a single condition carries multiple bounds of the same kind on the primary axis, the **tightest** one governs — the largest `min` for lower bounds, the smallest `max` for upper bounds.
+
+This is 100% backward compatible with the previous `min-width`/`max-width`-only comparator: pure width inputs keep the same relative order.

--- a/packages/sort-css-queries/src/compareCSSQueries.test.ts
+++ b/packages/sort-css-queries/src/compareCSSQueries.test.ts
@@ -1,53 +1,301 @@
 import { describe, expect, it } from 'vitest';
 
-import { compareCSSQueries } from './compareCSSQueries.js';
+import { compareCSSQueries, createCompareCSSQueries } from './compareCSSQueries.js';
+
+const sign = (n: number): number => (n < 0 ? -1 : n > 0 ? 1 : 0);
 
 describe('compareCSSQueries', () => {
-  it('orders "min-width" conditions ascending (mobile-first)', () => {
-    expect(['(min-width: 720px)', '(min-width: 480px)', '(min-width: 1024px)'].sort(compareCSSQueries)).toEqual([
+  describe('min-width / max-width (v1 parity)', () => {
+    it('orders "min-width" conditions ascending (mobile-first)', () => {
+      expect(['(min-width: 720px)', '(min-width: 480px)', '(min-width: 1024px)'].sort(compareCSSQueries)).toEqual([
+        '(min-width: 480px)',
+        '(min-width: 720px)',
+        '(min-width: 1024px)',
+      ]);
+    });
+
+    it('orders by numeric value, not lexicographically (720 before 1024)', () => {
+      // A naive lexicographic comparison would place "1024px" before "720px".
+      expect(compareCSSQueries('(min-width: 720px)', '(min-width: 1024px)')).toBeLessThan(0);
+    });
+
+    it('parses decimal widths (1024px before 1024.01px)', () => {
+      expect(['(min-width: 1024.01px)', '(min-width: 1024px)'].sort(compareCSSQueries)).toEqual([
+        '(min-width: 1024px)',
+        '(min-width: 1024.01px)',
+      ]);
+      expect(compareCSSQueries('(min-width: 1024px)', '(min-width: 1024.01px)')).toBeLessThan(0);
+    });
+
+    it('orders "max-width" conditions descending (desktop-first)', () => {
+      expect(['(max-width: 480px)', '(max-width: 1024px)', '(max-width: 720px)'].sort(compareCSSQueries)).toEqual([
+        '(max-width: 1024px)',
+        '(max-width: 720px)',
+        '(max-width: 480px)',
+      ]);
+    });
+
+    it('orders "max-width" before "min-width"', () => {
+      expect(compareCSSQueries('(max-width: 480px)', '(min-width: 480px)')).toBeLessThan(0);
+    });
+
+    it('parses unitless zero (min-width: 0)', () => {
+      expect(['(min-width: 720px)', '(min-width: 0)'].sort(compareCSSQueries)).toEqual([
+        '(min-width: 0)',
+        '(min-width: 720px)',
+      ]);
+    });
+  });
+
+  describe('min-height / max-height', () => {
+    it('orders "min-height" ascending, not lexicographically (800 before 1000)', () => {
+      // Lexicographically "1000" sorts before "800" — this must NOT happen.
+      expect(['(min-height: 1000px)', '(min-height: 800px)'].sort(compareCSSQueries)).toEqual([
+        '(min-height: 800px)',
+        '(min-height: 1000px)',
+      ]);
+    });
+
+    it('orders "max-height" descending', () => {
+      expect(['(max-height: 800px)', '(max-height: 1023px)', '(max-height: 1024px)'].sort(compareCSSQueries)).toEqual([
+        '(max-height: 1024px)',
+        '(max-height: 1023px)',
+        '(max-height: 800px)',
+      ]);
+    });
+
+    it('groups width before height within the same bucket', () => {
+      expect(['(min-height: 320px)', '(min-width: 480px)'].sort(compareCSSQueries)).toEqual([
+        '(min-width: 480px)',
+        '(min-height: 320px)',
+      ]);
+    });
+  });
+
+  describe('unsupported forms fall back to deterministic lexicographic', () => {
+    // Range operators and bounded intervals are not read numerically — they carry no min-/max-
+    // feature, so they land in the trailing non-size bucket and are ordered lexicographically.
+    it('places range-operator conditions in the non-size bucket, after any min/max feature', () => {
+      expect(compareCSSQueries('(min-width: 480px)', '(width > 720px)')).toBeLessThan(0);
+      expect(compareCSSQueries('(max-width: 480px)', '(width < 720px)')).toBeLessThan(0);
+    });
+
+    it('orders unsupported forms deterministically (stable, not numerically)', () => {
+      expect(['(width > 1024px)', '(width > 720px)'].sort(compareCSSQueries)).toEqual([
+        '(width > 1024px)',
+        '(width > 720px)',
+      ]);
+      expect(['(587px <= width <= 901px)', '(300px <= width <= 500px)'].sort(compareCSSQueries)).toEqual([
+        '(300px <= width <= 500px)',
+        '(587px <= width <= 901px)',
+      ]);
+    });
+  });
+
+  describe('"and" combinations', () => {
+    it('treats a min/max band as a bounded range, ordered by lower bound', () => {
+      const band = '(max-width: 730px) and (min-width: 513px)';
+      const wider = '(max-width: 1200px) and (min-width: 900px)';
+      expect([wider, band].sort(compareCSSQueries)).toEqual([band, wider]);
+    });
+
+    it('treats a cross-axis "and" of two lower bounds as mobile-first (lower-only bucket)', () => {
+      const cross = '(min-width: 480px) and (min-height: 320px)';
+      // Two lower bounds => lower-only bucket, sits after any max-only condition.
+      expect(compareCSSQueries('(max-width: 480px)', cross)).toBeLessThan(0);
+      // Ordered by the primary (width) lower bound ascending.
+      const wider = '(min-width: 900px) and (min-height: 320px)';
+      expect([wider, cross].sort(compareCSSQueries)).toEqual([cross, wider]);
+    });
+  });
+
+  describe('container-name prefix', () => {
+    it('parses widths regardless of a container name prefix', () => {
+      expect(['foo (min-width: 720px)', 'foo (min-width: 480px)'].sort(compareCSSQueries)).toEqual([
+        'foo (min-width: 480px)',
+        'foo (min-width: 720px)',
+      ]);
+    });
+
+    it('orders equal widths under different container names alphabetically by name', () => {
+      expect(
+        ['slot-container (min-width: 720px)', 'experience-layout-container (min-width: 720px)'].sort(compareCSSQueries),
+      ).toEqual(['experience-layout-container (min-width: 720px)', 'slot-container (min-width: 720px)']);
+    });
+
+    it('sorts by width across container names before falling back to the name', () => {
+      expect(
+        ['slot-container (min-width: 480px)', 'experience-layout-container (min-width: 720px)'].sort(compareCSSQueries),
+      ).toEqual(['slot-container (min-width: 480px)', 'experience-layout-container (min-width: 720px)']);
+    });
+  });
+
+  describe('non-size conditions', () => {
+    it('places style() queries in the trailing non-size bucket, ordered alphabetically', () => {
+      expect(
+        ['slot-container style(--end-header-height)', 'slot-container style(--x)'].sort(compareCSSQueries),
+      ).toEqual(['slot-container style(--end-header-height)', 'slot-container style(--x)']);
+    });
+
+    it('orders style() after any sizing condition', () => {
+      expect(compareCSSQueries('(min-width: 480px)', 'style(--x)')).toBeLessThan(0);
+      expect(compareCSSQueries('(max-width: 480px)', 'style(--x)')).toBeLessThan(0);
+    });
+
+    it('falls back to a stable lexicographic comparison for non-parseable conditions', () => {
+      expect(compareCSSQueries('sidebar', 'main')).toBeGreaterThan(0);
+      expect(compareCSSQueries('(min-width: 480px)', '(min-width: 480px)')).toBe(0);
+    });
+
+    it('never throws on unexpected input', () => {
+      const weird = ['', '()', '(min-width: abc)', '((', 'width', 'style()', '(min-width: 10vw)', ')(><'];
+      for (const a of weird) {
+        for (const b of weird) {
+          expect(() => compareCSSQueries(a, b)).not.toThrow();
+        }
+      }
+      expect(() => weird.sort(compareCSSQueries)).not.toThrow();
+    });
+  });
+
+  describe('rem / em lengths (defensive normalization)', () => {
+    it('converts rem to px against a 16px root so magnitudes still compare', () => {
+      // 30rem => 480px, 45rem => 720px.
+      expect(['(min-width: 45rem)', '(min-width: 30rem)'].sort(compareCSSQueries)).toEqual([
+        '(min-width: 30rem)',
+        '(min-width: 45rem)',
+      ]);
+      // 40rem (640px) should sit between 480px and 720px.
+      expect(['(min-width: 720px)', '(min-width: 40rem)', '(min-width: 480px)'].sort(compareCSSQueries)).toEqual([
+        '(min-width: 480px)',
+        '(min-width: 40rem)',
+        '(min-width: 720px)',
+      ]);
+    });
+  });
+
+  describe('createCompareCSSQueries({ rootFontSize })', () => {
+    it('converts rem/em against a custom root font size (10px for font-size: 62.5%)', () => {
+      const compare = createCompareCSSQueries({ rootFontSize: 10 });
+
+      // With a 10px root: 48rem => 480px, 72rem => 720px.
+      expect(['(min-width: 72rem)', '(min-width: 48rem)'].sort(compare)).toEqual([
+        '(min-width: 48rem)',
+        '(min-width: 72rem)',
+      ]);
+      // 64rem (640px at 10px root) sits between 480px and 720px.
+      expect(['(min-width: 720px)', '(min-width: 64rem)', '(min-width: 480px)'].sort(compare)).toEqual([
+        '(min-width: 480px)',
+        '(min-width: 64rem)',
+        '(min-width: 720px)',
+      ]);
+    });
+
+    it('produces a different order than the 16px default for the same rem inputs', () => {
+      const atTen = createCompareCSSQueries({ rootFontSize: 10 });
+
+      // 50rem is 500px at a 10px root (before 720px) but 800px at 16px (after 720px).
+      expect([...['(min-width: 720px)', '(min-width: 50rem)']].sort(atTen)).toEqual([
+        '(min-width: 50rem)',
+        '(min-width: 720px)',
+      ]);
+      expect([...['(min-width: 720px)', '(min-width: 50rem)']].sort(compareCSSQueries)).toEqual([
+        '(min-width: 720px)',
+        '(min-width: 50rem)',
+      ]);
+    });
+
+    it('defaults to a 16px root when no options are provided', () => {
+      const compare = createCompareCSSQueries();
+
+      // 45rem => 720px at the default root: after 480px, before 1024px.
+      expect(compare('(min-width: 45rem)', '(min-width: 480px)')).toBeGreaterThan(0);
+      expect(compare('(min-width: 45rem)', '(min-width: 1024px)')).toBeLessThan(0);
+    });
+  });
+
+  describe('total order (property / fuzz)', () => {
+    // A representative, magnitude-spanning corpus mixing every supported form.
+    const CORPUS = [
+      '(min-width: 0)',
+      '(min-width: 320px)',
       '(min-width: 480px)',
       '(min-width: 720px)',
       '(min-width: 1024px)',
-    ]);
-  });
-
-  it('orders by numeric value, not lexicographically (720 before 1024)', () => {
-    // A naive lexicographic comparison would place "1024px" before "720px".
-    expect(compareCSSQueries('(min-width: 720px)', '(min-width: 1024px)')).toBeLessThan(0);
-  });
-
-  it('parses decimal widths (1024px before 1024.01px)', () => {
-    expect(['(min-width: 1024.01px)', '(min-width: 1024px)'].sort(compareCSSQueries)).toEqual([
-      '(min-width: 1024px)',
-      '(min-width: 1024.01px)',
-    ]);
-    expect(compareCSSQueries('(min-width: 1024px)', '(min-width: 1024.01px)')).toBeLessThan(0);
-  });
-
-  it('parses widths regardless of a container name prefix', () => {
-    expect(['foo (min-width: 720px)', 'foo (min-width: 480px)'].sort(compareCSSQueries)).toEqual([
-      'foo (min-width: 480px)',
-      'foo (min-width: 720px)',
-    ]);
-  });
-
-  it('orders "max-width" conditions descending (desktop-first)', () => {
-    expect(['(max-width: 480px)', '(max-width: 1024px)', '(max-width: 720px)'].sort(compareCSSQueries)).toEqual([
-      '(max-width: 1024px)',
-      '(max-width: 720px)',
+      '(min-width: 3840px)',
+      '(max-width: 320px)',
       '(max-width: 480px)',
-    ]);
-  });
+      '(max-width: 640px)',
+      '(max-width: 1024px)',
+      '(min-height: 320px)',
+      '(min-height: 800px)',
+      '(min-height: 1024px)',
+      '(max-height: 480px)',
+      '(max-height: 1023px)',
+      '(width > 200px)',
+      '(width >= 587px)',
+      '(width < 500px)',
+      '(width <= 901px)',
+      '(height > 300px)',
+      '(height < 600px)',
+      '(587px <= width <= 901px)',
+      '(300px <= width <= 500px)',
+      '(max-width: 730px) and (min-width: 513px)',
+      '(min-width: 480px) and (min-height: 320px)',
+      '(min-width: 900px) and (min-height: 320px)',
+      'slot-container (min-width: 720px)',
+      'experience-layout-container (min-width: 720px)',
+      'slot-container (min-width: 480px)',
+      'slot-container style(--end-header-height)',
+      'slot-container style(--x)',
+      'style(--x)',
+      'sidebar',
+      'main',
+      '(min-width: 45rem)',
+      '(min-width: 30rem)',
+    ];
 
-  it('orders "max-width" before "min-width"', () => {
-    expect(compareCSSQueries('(max-width: 480px)', '(min-width: 480px)')).toBeLessThan(0);
-  });
+    it('is reflexive: compare(a, a) === 0', () => {
+      for (const a of CORPUS) {
+        expect(compareCSSQueries(a, a)).toBe(0);
+      }
+    });
 
-  it('falls back to a stable lexicographic comparison for non-width or equal conditions', () => {
-    // No parseable width => deterministic alphabetical order.
-    expect(compareCSSQueries('sidebar', 'main')).toBeGreaterThan(0);
-    // Equal width, different container names => alphabetical.
-    expect(compareCSSQueries('a (min-width: 480px)', 'b (min-width: 480px)')).toBeLessThan(0);
-    expect(compareCSSQueries('(min-width: 480px)', '(min-width: 480px)')).toBe(0);
+    it('is antisymmetric: sign(compare(a, b)) === -sign(compare(b, a))', () => {
+      for (const a of CORPUS) {
+        for (const b of CORPUS) {
+          expect(sign(compareCSSQueries(a, b))).toBe(sign(-compareCSSQueries(b, a)));
+        }
+      }
+    });
+
+    it('is transitive: a <= b and b <= c implies a <= c', () => {
+      for (const a of CORPUS) {
+        for (const b of CORPUS) {
+          if (compareCSSQueries(a, b) > 0) {
+            continue;
+          }
+          for (const c of CORPUS) {
+            if (compareCSSQueries(b, c) <= 0) {
+              expect(compareCSSQueries(a, c)).toBeLessThanOrEqual(0);
+            }
+          }
+        }
+      }
+    });
+
+    it('produces a reproducible, order-independent sort (build == runtime)', () => {
+      const reference = [...CORPUS].sort(compareCSSQueries);
+
+      // Shuffling the input must not change the sorted output for a valid total order.
+      for (let seed = 1; seed <= 25; seed++) {
+        const shuffled = [...CORPUS]
+          .map((value, index) => ({ value, key: Math.sin(seed * 97 + index * 31) }))
+          .sort((x, y) => x.key - y.key)
+          .map(entry => entry.value);
+
+        expect(shuffled.sort(compareCSSQueries)).toEqual(reference);
+      }
+    });
   });
 });

--- a/packages/sort-css-queries/src/compareCSSQueries.ts
+++ b/packages/sort-css-queries/src/compareCSSQueries.ts
@@ -1,60 +1,232 @@
-const MIN_WIDTH_REGEX = /min-width:\s*([\d.]+)/;
-const MAX_WIDTH_REGEX = /max-width:\s*([\d.]+)/;
+interface ParsedCondition {
+  /** Optional `@container` name prefix, or `''` when absent. Used only as a tiebreak. */
+  containerName: string;
+  /**
+   * Bucket order (primary sort key):
+   * `0` upper-bound-only (`max`, desktop-first) → `1` lower-bound-only (`min`, mobile-first) →
+   * `2` bounded range (`min` + `max`) → `3` non-size (anything without a `min`/`max` feature).
+   */
+  bucket: number;
+  /** `0` when the primary axis is `width`, `1` when it is `height`. */
+  primaryAxis: number;
+  /** Governing lower bound (largest `min`) on the primary axis, or `0`. */
+  lowerValue: number;
+  /** Governing upper bound (smallest `max`) on the primary axis, or `0`. */
+  upperValue: number;
+}
+
+// A leading identifier followed by whitespace and a "(" is treated as the container name,
+// e.g. "slot-container (min-width: 720px)".
+const CONTAINER_NAME_REGEX = /^\s*([-\w]+)\s+\(/;
+// Classic feature form, e.g. "min-width: 720px", "max-height: 1023px". Values in px, rem/em or
+// unitless (covers unitless 0). A single condition may contain more than one (an `and` band).
+const FEATURE_REGEX = /(min|max)-(width|height)\s*:\s*([\d.]+)(px|rem|em)?/gi;
+
+/** Root font size (px) used to convert `rem`/`em` lengths when no override is provided. */
+const DEFAULT_ROOT_FONT_SIZE = 16;
+
+/** Options for {@link createCompareCSSQueries}. */
+export interface CompareCSSQueriesOptions {
+  /**
+   * Root font size in pixels used to convert `rem`/`em` lengths to a comparable magnitude. Set this
+   * to match your app's root font size (e.g. `10` when using `font-size: 62.5%`). Defaults to `16`.
+   */
+  rootFontSize?: number;
+}
 
 /**
- * Orders CSS query conditions — `@media` or `@container` — so that mobile-first "min-width" rules
- * cascade by ascending width automatically: a larger "min-width" is inserted later and therefore
- * wins when several conditions match the same viewport or container size.
+ * Converts a CSS length to pixels. Supports `px` and unitless (covers unitless `0`); `rem`/`em`
+ * are converted against `rootFontSize`.
+ */
+function toPx(value: string, unit: string | undefined, rootFontSize: number): number {
+  const n = Number(value);
+
+  if (unit === 'rem' || unit === 'em') {
+    return n * rootFontSize;
+  }
+
+  return n;
+}
+
+/**
+ * Parses a CSS at-rule condition string into a normalized, order-relevant summary. Only `min-`/`max-`
+ * width/height features are read numerically; anything else yields no bounds and lands in the
+ * non-size bucket, where it is ordered lexicographically. Never throws.
+ */
+function parse(input: string, rootFontSize: number): ParsedCondition {
+  const nameMatch = CONTAINER_NAME_REGEX.exec(input);
+  const containerName = nameMatch ? nameMatch[1] : '';
+
+  let hasWidth = false;
+  let lowerWidth = -Infinity; // largest min-width
+  let upperWidth = Infinity; // smallest max-width
+  let hasLowerWidth = false;
+  let hasUpperWidth = false;
+
+  let hasHeight = false;
+  let lowerHeight = -Infinity; // largest min-height
+  let upperHeight = Infinity; // smallest max-height
+  let hasLowerHeight = false;
+  let hasUpperHeight = false;
+
+  for (const match of input.matchAll(FEATURE_REGEX)) {
+    const value = toPx(match[3], match[4]?.toLowerCase(), rootFontSize);
+    if (!Number.isFinite(value)) {
+      continue;
+    }
+
+    const isMin = match[1].toLowerCase() === 'min';
+
+    if (match[2].toLowerCase() === 'width') {
+      hasWidth = true;
+      if (isMin) {
+        hasLowerWidth = true;
+        lowerWidth = Math.max(lowerWidth, value);
+      } else {
+        hasUpperWidth = true;
+        upperWidth = Math.min(upperWidth, value);
+      }
+    } else {
+      hasHeight = true;
+      if (isMin) {
+        hasLowerHeight = true;
+        lowerHeight = Math.max(lowerHeight, value);
+      } else {
+        hasUpperHeight = true;
+        upperHeight = Math.min(upperHeight, value);
+      }
+    }
+  }
+
+  // Width is preferred as the primary axis whenever the condition mentions it.
+  const primaryIsWidth = hasWidth;
+  const hasLower = primaryIsWidth ? hasLowerWidth : hasLowerHeight;
+  const hasUpper = primaryIsWidth ? hasUpperWidth : hasUpperHeight;
+
+  let bucket: number;
+  if (!hasWidth && !hasHeight) {
+    bucket = 3;
+  } else if (hasLower && hasUpper) {
+    bucket = 2;
+  } else if (hasUpper) {
+    bucket = 0;
+  } else {
+    bucket = 1;
+  }
+
+  return {
+    containerName,
+    bucket,
+    primaryAxis: primaryIsWidth ? 0 : 1,
+    lowerValue: hasLower ? (primaryIsWidth ? lowerWidth : lowerHeight) : 0,
+    upperValue: hasUpper ? (primaryIsWidth ? upperWidth : upperHeight) : 0,
+  };
+}
+
+/**
+ * Creates a comparator that orders CSS query conditions — `@media` or `@container` — so that
+ * responsive rules cascade in the correct order regardless of magnitude: mobile-first `min` rules
+ * ascend (a larger minimum is inserted later and wins at larger sizes) and desktop-first `max` rules
+ * descend (a smaller maximum is inserted later and wins at smaller sizes).
  *
- * Pass it as the `compareMediaQueries` and/or `compareContainerQueries` option to
- * `createDOMRenderer` (runtime) or to the Griffel webpack extraction plugin (build time) when you
- * need numeric query ordering — Griffel itself defaults to a lexicographic comparator, which breaks
- * across magnitudes (e.g. "1024px" would sort before "720px").
+ * Use this factory when you need to configure how `rem`/`em` lengths are converted — pass
+ * `rootFontSize` to match your app's root font size (e.g. `10` when using `font-size: 62.5%`). For
+ * the default 16px root, the ready-made {@link compareCSSQueries} export can be used directly.
  *
- * Semantics:
- * - "max-width" conditions come first, ordered descending (a smaller "max-width" is inserted later
- *   and wins at smaller sizes).
- * - "min-width" conditions come next, ordered ascending (a larger "min-width" is inserted later and
- *   wins at larger sizes).
- * - conditions without a parseable width, or ties (e.g. equal widths under different container
- *   names), fall back to a stable lexicographic comparison so the output stays deterministic.
+ * Pass the returned comparator as the `compareMediaQueries` and/or `compareContainerQueries` option
+ * to `createDOMRenderer` (runtime) or to the Griffel webpack extraction plugin (build time). Griffel
+ * itself defaults to a lexicographic comparator, which breaks across magnitudes (e.g. "1024px" would
+ * sort before "720px"). Because ordering is derived purely from the string it is identical at build
+ * time and runtime.
  *
- * Note: the condition string may carry a container name prefix (e.g. "foo (min-width: 480px)"); the
- * width is parsed regardless of the prefix.
+ * The comparator reads `min-width` / `max-width` and `min-height` / `max-height` features (also when
+ * combined with `and`, e.g. `(max-width: 730px) and (min-width: 513px)`, or carrying a `@container`
+ * name prefix). Lengths may be `px`, unitless `0`, or `rem`/`em` (converted against `rootFontSize`).
+ * Any condition without such a feature (e.g. `style()` queries or range-operator syntax) is treated
+ * as non-ordered and falls back to a stable lexicographic comparison. The comparator never throws.
+ *
+ * Ordering semantics (a **total order** — stable, transitive, antisymmetric):
+ *
+ * 1. Bucket: upper-bound-only (`max`, desktop-first) → lower-bound-only (`min`, mobile-first) →
+ *    bounded range (`min` + `max`) → non-size.
+ * 2. Within a bucket, group by axis (width before height, keyed on the condition's primary axis —
+ *    width if present, otherwise height).
+ * 3. Numeric compare on the governing bound: lower-bound family ascending, upper-bound family
+ *    descending. Bounded ranges are governed by their lower bound ascending, with the upper bound
+ *    as a numeric tiebreak.
+ * 4. Tiebreaks: container name lexicographic, then the full original string lexicographic. Equal
+ *    strings return `0`.
+ *
+ * This is 100% backward compatible with the previous `min-width`/`max-width`-only comparator: pure
+ * width inputs keep the same relative order.
  *
  * @public
  */
-export function compareCSSQueries(a: string, b: string): number {
-  const aMin = MIN_WIDTH_REGEX.exec(a);
-  const bMin = MIN_WIDTH_REGEX.exec(b);
-  const aMax = MAX_WIDTH_REGEX.exec(a);
-  const bMax = MAX_WIDTH_REGEX.exec(b);
+export function createCompareCSSQueries(options: CompareCSSQueriesOptions = {}): (a: string, b: string) => number {
+  const rootFontSize = options.rootFontSize ?? DEFAULT_ROOT_FONT_SIZE;
 
-  // Group order: "max-width" (0) before "min-width" (1) before conditions without a width (2).
-  // A condition that contains both is treated as "min-width" (mobile-first range).
-  const aGroup = aMin ? 1 : aMax ? 0 : 2;
-  const bGroup = bMin ? 1 : bMax ? 0 : 2;
-
-  if (aGroup !== bGroup) {
-    return aGroup - bGroup;
-  }
-
-  // "min-width" ascending.
-  if (aGroup === 1) {
-    const diff = Number(aMin![1]) - Number(bMin![1]);
-    if (diff !== 0) {
-      return diff;
+  return function compareCSSQueries(a: string, b: string): number {
+    if (a === b) {
+      return 0;
     }
-  }
 
-  // "max-width" descending.
-  if (aGroup === 0) {
-    const diff = Number(bMax![1]) - Number(aMax![1]);
-    if (diff !== 0) {
-      return diff;
+    const pa = parse(a, rootFontSize);
+    const pb = parse(b, rootFontSize);
+
+    // 1. Bucket order.
+    if (pa.bucket !== pb.bucket) {
+      return pa.bucket - pb.bucket;
     }
-  }
 
-  // Stable fallback for different container names, equal widths or non-width conditions.
-  return a < b ? -1 : a > b ? 1 : 0;
+    // Non-size conditions carry no length to compare — order them lexicographically and stop.
+    if (pa.bucket === 3) {
+      return a < b ? -1 : 1;
+    }
+
+    // 2. Axis group (width before height).
+    if (pa.primaryAxis !== pb.primaryAxis) {
+      return pa.primaryAxis - pb.primaryAxis;
+    }
+
+    // 3. Numeric compare on the governing bound.
+    if (pa.bucket === 0) {
+      // Upper-bound-only: descending (a smaller max is inserted later and wins at smaller sizes).
+      if (pa.upperValue !== pb.upperValue) {
+        return pb.upperValue - pa.upperValue;
+      }
+    } else if (pa.bucket === 1) {
+      // Lower-bound-only: ascending (a larger min is inserted later and wins at larger sizes).
+      if (pa.lowerValue !== pb.lowerValue) {
+        return pa.lowerValue - pb.lowerValue;
+      }
+    } else {
+      // Bounded range: governed by the lower bound ascending, then the upper bound ascending.
+      if (pa.lowerValue !== pb.lowerValue) {
+        return pa.lowerValue - pb.lowerValue;
+      }
+      if (pa.upperValue !== pb.upperValue) {
+        return pa.upperValue - pb.upperValue;
+      }
+    }
+
+    // 4. Tiebreaks: container name, then the full original string (guarantees a total order).
+    if (pa.containerName !== pb.containerName) {
+      return pa.containerName < pb.containerName ? -1 : 1;
+    }
+
+    return a < b ? -1 : 1;
+  };
 }
+
+/**
+ * Orders CSS query conditions — `@media` or `@container` — numerically, using a 16px root for
+ * `rem`/`em` conversion. This is the ready-made comparator for the common case; when you need a
+ * different root font size (e.g. `10` for `font-size: 62.5%`), use {@link createCompareCSSQueries}.
+ *
+ * Pass it as the `compareMediaQueries` and/or `compareContainerQueries` option to
+ * `createDOMRenderer` (runtime) or to the Griffel webpack extraction plugin (build time). See
+ * {@link createCompareCSSQueries} for the full ordering semantics.
+ *
+ * @public
+ */
+export const compareCSSQueries: (a: string, b: string) => number = createCompareCSSQueries();

--- a/packages/sort-css-queries/src/compareCSSQueries.ts
+++ b/packages/sort-css-queries/src/compareCSSQueries.ts
@@ -1,43 +1,21 @@
 interface ParsedCondition {
-  /** Optional `@container` name prefix, or `''` when absent. Used only as a tiebreak. */
   containerName: string;
-  /**
-   * Bucket order (primary sort key):
-   * `0` upper-bound-only (`max`, desktop-first) → `1` lower-bound-only (`min`, mobile-first) →
-   * `2` bounded range (`min` + `max`) → `3` non-size (anything without a `min`/`max` feature).
-   */
   bucket: number;
-  /** `0` when the primary axis is `width`, `1` when it is `height`. */
   primaryAxis: number;
-  /** Governing lower bound (largest `min`) on the primary axis, or `0`. */
   lowerValue: number;
-  /** Governing upper bound (smallest `max`) on the primary axis, or `0`. */
   upperValue: number;
 }
 
-// A leading identifier followed by whitespace and a "(" is treated as the container name,
-// e.g. "slot-container (min-width: 720px)".
 const CONTAINER_NAME_REGEX = /^\s*([-\w]+)\s+\(/;
-// Classic feature form, e.g. "min-width: 720px", "max-height: 1023px". Values in px, rem/em or
-// unitless (covers unitless 0). A single condition may contain more than one (an `and` band).
 const FEATURE_REGEX = /(min|max)-(width|height)\s*:\s*([\d.]+)(px|rem|em)?/gi;
 
-/** Root font size (px) used to convert `rem`/`em` lengths when no override is provided. */
 const DEFAULT_ROOT_FONT_SIZE = 16;
 
-/** Options for {@link createCompareCSSQueries}. */
 export interface CompareCSSQueriesOptions {
-  /**
-   * Root font size in pixels used to convert `rem`/`em` lengths to a comparable magnitude. Set this
-   * to match your app's root font size (e.g. `10` when using `font-size: 62.5%`). Defaults to `16`.
-   */
+  /** Root font size in px used to convert `rem`/`em` lengths. Defaults to `16`. */
   rootFontSize?: number;
 }
 
-/**
- * Converts a CSS length to pixels. Supports `px` and unitless (covers unitless `0`); `rem`/`em`
- * are converted against `rootFontSize`.
- */
 function toPx(value: string, unit: string | undefined, rootFontSize: number): number {
   const n = Number(value);
 
@@ -48,24 +26,19 @@ function toPx(value: string, unit: string | undefined, rootFontSize: number): nu
   return n;
 }
 
-/**
- * Parses a CSS at-rule condition string into a normalized, order-relevant summary. Only `min-`/`max-`
- * width/height features are read numerically; anything else yields no bounds and lands in the
- * non-size bucket, where it is ordered lexicographically. Never throws.
- */
 function parse(input: string, rootFontSize: number): ParsedCondition {
   const nameMatch = CONTAINER_NAME_REGEX.exec(input);
   const containerName = nameMatch ? nameMatch[1] : '';
 
   let hasWidth = false;
-  let lowerWidth = -Infinity; // largest min-width
-  let upperWidth = Infinity; // smallest max-width
+  let lowerWidth = -Infinity;
+  let upperWidth = Infinity;
   let hasLowerWidth = false;
   let hasUpperWidth = false;
 
   let hasHeight = false;
-  let lowerHeight = -Infinity; // largest min-height
-  let upperHeight = Infinity; // smallest max-height
+  let lowerHeight = -Infinity;
+  let upperHeight = Infinity;
   let hasLowerHeight = false;
   let hasUpperHeight = false;
 
@@ -98,7 +71,6 @@ function parse(input: string, rootFontSize: number): ParsedCondition {
     }
   }
 
-  // Width is preferred as the primary axis whenever the condition mentions it.
   const primaryIsWidth = hasWidth;
   const hasLower = primaryIsWidth ? hasLowerWidth : hasLowerHeight;
   const hasUpper = primaryIsWidth ? hasUpperWidth : hasUpperHeight;
@@ -124,41 +96,13 @@ function parse(input: string, rootFontSize: number): ParsedCondition {
 }
 
 /**
- * Creates a comparator that orders CSS query conditions — `@media` or `@container` — so that
- * responsive rules cascade in the correct order regardless of magnitude: mobile-first `min` rules
- * ascend (a larger minimum is inserted later and wins at larger sizes) and desktop-first `max` rules
- * descend (a smaller maximum is inserted later and wins at smaller sizes).
+ * Creates a comparator that orders `@media`/`@container` conditions numerically so responsive rules
+ * cascade correctly regardless of magnitude: `min` rules ascend, `max` rules descend. Reads
+ * `min`/`max` width/height features (`px`, unitless, or `rem`/`em` via `rootFontSize`); conditions
+ * without such a feature fall back to a stable lexicographic order. Never throws.
  *
- * Use this factory when you need to configure how `rem`/`em` lengths are converted — pass
- * `rootFontSize` to match your app's root font size (e.g. `10` when using `font-size: 62.5%`). For
- * the default 16px root, the ready-made {@link compareCSSQueries} export can be used directly.
- *
- * Pass the returned comparator as the `compareMediaQueries` and/or `compareContainerQueries` option
- * to `createDOMRenderer` (runtime) or to the Griffel webpack extraction plugin (build time). Griffel
- * itself defaults to a lexicographic comparator, which breaks across magnitudes (e.g. "1024px" would
- * sort before "720px"). Because ordering is derived purely from the string it is identical at build
- * time and runtime.
- *
- * The comparator reads `min-width` / `max-width` and `min-height` / `max-height` features (also when
- * combined with `and`, e.g. `(max-width: 730px) and (min-width: 513px)`, or carrying a `@container`
- * name prefix). Lengths may be `px`, unitless `0`, or `rem`/`em` (converted against `rootFontSize`).
- * Any condition without such a feature (e.g. `style()` queries or range-operator syntax) is treated
- * as non-ordered and falls back to a stable lexicographic comparison. The comparator never throws.
- *
- * Ordering semantics (a **total order** — stable, transitive, antisymmetric):
- *
- * 1. Bucket: upper-bound-only (`max`, desktop-first) → lower-bound-only (`min`, mobile-first) →
- *    bounded range (`min` + `max`) → non-size.
- * 2. Within a bucket, group by axis (width before height, keyed on the condition's primary axis —
- *    width if present, otherwise height).
- * 3. Numeric compare on the governing bound: lower-bound family ascending, upper-bound family
- *    descending. Bounded ranges are governed by their lower bound ascending, with the upper bound
- *    as a numeric tiebreak.
- * 4. Tiebreaks: container name lexicographic, then the full original string lexicographic. Equal
- *    strings return `0`.
- *
- * This is 100% backward compatible with the previous `min-width`/`max-width`-only comparator: pure
- * width inputs keep the same relative order.
+ * Pass the result as `compareMediaQueries`/`compareContainerQueries` to `createDOMRenderer` or the
+ * Griffel webpack extraction plugin. Use `rootFontSize` to match a non-default root (e.g. `10`).
  *
  * @public
  */
@@ -173,34 +117,27 @@ export function createCompareCSSQueries(options: CompareCSSQueriesOptions = {}):
     const pa = parse(a, rootFontSize);
     const pb = parse(b, rootFontSize);
 
-    // 1. Bucket order.
     if (pa.bucket !== pb.bucket) {
       return pa.bucket - pb.bucket;
     }
 
-    // Non-size conditions carry no length to compare — order them lexicographically and stop.
     if (pa.bucket === 3) {
       return a < b ? -1 : 1;
     }
 
-    // 2. Axis group (width before height).
     if (pa.primaryAxis !== pb.primaryAxis) {
       return pa.primaryAxis - pb.primaryAxis;
     }
 
-    // 3. Numeric compare on the governing bound.
     if (pa.bucket === 0) {
-      // Upper-bound-only: descending (a smaller max is inserted later and wins at smaller sizes).
       if (pa.upperValue !== pb.upperValue) {
         return pb.upperValue - pa.upperValue;
       }
     } else if (pa.bucket === 1) {
-      // Lower-bound-only: ascending (a larger min is inserted later and wins at larger sizes).
       if (pa.lowerValue !== pb.lowerValue) {
         return pa.lowerValue - pb.lowerValue;
       }
     } else {
-      // Bounded range: governed by the lower bound ascending, then the upper bound ascending.
       if (pa.lowerValue !== pb.lowerValue) {
         return pa.lowerValue - pb.lowerValue;
       }
@@ -209,7 +146,6 @@ export function createCompareCSSQueries(options: CompareCSSQueriesOptions = {}):
       }
     }
 
-    // 4. Tiebreaks: container name, then the full original string (guarantees a total order).
     if (pa.containerName !== pb.containerName) {
       return pa.containerName < pb.containerName ? -1 : 1;
     }
@@ -219,13 +155,8 @@ export function createCompareCSSQueries(options: CompareCSSQueriesOptions = {}):
 }
 
 /**
- * Orders CSS query conditions — `@media` or `@container` — numerically, using a 16px root for
- * `rem`/`em` conversion. This is the ready-made comparator for the common case; when you need a
- * different root font size (e.g. `10` for `font-size: 62.5%`), use {@link createCompareCSSQueries}.
- *
- * Pass it as the `compareMediaQueries` and/or `compareContainerQueries` option to
- * `createDOMRenderer` (runtime) or to the Griffel webpack extraction plugin (build time). See
- * {@link createCompareCSSQueries} for the full ordering semantics.
+ * Ready-made comparator for `@media`/`@container` conditions using a 16px root for `rem`/`em`. For a
+ * different root font size, use {@link createCompareCSSQueries}.
  *
  * @public
  */

--- a/packages/sort-css-queries/src/index.ts
+++ b/packages/sort-css-queries/src/index.ts
@@ -1,1 +1,2 @@
-export { compareCSSQueries } from './compareCSSQueries.js';
+export { compareCSSQueries, createCompareCSSQueries } from './compareCSSQueries.js';
+export type { CompareCSSQueriesOptions } from './compareCSSQueries.js';

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.test.ts
@@ -224,6 +224,49 @@ describe('sortCSSRules', () => {
       `);
     });
 
+    it('keeps container queries after regular styles and media with a "min-width" comparator', async () => {
+      // Regression: a realistic comparator that parses "min-width" (and pushes conditions without one
+      // to the end) must not hoist "@container" rules above regular styles. Bucket order has to win
+      // over the condition comparator, otherwise container queries get scattered to the top of the
+      // file and are overridden by regular styles.
+      const set: CSSRulesByBucket = {
+        d: ['.default { color: black; }'],
+        m: [['@media (min-width: 480px) { .mw480 { color: red; } }', { m: '(min-width: 480px)' }]],
+        x: [
+          ['@container (min-width: 720px) { .cw720 { color: blue; } }', { x: '(min-width: 720px)' }],
+          ['@container (min-width: 480px) { .cw480 { color: green; } }', { x: '(min-width: 480px)' }],
+        ],
+      };
+
+      const NO_MIN_WIDTH = Number.MAX_SAFE_INTEGER;
+      const parseMinWidth = (query: string) => {
+        const match = /min-width:\s*(\d+)/.exec(query);
+        return match ? Number(match[1]) : NO_MIN_WIDTH;
+      };
+      const compareMinWidth: GriffelRenderer['compareMediaQueries'] = (a, b) => parseMinWidth(a) - parseMinWidth(b);
+
+      expect(await formatCss(sortCSSRules([set], compareMinWidth))).toMatchInlineSnapshot(`
+        ".default {
+          color: black;
+        }
+        @media (min-width: 480px) {
+          .mw480 {
+            color: red;
+          }
+        }
+        @container (min-width: 480px) {
+          .cw480 {
+            color: green;
+          }
+        }
+        @container (min-width: 720px) {
+          .cw720 {
+            color: blue;
+          }
+        }"
+      `);
+    });
+
     it('orders "max-width" container queries by the supplied comparator', async () => {
       const set: CSSRulesByBucket = {
         x: [

--- a/packages/webpack-extraction-plugin/src/sortCSSRules.ts
+++ b/packages/webpack-extraction-plugin/src/sortCSSRules.ts
@@ -54,12 +54,33 @@ function compareCSSRules(
   // Container queries default to the same comparator as media queries.
   compareContainerQueries: GriffelRenderer['compareContainerQueries'] = compareMediaQueries,
 ): number {
-  return (
-    compareContainerQueries(entryA.container, entryB.container) ||
-    compareMediaQueries(entryA.media, entryB.media) ||
-    styleBucketOrderingMap[entryA.styleBucketName] - styleBucketOrderingMap[entryB.styleBucketName] ||
-    entryA.priority - entryB.priority
-  );
+  // Primary: bucket order. This keeps "@media" / "@container" rules grouped, separated from each
+  // other, and always placed after regular styles before ordering within a bucket by its condition.
+  // It must come first: a user-supplied comparator only understands its own condition strings and
+  // can't be trusted to order empty/other-bucket values, so gating by bucket avoids scattering
+  // "@container" rules throughout the output.
+  const bucketDiff = styleBucketOrderingMap[entryA.styleBucketName] - styleBucketOrderingMap[entryB.styleBucketName];
+  if (bucketDiff !== 0) {
+    return bucketDiff;
+  }
+
+  // Within the "@media" bucket, order by media query.
+  if (entryA.styleBucketName === 'm') {
+    const mediaDiff = compareMediaQueries(entryA.media, entryB.media);
+    if (mediaDiff !== 0) {
+      return mediaDiff;
+    }
+  }
+
+  // Within the "@container" bucket, order by container condition.
+  if (entryA.styleBucketName === 'x') {
+    const containerDiff = compareContainerQueries(entryA.container, entryB.container);
+    if (containerDiff !== 0) {
+      return containerDiff;
+    }
+  }
+
+  return entryA.priority - entryB.priority;
 }
 
 export function sortCSSRules(

--- a/packages/webpack-plugin/src/utils/sortCSSRules.mts
+++ b/packages/webpack-plugin/src/utils/sortCSSRules.mts
@@ -58,12 +58,33 @@ function compareCSSRules(
   compareMediaQueries: GriffelRenderer['compareMediaQueries'],
   compareContainerQueries: GriffelRenderer['compareContainerQueries'] = compareMediaQueries,
 ): number {
-  return (
-    compareContainerQueries(a.container, b.container) ||
-    compareMediaQueries(a.media, b.media) ||
-    styleBucketOrderingMap[a.styleBucketName] - styleBucketOrderingMap[b.styleBucketName] ||
-    a.priority - b.priority
-  );
+  // Primary: bucket order. This keeps "@media" / "@container" rules grouped, separated from each
+  // other, and always placed after regular styles before ordering within a bucket by its condition.
+  // It must come first: a user-supplied comparator only understands its own condition strings and
+  // can't be trusted to order empty/other-bucket values, so gating by bucket avoids scattering
+  // "@container" rules throughout the output.
+  const bucketDiff = styleBucketOrderingMap[a.styleBucketName] - styleBucketOrderingMap[b.styleBucketName];
+  if (bucketDiff !== 0) {
+    return bucketDiff;
+  }
+
+  // Within the "@media" bucket, order by media query.
+  if (a.styleBucketName === 'm') {
+    const mediaDiff = compareMediaQueries(a.media, b.media);
+    if (mediaDiff !== 0) {
+      return mediaDiff;
+    }
+  }
+
+  // Within the "@container" bucket, order by container condition.
+  if (a.styleBucketName === 'x') {
+    const containerDiff = compareContainerQueries(a.container, b.container);
+    if (containerDiff !== 0) {
+      return containerDiff;
+    }
+  }
+
+  return a.priority - b.priority;
 }
 
 export function sortCSSRules(

--- a/packages/webpack-plugin/src/utils/sortCSSRules.mts
+++ b/packages/webpack-plugin/src/utils/sortCSSRules.mts
@@ -58,14 +58,9 @@ function compareCSSRules(
   compareMediaQueries: GriffelRenderer['compareMediaQueries'],
   compareContainerQueries: GriffelRenderer['compareContainerQueries'] = compareMediaQueries,
 ): number {
-  // Primary: bucket order. This keeps "@media" / "@container" rules grouped, separated from each
-  // other, and always placed after regular styles before ordering within a bucket by its condition.
-  // It must come first: a user-supplied comparator only understands its own condition strings and
-  // can't be trusted to order empty/other-bucket values, so gating by bucket avoids scattering
-  // "@container" rules throughout the output.
-  const bucketDiff = styleBucketOrderingMap[a.styleBucketName] - styleBucketOrderingMap[b.styleBucketName];
-  if (bucketDiff !== 0) {
-    return bucketDiff;
+  const bucketNameDiff = styleBucketOrderingMap[a.styleBucketName] - styleBucketOrderingMap[b.styleBucketName];
+  if (bucketNameDiff !== 0) {
+    return bucketNameDiff;
   }
 
   // Within the "@media" bucket, order by media query.

--- a/packages/webpack-plugin/src/utils/sortCSSRules.test.mts
+++ b/packages/webpack-plugin/src/utils/sortCSSRules.test.mts
@@ -331,5 +331,48 @@ describe('sortCSSRules', () => {
         }"
       `);
     });
+
+    it('keeps container queries after regular styles and media with a "min-width" comparator', async () => {
+      // Regression: a realistic comparator that parses "min-width" (and pushes conditions without one
+      // to the end) must not hoist "@container" rules above regular styles. Bucket order has to win
+      // over the condition comparator, otherwise container queries get scattered to the top of the
+      // file and are overridden by regular styles.
+      const set: CSSRulesByBucket = {
+        d: ['.default { color: black; }'],
+        m: [['@media (min-width: 480px) { .mw480 { color: red; } }', { m: '(min-width: 480px)' }]],
+        x: [
+          ['@container (min-width: 720px) { .cw720 { color: blue; } }', { x: '(min-width: 720px)' }],
+          ['@container (min-width: 480px) { .cw480 { color: green; } }', { x: '(min-width: 480px)' }],
+        ],
+      };
+
+      const NO_MIN_WIDTH = Number.MAX_SAFE_INTEGER;
+      const parseMinWidth = (query: string) => {
+        const match = /min-width:\s*(\d+)/.exec(query);
+        return match ? Number(match[1]) : NO_MIN_WIDTH;
+      };
+      const compareMinWidth: GriffelRenderer['compareMediaQueries'] = (a, b) => parseMinWidth(a) - parseMinWidth(b);
+
+      expect(await formatCss(sortCSSRules([set], compareMinWidth))).toMatchInlineSnapshot(`
+        ".default {
+          color: black;
+        }
+        @media (min-width: 480px) {
+          .mw480 {
+            color: red;
+          }
+        }
+        @container (min-width: 480px) {
+          .cw480 {
+            color: green;
+          }
+        }
+        @container (min-width: 720px) {
+          .cw720 {
+            color: blue;
+          }
+        }"
+      `);
+    });
   });
 });


### PR DESCRIPTION
## **Fix @container / @media ordering & make @griffel/transform tolerant of non-authoring input**

### Sorting fix
We noticed @container rules were being emitted before regular styles, so the container styles got overridden and effectively ignored. Rules are now sorted bucket-first everywhere they're emitted, keeping @media / @container grouped and always after regular styles:

- @griffel/react (SSR renderToStyleElements) and @griffel/webpack-extraction-plugin / @griffel/webpack-plugin (sortCSSRules) now order by bucket first, then by the respective query comparator within the @media / @container buckets.
- @griffel/sort-css-queries: rewrote compareCSSQueries into a total order (bucket → axis → numeric bound), added min/max-height and and-band support, and a createCompareCSSQueries({ rootFontSize }) factory for rem/em conversion. Never throws.

**Tests & changesets**
Expanded coverage for the comparator, SSR ordering, and both webpack sortCSSRules. Beachball patch change files added for all five affected packages.