### PR TITLE
fix(transform): skip CommonJS files and multi-arg runtime calls inste…

### DIFF
--- a/change/@griffel-transform-skip-cjs-and-runtime-calls-20260715120000.json
+++ b/change/@griffel-transform-skip-cjs-and-runtime-calls-20260715120000.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Skip CommonJS files and multi-argument runtime calls gracefully instead of throwing",
+  "packageName": "@griffel/transform",
+  "email": "copilot@github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transform/__fixtures__/error-argument-count/output.meta.json
+++ b/packages/transform/__fixtures__/error-argument-count/output.meta.json
@@ -1,0 +1,4 @@
+{
+  "usedProcessing": false,
+  "usedVMForEvaluation": false
+}

--- a/packages/transform/__fixtures__/error-argument-count/output.ts
+++ b/packages/transform/__fixtures__/error-argument-count/output.ts
@@ -1,0 +1,4 @@
+import { makeStyles } from '@griffel/react';
+
+// This file is .js intentionally to avoid TS compiler errors
+export const useStyles = makeStyles({ root: { color: 'red' } }, 'foo');

--- a/packages/transform/__fixtures__/error-cjs/output.meta.json
+++ b/packages/transform/__fixtures__/error-cjs/output.meta.json
@@ -1,0 +1,4 @@
+{
+  "usedProcessing": false,
+  "usedVMForEvaluation": false
+}

--- a/packages/transform/__fixtures__/error-cjs/output.ts
+++ b/packages/transform/__fixtures__/error-cjs/output.ts
@@ -1,0 +1,4 @@
+const { makeStyles } = require('@griffel/react');
+
+const useStyles = makeStyles({ root: { color: 'red' } });
+module.exports = { useStyles };

--- a/packages/transform/src/transformSync.mts
+++ b/packages/transform/src/transformSync.mts
@@ -265,9 +265,6 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
         const functionKind = importedName as FunctionKinds;
 
         if (node.arguments.length !== 1) {
-          // Multi-argument calls are the lower-level @griffel/core runtime form
-          // (e.g. makeStyles(styles, insertionFactory)), not the authoring API
-          // this transform rewrites, so skip them.
           return;
         }
 

--- a/packages/transform/src/transformSync.mts
+++ b/packages/transform/src/transformSync.mts
@@ -202,10 +202,8 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
   }
 
   if (parseResult.program.body.length > 0 && !parseResult.module.hasModuleSyntax) {
-    throw new Error(
-      `Transform error: "${filename}" is not an ES module. ` +
-        `@griffel/transform only supports ES modules (files using import/export syntax).`,
-    );
+    // Skip CommonJS files gracefully as they can't contain ESM Griffel imports.
+    return { code: sourceCode, usedProcessing: false, usedVMForEvaluation: false };
   }
 
   const magicString = new MagicString(sourceCode);
@@ -215,7 +213,9 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
   const hasGriffelImports = parseResult.module.staticImports.some(
     si =>
       importsToTransformSet.has(si.moduleRequest.value) &&
-      si.entries.some(e => e.importName.kind === 'Name' && functionsToTransformSet.has(e.importName.name as FunctionKinds)),
+      si.entries.some(
+        e => e.importName.kind === 'Name' && functionsToTransformSet.has(e.importName.name as FunctionKinds),
+      ),
   );
 
   if (!hasGriffelImports) {
@@ -265,9 +265,10 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
         const functionKind = importedName as FunctionKinds;
 
         if (node.arguments.length !== 1) {
-          throw new Error(
-            `${functionKind}() function accepts only a single param, got ${node.arguments.length} in ${filename}`,
-          );
+          // Multi-argument calls are the lower-level @griffel/core runtime form
+          // (e.g. makeStyles(styles, insertionFactory)), not the authoring API
+          // this transform rewrites, so skip them.
+          return;
         }
 
         // Track the import specifier for rewriting (deduped by node start position)

--- a/packages/transform/src/transformSync.test.mts
+++ b/packages/transform/src/transformSync.test.mts
@@ -23,7 +23,9 @@ const nodeResolve: TransformResolver = (id, opts) => {
     }
 
     return {
-      path: (NativeModule as unknown as { _resolveFilename: (id: string, options: unknown) => string })._resolveFilename(id, opts),
+      path: (
+        NativeModule as unknown as { _resolveFilename: (id: string, options: unknown) => string }
+      )._resolveFilename(id, opts),
       builtin: false,
     };
   } finally {
@@ -58,11 +60,7 @@ const fixturesDir = path.join(__dirname, '..', '__fixtures__');
  *
  * Only applied when the meta output contains asset tags; other fixtures pass through unchanged.
  */
-function normalizeAssetOutputs(
-  code: string,
-  meta: string,
-  fixtureDir: string,
-): { code: string; meta: string } {
+function normalizeAssetOutputs(code: string, meta: string, fixtureDir: string): { code: string; meta: string } {
   if (meta.indexOf(ASSET_TAG_OPEN) === -1) {
     return { code, meta };
   }
@@ -250,7 +248,9 @@ const TESTS: TestCase[] = [
     fixture: path.resolve(fixturesDir, 'config-evaluation-rules', 'code.ts'),
     outputFixture: path.resolve(fixturesDir, 'config-evaluation-rules', 'output.ts'),
     transformOptions: {
-      evaluationRules: [{ action: require(path.resolve(fixturesDir, 'config-evaluation-rules', 'sampleEvaluator.cjs')).default }],
+      evaluationRules: [
+        { action: require(path.resolve(fixturesDir, 'config-evaluation-rules', 'sampleEvaluator.cjs')).default },
+      ],
     },
   },
 
@@ -310,9 +310,9 @@ const TESTS: TestCase[] = [
   },
 
   {
-    title: 'errors: throws on CJS',
+    title: 'skips: CommonJS files',
     fixture: path.resolve(fixturesDir, 'error-cjs', 'fixture.js'),
-    error: /is not an ES module/,
+    outputFixture: path.resolve(fixturesDir, 'error-cjs', 'output.ts'),
   },
 
   // Exports
@@ -343,9 +343,9 @@ const TESTS: TestCase[] = [
     },
   },
   {
-    title: 'errors: throws on invalid argument count',
+    title: 'skips: multi-argument runtime calls',
     fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
-    error: /function accepts only a single param/,
+    outputFixture: path.resolve(fixturesDir, 'error-argument-count', 'output.ts'),
   },
   {
     title: 'errors: throws on undefined',


### PR DESCRIPTION
### @griffel/transform: skip non-authoring input instead of throwing
- CommonJS (non-ESM) files now pass through untouched instead of throwing, restoring pre-3.0.x behavior so CJS dependencies (e.g. @fluentui/react lib-commonjs) can flow through the loader.
- Multi-argument Griffel calls — the lower-level @griffel/core runtime form such as makeStyles(styles, insertionFactory) used internally by @griffel/react — are skipped instead of throwing, since they aren't the authoring API this transform rewrites.

Beachball patch change file added for @griffel/transform.