### PR TITLE
feat(transform): return metadata from transformSync

### DIFF
--- a/change/@griffel-transform/transform-return-metadata-20260724131123.json
+++ b/change/@griffel-transform/transform-return-metadata-20260724131123.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: return metadata (CSS entries, source locations, comment directives) from transformSync when generateMetadata is enabled",
+  "packageName": "@griffel/transform",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transform/__fixtures__/assets-multiple-declarations/output.meta.json
+++ b/packages/transform/__fixtures__/assets-multiple-declarations/output.meta.json
@@ -5,5 +5,50 @@
     "d": [
       ".f___0{background-image:url(<griffel-asset>blank.jpg</griffel-asset>),url(<griffel-asset>empty.jpg</griffel-asset>);}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [
+          ".f___0{background-image:url(<griffel-asset>blank.jpg</griffel-asset>),url(<griffel-asset>empty.jpg</griffel-asset>);}"
+        ]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 6,
+          "column": 25,
+          "index": 138
+        },
+        "end": {
+          "line": 8,
+          "column": 2,
+          "index": 214
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 7,
+            "column": 2,
+            "index": 153
+          },
+          "end": {
+            "line": 7,
+            "column": 59,
+            "index": 210
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/assets-reset-styles/output.meta.json
+++ b/packages/transform/__fixtures__/assets-reset-styles/output.meta.json
@@ -7,5 +7,46 @@
       ".r___0:hover{background-image:url(<griffel-asset>blank.jpg</griffel-asset>);}",
       ".r___0:focus{background-image:url(<griffel-asset>empty.jpg</griffel-asset>);}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {},
+    "cssResetEntries": {
+      "useStyles": [
+        ".r___0{background-image:url(<griffel-asset>blank.jpg</griffel-asset>);}",
+        ".r___0:hover{background-image:url(<griffel-asset>blank.jpg</griffel-asset>);}",
+        ".r___0:focus{background-image:url(<griffel-asset>empty.jpg</griffel-asset>);}"
+      ]
+    },
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 7,
+          "column": 25,
+          "index": 185
+        },
+        "end": {
+          "line": 11,
+          "column": 2,
+          "index": 350
+        }
+      }
+    },
+    "locations": {},
+    "resetLocations": {
+      "useStyles": {
+        "start": {
+          "line": 7,
+          "column": 41,
+          "index": 201
+        },
+        "end": {
+          "line": 11,
+          "column": 1,
+          "index": 349
+        }
+      }
+    },
+    "commentDirectives": {},
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/assets-urls/output.meta.json
+++ b/packages/transform/__fixtures__/assets-urls/output.meta.json
@@ -10,5 +10,117 @@
       ".f15gfcnl{background-image:url('data:image/svg+xml,%3Csvg xmlns=\"http://www.w3.org/2000/svg\" height=\"32\" aria-hidden=\"true\" viewBox=\"0 0 16 16\" width=\"32\" data-view-component=\"true\" class=\"octicon octicon-mark-github v-align-middle\"%3E%3Cpath fill-rule=\"evenodd\" d=\"M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z\"%3E%3C/path%3E%3C/svg%3E');}",
       ".f1bk4c0y{filter:url(#a);}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "httpUrl": [".f405sdg{background-image:url(http://www.example.com);}"],
+        "httpsUrl": [".fvpuk3z{background-image:url(https://www.example.com);}"],
+        "httpsUrlWithQuotes": [".fcrzfig{background-image:url(\"https://www.example.com\");}"],
+        "dataUrl": [
+          ".f1b0d1k8{background-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);}"
+        ],
+        "dataUrlQuotes": [
+          ".f15gfcnl{background-image:url('data:image/svg+xml,%3Csvg xmlns=\"http://www.w3.org/2000/svg\" height=\"32\" aria-hidden=\"true\" viewBox=\"0 0 16 16\" width=\"32\" data-view-component=\"true\" class=\"octicon octicon-mark-github v-align-middle\"%3E%3Cpath fill-rule=\"evenodd\" d=\"M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z\"%3E%3C/path%3E%3C/svg%3E');}"
+        ],
+        "hashOnly": [".f1bk4c0y{filter:url(#a);}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 13,
+          "column": 2,
+          "index": 1336
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "httpUrl": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 86
+          },
+          "end": {
+            "line": 4,
+            "column": 61,
+            "index": 145
+          }
+        },
+        "httpsUrl": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 149
+          },
+          "end": {
+            "line": 5,
+            "column": 63,
+            "index": 210
+          }
+        },
+        "httpsUrlWithQuotes": {
+          "start": {
+            "line": 6,
+            "column": 2,
+            "index": 214
+          },
+          "end": {
+            "line": 6,
+            "column": 75,
+            "index": 287
+          }
+        },
+        "dataUrl": {
+          "start": {
+            "line": 7,
+            "column": 2,
+            "index": 291
+          },
+          "end": {
+            "line": 7,
+            "column": 117,
+            "index": 406
+          }
+        },
+        "dataUrlQuotes": {
+          "start": {
+            "line": 8,
+            "column": 2,
+            "index": 410
+          },
+          "end": {
+            "line": 11,
+            "column": 3,
+            "index": 1297
+          }
+        },
+        "hashOnly": {
+          "start": {
+            "line": 12,
+            "column": 2,
+            "index": 1301
+          },
+          "end": {
+            "line": 12,
+            "column": 33,
+            "index": 1332
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/assets/output.meta.json
+++ b/packages/transform/__fixtures__/assets/output.meta.json
@@ -8,5 +8,87 @@
       ".f___2{background-image:url(<griffel-asset>empty.jpg</griffel-asset>);}",
       ".f___3{filter:url(./a.svg#a);}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "rootA": [".f___0{background-image:url(<griffel-asset>blank.jpg</griffel-asset>);}"],
+        "rootB": [".f___1{background-image:url(\"<griffel-asset>blank.jpg</griffel-asset>\");}"],
+        "rootC": [".f___2{background-image:url(<griffel-asset>empty.jpg</griffel-asset>);}"],
+        "assetWithHash": [".f___3{filter:url(./a.svg#a);}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 7,
+          "column": 25,
+          "index": 180
+        },
+        "end": {
+          "line": 12,
+          "column": 2,
+          "index": 394
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "rootA": {
+          "start": {
+            "line": 8,
+            "column": 2,
+            "index": 195
+          },
+          "end": {
+            "line": 8,
+            "column": 45,
+            "index": 238
+          }
+        },
+        "rootB": {
+          "start": {
+            "line": 9,
+            "column": 2,
+            "index": 242
+          },
+          "end": {
+            "line": 9,
+            "column": 56,
+            "index": 296
+          }
+        },
+        "rootC": {
+          "start": {
+            "line": 10,
+            "column": 2,
+            "index": 300
+          },
+          "end": {
+            "line": 10,
+            "column": 45,
+            "index": 343
+          }
+        },
+        "assetWithHash": {
+          "start": {
+            "line": 11,
+            "column": 2,
+            "index": 347
+          },
+          "end": {
+            "line": 11,
+            "column": 45,
+            "index": 390
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/at-rules/output.meta.json
+++ b/packages/transform/__fixtures__/at-rules/output.meta.json
@@ -11,5 +11,51 @@
       ]
     ],
     "t": ["@supports (display: flex){.f1dyc5nu{padding-left:4px;}.f1kq3x14{padding-right:4px;}}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [
+          "@media (min-width: 600px){.f1h4p6a1{padding-right:4px;}.fgefjy{padding-left:4px;}}",
+          "@supports (display: flex){.f1dyc5nu{padding-left:4px;}.f1kq3x14{padding-right:4px;}}"
+        ]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 14,
+          "column": 2,
+          "index": 291
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 86
+          },
+          "end": {
+            "line": 13,
+            "column": 3,
+            "index": 287
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/config-classname-hash-salt/output.meta.json
+++ b/packages/transform/__fixtures__/config-classname-hash-salt/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
     "d": [".feohi3x{color:red;}", ".f1rwgqon{padding-left:4px;}", ".f1tyzn0d{padding-right:4px;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".feohi3x{color:red;}", ".f1rwgqon{padding-left:4px;}", ".f1tyzn0d{padding-right:4px;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 5,
+          "column": 2,
+          "index": 132
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 86
+          },
+          "end": {
+            "line": 4,
+            "column": 44,
+            "index": 128
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/config-evaluation-rules/output.meta.json
+++ b/packages/transform/__fixtures__/config-evaluation-rules/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": true,
   "cssRulesByBucket": {
     "d": [".f163i14w{color:blue;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".f163i14w{color:blue;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 108
+        },
+        "end": {
+          "line": 8,
+          "column": 2,
+          "index": 351
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 7,
+            "column": 2,
+            "index": 322
+          },
+          "end": {
+            "line": 7,
+            "column": 27,
+            "index": 347
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/export-default/output.meta.json
+++ b/packages/transform/__fixtures__/export-default/output.meta.json
@@ -10,5 +10,61 @@
       ".fjf1xye{margin-left:4px;}",
       ".f8zmjen{margin-right:4px;}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "unknownHook": {
+        "root": [".fe3e8s9{color:red;}", ".fycuoez{padding-left:4px;}", ".f8wuabp{padding-right:4px;}"],
+        "icon": [".fcnqdeg{background-color:green;}", ".fjf1xye{margin-left:4px;}", ".f8zmjen{margin-right:4px;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "unknownHook": {
+        "start": {
+          "line": 3,
+          "column": 15,
+          "index": 61
+        },
+        "end": {
+          "line": 6,
+          "column": 2,
+          "index": 179
+        }
+      }
+    },
+    "locations": {
+      "unknownHook": {
+        "root": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 76
+          },
+          "end": {
+            "line": 4,
+            "column": 44,
+            "index": 118
+          }
+        },
+        "icon": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 122
+          },
+          "end": {
+            "line": 5,
+            "column": 55,
+            "index": 175
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "unknownHook": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/function-mixin/output.meta.json
+++ b/packages/transform/__fixtures__/function-mixin/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": true,
   "cssRulesByBucket": {
     "d": [".f1817uup{color:var(--colorBrandBackground);}", ".ftgm304{display:block;}", ".fk73vx1{opacity:0;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "avatar": [".f1817uup{color:var(--colorBrandBackground);}", ".ftgm304{display:block;}", ".fk73vx1{opacity:0;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 111
+        },
+        "end": {
+          "line": 6,
+          "column": 2,
+          "index": 185
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "avatar": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 126
+          },
+          "end": {
+            "line": 5,
+            "column": 57,
+            "index": 181
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/import-alias/output.meta.json
+++ b/packages/transform/__fixtures__/import-alias/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
     "d": [".fe3e8s9{color:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".fe3e8s9{color:red;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 87
+        },
+        "end": {
+          "line": 5,
+          "column": 2,
+          "index": 130
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 104
+          },
+          "end": {
+            "line": 4,
+            "column": 24,
+            "index": 126
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/import-custom-module/output.meta.json
+++ b/packages/transform/__fixtures__/import-custom-module/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
     "d": [".fe3e8s9{color:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".fe3e8s9{color:red;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 152
+        },
+        "end": {
+          "line": 6,
+          "column": 2,
+          "index": 193
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 167
+          },
+          "end": {
+            "line": 5,
+            "column": 24,
+            "index": 189
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/keyframes/output.meta.json
+++ b/packages/transform/__fixtures__/keyframes/output.meta.json
@@ -13,5 +13,61 @@
       ".f1e467oh{animation-name:f1q8eu9e,f19fnzg9;}",
       ".f1w9bd63{animation-name:f55c0se,f19fnzg9;}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "single": [".f1g6ul6r{animation-name:f1q8eu9e;}", ".f1fp4ujf{animation-name:f55c0se;}"],
+        "multiple": [".f1e467oh{animation-name:f1q8eu9e,f19fnzg9;}", ".f1w9bd63{animation-name:f55c0se,f19fnzg9;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 22,
+          "column": 2,
+          "index": 456
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "single": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 86
+          },
+          "end": {
+            "line": 9,
+            "column": 3,
+            "index": 213
+          }
+        },
+        "multiple": {
+          "start": {
+            "line": 10,
+            "column": 2,
+            "index": 217
+          },
+          "end": {
+            "line": 21,
+            "column": 3,
+            "index": 452
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/multiple-declarations/code.ts
+++ b/packages/transform/__fixtures__/multiple-declarations/code.ts
@@ -1,8 +1,12 @@
-import { makeStyles } from '@griffel/react';
+import { makeResetStyles, makeStyles } from '@griffel/react';
 
 export const useStyles1 = makeStyles({
   root: { color: 'red' },
+  icon: { color: 'blue' },
 });
 export const useStyles2 = makeStyles({
   root: { color: 'green' },
 });
+
+export const useResetStyles1 = makeResetStyles({ color: 'red' });
+export const useResetStyles2 = makeResetStyles({ color: 'green' });

--- a/packages/transform/__fixtures__/multiple-declarations/output.meta.json
+++ b/packages/transform/__fixtures__/multiple-declarations/output.meta.json
@@ -2,6 +2,145 @@
   "usedProcessing": true,
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
-    "d": [".fka9v86{color:green;}", ".fe3e8s9{color:red;}"]
+    "r": [".rbjcoli{color:green;}", ".rtokvmb{color:red;}"],
+    "d": [".fka9v86{color:green;}", ".fe3e8s9{color:red;}", ".f163i14w{color:blue;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles1": {
+        "root": [".fe3e8s9{color:red;}"],
+        "icon": [".f163i14w{color:blue;}"]
+      },
+      "useStyles2": {
+        "root": [".fka9v86{color:green;}"]
+      }
+    },
+    "cssResetEntries": {
+      "useResetStyles1": [".rtokvmb{color:red;}"],
+      "useResetStyles2": [".rbjcoli{color:green;}"]
+    },
+    "callExpressionLocations": {
+      "useStyles1": {
+        "start": {
+          "line": 3,
+          "column": 26,
+          "index": 89
+        },
+        "end": {
+          "line": 6,
+          "column": 2,
+          "index": 157
+        }
+      },
+      "useStyles2": {
+        "start": {
+          "line": 7,
+          "column": 26,
+          "index": 185
+        },
+        "end": {
+          "line": 9,
+          "column": 2,
+          "index": 228
+        }
+      },
+      "useResetStyles1": {
+        "start": {
+          "line": 11,
+          "column": 31,
+          "index": 262
+        },
+        "end": {
+          "line": 11,
+          "column": 64,
+          "index": 295
+        }
+      },
+      "useResetStyles2": {
+        "start": {
+          "line": 12,
+          "column": 31,
+          "index": 328
+        },
+        "end": {
+          "line": 12,
+          "column": 66,
+          "index": 363
+        }
+      }
+    },
+    "locations": {
+      "useStyles1": {
+        "root": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 104
+          },
+          "end": {
+            "line": 4,
+            "column": 24,
+            "index": 126
+          }
+        },
+        "icon": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 130
+          },
+          "end": {
+            "line": 5,
+            "column": 25,
+            "index": 153
+          }
+        }
+      },
+      "useStyles2": {
+        "root": {
+          "start": {
+            "line": 8,
+            "column": 2,
+            "index": 200
+          },
+          "end": {
+            "line": 8,
+            "column": 26,
+            "index": 224
+          }
+        }
+      }
+    },
+    "resetLocations": {
+      "useResetStyles1": {
+        "start": {
+          "line": 11,
+          "column": 47,
+          "index": 278
+        },
+        "end": {
+          "line": 11,
+          "column": 63,
+          "index": 294
+        }
+      },
+      "useResetStyles2": {
+        "start": {
+          "line": 12,
+          "column": 47,
+          "index": 344
+        },
+        "end": {
+          "line": 12,
+          "column": 65,
+          "index": 362
+        }
+      }
+    },
+    "commentDirectives": {
+      "useStyles1": {},
+      "useStyles2": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/multiple-declarations/output.ts
+++ b/packages/transform/__fixtures__/multiple-declarations/output.ts
@@ -1,4 +1,7 @@
-import { __css } from '@griffel/react';
+import { __resetCSS, __css } from '@griffel/react';
 
-export const useStyles1 = __css({ root: { sj55zd: 'fe3e8s9' } });
+export const useStyles1 = __css({ root: { sj55zd: 'fe3e8s9' }, icon: { sj55zd: 'f163i14w' } });
 export const useStyles2 = __css({ root: { sj55zd: 'fka9v86' } });
+
+export const useResetStyles1 = __resetCSS('rtokvmb', null);
+export const useResetStyles2 = __resetCSS('rbjcoli', null);

--- a/packages/transform/__fixtures__/non-existing-module-call/output.meta.json
+++ b/packages/transform/__fixtures__/non-existing-module-call/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
     "d": [".fe3e8s9{color:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "container": [".fe3e8s9{color:red;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 112
+        },
+        "end": {
+          "line": 8,
+          "column": 2,
+          "index": 165
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "container": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 127
+          },
+          "end": {
+            "line": 7,
+            "column": 3,
+            "index": 161
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-computed-keys/output.meta.json
+++ b/packages/transform/__fixtures__/object-computed-keys/output.meta.json
@@ -10,5 +10,53 @@
       ".fjf1xye{margin-left:4px;}",
       ".f8zmjen{margin-right:4px;}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".fe3e8s9{color:red;}", ".fycuoez{padding-left:4px;}", ".f8wuabp{padding-right:4px;}"],
+        "rootprimary": [
+          ".fcnqdeg{background-color:green;}",
+          ".fjf1xye{margin-left:4px;}",
+          ".f8zmjen{margin-right:4px;}"
+        ]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 5,
+          "column": 25,
+          "index": 97
+        },
+        "end": {
+          "line": 8,
+          "column": 2,
+          "index": 239
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "rootSlot": {
+          "start": {
+            "line": 6,
+            "column": 2,
+            "index": 112
+          },
+          "end": {
+            "line": 6,
+            "column": 50,
+            "index": 160
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-imported-keys/output.meta.json
+++ b/packages/transform/__fixtures__/object-imported-keys/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": true,
   "cssRulesByBucket": {
     "d": [".f1wgwx3x .component-bar{color:red;}", ".fglt6ox .component-foo{color:blue;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".f1wgwx3x .component-bar{color:red;}", ".fglt6ox .component-foo{color:blue;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 119
+        },
+        "end": {
+          "line": 9,
+          "column": 2,
+          "index": 227
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 134
+          },
+          "end": {
+            "line": 8,
+            "column": 3,
+            "index": 223
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-mixins/output.meta.json
+++ b/packages/transform/__fixtures__/object-mixins/output.meta.json
@@ -12,5 +12,100 @@
       ".f85kjgz{grid-row-gap:10px;}",
       ".fka9v86{color:green;}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".f22iagw{display:flex;}", ".f1vx9l62{flex-direction:column;}"],
+        "label": [".figsok6{font-weight:var(--fontWeightRegular);}"],
+        "header": [".f16wzh4i{font-weight:bold;}"],
+        "icon": [".f22iagw{display:flex;}", ".f1vx9l62{flex-direction:column;}", ".fe3e8s9{color:red;}"],
+        "image": [".f13qh94s{display:grid;}", ".f85kjgz{grid-row-gap:10px;}", ".fka9v86{color:green;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 134
+        },
+        "end": {
+          "line": 11,
+          "column": 2,
+          "index": 318
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 149
+          },
+          "end": {
+            "line": 5,
+            "column": 18,
+            "index": 165
+          }
+        },
+        "label": {
+          "start": {
+            "line": 6,
+            "column": 2,
+            "index": 169
+          },
+          "end": {
+            "line": 6,
+            "column": 24,
+            "index": 191
+          }
+        },
+        "header": {
+          "start": {
+            "line": 7,
+            "column": 2,
+            "index": 195
+          },
+          "end": {
+            "line": 7,
+            "column": 27,
+            "index": 220
+          }
+        },
+        "icon": {
+          "start": {
+            "line": 9,
+            "column": 2,
+            "index": 225
+          },
+          "end": {
+            "line": 9,
+            "column": 39,
+            "index": 262
+          }
+        },
+        "image": {
+          "start": {
+            "line": 10,
+            "column": 2,
+            "index": 266
+          },
+          "end": {
+            "line": 10,
+            "column": 50,
+            "index": 314
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-nesting/output.meta.json
+++ b/packages/transform/__fixtures__/object-nesting/output.meta.json
@@ -5,5 +5,53 @@
     "d": [".f22iagw{display:flex;}", ".fh8e7tb .foo:hover{color:green;}"],
     "h": [".faf35ka:hover{color:red;}"],
     "f": [".f17t1d3d:focus:hover{color:blue;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [
+          ".f22iagw{display:flex;}",
+          ".faf35ka:hover{color:red;}",
+          ".f17t1d3d:focus:hover{color:blue;}",
+          ".fh8e7tb .foo:hover{color:green;}"
+        ]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 109
+        },
+        "end": {
+          "line": 13,
+          "column": 2,
+          "index": 292
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 124
+          },
+          "end": {
+            "line": 12,
+            "column": 3,
+            "index": 288
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-reset/output.meta.json
+++ b/packages/transform/__fixtures__/object-reset/output.meta.json
@@ -3,5 +3,61 @@
   "usedVMForEvaluation": true,
   "cssRulesByBucket": {
     "d": [".fe3e8s9{color:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".fe3e8s9{color:red;}"],
+        "icon": []
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 5,
+          "column": 25,
+          "index": 160
+        },
+        "end": {
+          "line": 8,
+          "column": 2,
+          "index": 247
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 6,
+            "column": 2,
+            "index": 175
+          },
+          "end": {
+            "line": 6,
+            "column": 44,
+            "index": 217
+          }
+        },
+        "icon": {
+          "start": {
+            "line": 7,
+            "column": 2,
+            "index": 221
+          },
+          "end": {
+            "line": 7,
+            "column": 24,
+            "index": 243
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-sequence-expr/output.meta.json
+++ b/packages/transform/__fixtures__/object-sequence-expr/output.meta.json
@@ -3,5 +3,48 @@
   "usedVMForEvaluation": true,
   "cssRulesByBucket": {
     "h": [".f1cm6cy7:hover .fui-Switch:before{background-color:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".f1cm6cy7:hover .fui-Switch:before{background-color:red;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 7,
+          "column": 25,
+          "index": 200
+        },
+        "end": {
+          "line": 16,
+          "column": 2,
+          "index": 358
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 8,
+            "column": 2,
+            "index": 215
+          },
+          "end": {
+            "line": 15,
+            "column": 7,
+            "index": 354
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-shorthands/output.meta.json
+++ b/packages/transform/__fixtures__/object-shorthands/output.meta.json
@@ -16,5 +16,48 @@
         }
       ]
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".fq3r367{border-right:5px solid red ;}", ".f171p8tk{border-bottom:5px solid red;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 8,
+          "column": 2,
+          "index": 184
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 86
+          },
+          "end": {
+            "line": 7,
+            "column": 3,
+            "index": 180
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object-variables/output.meta.json
+++ b/packages/transform/__fixtures__/object-variables/output.meta.json
@@ -11,5 +11,66 @@
       ".fjf1xye{margin-left:4px;}",
       ".f8zmjen{margin-right:4px;}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".fe3e8s9{color:red;}", ".fycuoez{padding-left:4px;}", ".f8wuabp{padding-right:4px;}"],
+        "icon": [
+          ".fusgiwz{color:#000;}",
+          ".fcnqdeg{background-color:green;}",
+          ".fjf1xye{margin-left:4px;}",
+          ".f8zmjen{margin-right:4px;}"
+        ]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 6,
+          "column": 25,
+          "index": 140
+        },
+        "end": {
+          "line": 9,
+          "column": 2,
+          "index": 284
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 7,
+            "column": 2,
+            "index": 155
+          },
+          "end": {
+            "line": 7,
+            "column": 47,
+            "index": 200
+          }
+        },
+        "icon": {
+          "start": {
+            "line": 8,
+            "column": 2,
+            "index": 204
+          },
+          "end": {
+            "line": 8,
+            "column": 78,
+            "index": 280
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/object/code.ts
+++ b/packages/transform/__fixtures__/object/code.ts
@@ -1,6 +1,8 @@
 import { makeStyles } from '@griffel/react';
 
 export const useStyles = makeStyles({
+  // griffel-csslint-disable color-named
+  // griffel-csslint-disable color-no-hex
   root: { color: 'red', paddingLeft: '4px' },
   icon: { backgroundColor: 'green', marginLeft: '4px' },
 });

--- a/packages/transform/__fixtures__/object/output.meta.json
+++ b/packages/transform/__fixtures__/object/output.meta.json
@@ -10,5 +10,66 @@
       ".fjf1xye{margin-left:4px;}",
       ".f8zmjen{margin-right:4px;}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".fe3e8s9{color:red;}", ".fycuoez{padding-left:4px;}", ".f8wuabp{padding-right:4px;}"],
+        "icon": [".fcnqdeg{background-color:green;}", ".fjf1xye{margin-left:4px;}", ".f8zmjen{margin-right:4px;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 8,
+          "column": 2,
+          "index": 272
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 6,
+            "column": 2,
+            "index": 169
+          },
+          "end": {
+            "line": 6,
+            "column": 44,
+            "index": 211
+          }
+        },
+        "icon": {
+          "start": {
+            "line": 7,
+            "column": 2,
+            "index": 215
+          },
+          "end": {
+            "line": 7,
+            "column": 55,
+            "index": 268
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {
+        "root": [
+          ["griffel-csslint-disable", "color-named"],
+          ["griffel-csslint-disable", "color-no-hex"]
+        ]
+      }
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/reset-styles-at-rules/output.meta.json
+++ b/packages/transform/__fixtures__/reset-styles-at-rules/output.meta.json
@@ -4,5 +4,46 @@
   "cssRulesByBucket": {
     "r": [".rjrhw4c{color:red;}"],
     "s": ["@supports (display: flex){.rjrhw4c{color:pink;}}", "@media (min-width: 100px){.rjrhw4c{color:blue;}}"]
+  },
+  "metadata": {
+    "cssEntries": {},
+    "cssResetEntries": {
+      "useStyles": [
+        ".rjrhw4c{color:red;}",
+        "@supports (display: flex){.rjrhw4c{color:pink;}}",
+        "@media (min-width: 100px){.rjrhw4c{color:blue;}}"
+      ]
+    },
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 76
+        },
+        "end": {
+          "line": 7,
+          "column": 2,
+          "index": 212
+        }
+      }
+    },
+    "locations": {},
+    "resetLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 41,
+          "index": 92
+        },
+        "end": {
+          "line": 7,
+          "column": 1,
+          "index": 211
+        }
+      }
+    },
+    "commentDirectives": {},
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/reset-styles/code.ts
+++ b/packages/transform/__fixtures__/reset-styles/code.ts
@@ -1,6 +1,15 @@
 import { makeResetStyles } from '@griffel/react';
 
+// griffel-csslint-disable color-named
 export const useStyles = makeResetStyles({
   color: 'red',
   paddingLeft: '4px',
 });
+
+// griffel-csslint-disable color-named
+// griffel-csslint-disable color-no-hex
+const useOtherStyles = makeResetStyles({
+  color: 'blue',
+});
+
+export { useOtherStyles };

--- a/packages/transform/__fixtures__/reset-styles/output.meta.json
+++ b/packages/transform/__fixtures__/reset-styles/output.meta.json
@@ -2,6 +2,74 @@
   "usedProcessing": true,
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
-    "r": [".rjefjbm{color:red;padding-left:4px;}", ".r7z97ji{color:red;padding-right:4px;}"]
+    "r": [".r14ksm7b{color:blue;}", ".rjefjbm{color:red;padding-left:4px;}", ".r7z97ji{color:red;padding-right:4px;}"]
+  },
+  "metadata": {
+    "cssEntries": {},
+    "cssResetEntries": {
+      "useStyles": [".rjefjbm{color:red;padding-left:4px;}", ".r7z97ji{color:red;padding-right:4px;}"],
+      "useOtherStyles": [".r14ksm7b{color:blue;}"]
+    },
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 115
+        },
+        "end": {
+          "line": 7,
+          "column": 2,
+          "index": 173
+        }
+      },
+      "useOtherStyles": {
+        "start": {
+          "line": 11,
+          "column": 23,
+          "index": 278
+        },
+        "end": {
+          "line": 13,
+          "column": 2,
+          "index": 315
+        }
+      }
+    },
+    "locations": {},
+    "resetLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 41,
+          "index": 131
+        },
+        "end": {
+          "line": 7,
+          "column": 1,
+          "index": 172
+        }
+      },
+      "useOtherStyles": {
+        "start": {
+          "line": 11,
+          "column": 39,
+          "index": 294
+        },
+        "end": {
+          "line": 13,
+          "column": 1,
+          "index": 314
+        }
+      }
+    },
+    "commentDirectives": {},
+    "resetCommentDirectives": {
+      "useStyles": [["griffel-csslint-disable", "color-named"]],
+      "useOtherStyles": [
+        ["griffel-csslint-disable", "color-named"],
+        ["griffel-csslint-disable", "color-no-hex"]
+      ]
+    }
   }
 }

--- a/packages/transform/__fixtures__/reset-styles/output.ts
+++ b/packages/transform/__fixtures__/reset-styles/output.ts
@@ -1,3 +1,10 @@
 import { __resetCSS } from '@griffel/react';
 
+// griffel-csslint-disable color-named
 export const useStyles = __resetCSS('rjefjbm', 'r7z97ji');
+
+// griffel-csslint-disable color-named
+// griffel-csslint-disable color-no-hex
+const useOtherStyles = __resetCSS('r14ksm7b', null);
+
+export { useOtherStyles };

--- a/packages/transform/__fixtures__/rules-with-metadata/output.meta.json
+++ b/packages/transform/__fixtures__/rules-with-metadata/output.meta.json
@@ -10,5 +10,48 @@
         }
       ]
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "media": ["@media screen and (max-width: 100px){.ful25cn{color:red;}}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 9,
+          "column": 2,
+          "index": 175
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "media": {
+          "start": {
+            "line": 4,
+            "column": 2,
+            "index": 86
+          },
+          "end": {
+            "line": 8,
+            "column": 3,
+            "index": 171
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/shared-mixins/output.meta.json
+++ b/packages/transform/__fixtures__/shared-mixins/output.meta.json
@@ -3,5 +3,50 @@
   "usedVMForEvaluation": true,
   "cssRulesByBucket": {
     "d": [".f22iagw{display:flex;}", ".f13qh94s{display:grid;}", ".fe3e8s9{color:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [".f22iagw{display:flex;}"],
+        "container": [".f13qh94s{display:grid;}"],
+        "icon": [".fe3e8s9{color:red;}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 112
+        },
+        "end": {
+          "line": 7,
+          "column": 2,
+          "index": 172
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "icon": {
+          "start": {
+            "line": 6,
+            "column": 2,
+            "index": 146
+          },
+          "end": {
+            "line": 6,
+            "column": 24,
+            "index": 168
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/static-styles-array/output.meta.json
+++ b/packages/transform/__fixtures__/static-styles-array/output.meta.json
@@ -3,5 +3,27 @@
   "usedVMForEvaluation": true,
   "cssRulesByBucket": {
     "d": ["body{background:red;}", "html{margin:0;}"]
+  },
+  "metadata": {
+    "cssEntries": {},
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStaticStyles": {
+        "start": {
+          "line": 3,
+          "column": 31,
+          "index": 83
+        },
+        "end": {
+          "line": 10,
+          "column": 2,
+          "index": 182
+        }
+      }
+    },
+    "locations": {},
+    "resetLocations": {},
+    "commentDirectives": {},
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/static-styles-string/output.meta.json
+++ b/packages/transform/__fixtures__/static-styles-string/output.meta.json
@@ -3,5 +3,27 @@
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
     "d": ["body{background:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {},
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStaticStyles": {
+        "start": {
+          "line": 3,
+          "column": 31,
+          "index": 83
+        },
+        "end": {
+          "line": 3,
+          "column": 76,
+          "index": 128
+        }
+      }
+    },
+    "locations": {},
+    "resetLocations": {},
+    "commentDirectives": {},
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/static-styles/output.meta.json
+++ b/packages/transform/__fixtures__/static-styles/output.meta.json
@@ -3,5 +3,27 @@
   "usedVMForEvaluation": false,
   "cssRulesByBucket": {
     "d": ["body{background:red;}"]
+  },
+  "metadata": {
+    "cssEntries": {},
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStaticStyles": {
+        "start": {
+          "line": 3,
+          "column": 31,
+          "index": 83
+        },
+        "end": {
+          "line": 7,
+          "column": 2,
+          "index": 142
+        }
+      }
+    },
+    "locations": {},
+    "resetLocations": {},
+    "commentDirectives": {},
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/tokens/output.meta.json
+++ b/packages/transform/__fixtures__/tokens/output.meta.json
@@ -8,5 +8,65 @@
       ".f22iagw{display:flex;}",
       ".f1817uup{color:var(--colorBrandBackground);}"
     ]
+  },
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": [
+          ".f1734hy{background-color:black;}",
+          ".ff34w31{color:var(--colorPaletteBlueBorder2);}",
+          ".f22iagw{display:flex;}"
+        ],
+        "rootPrimary": [".f1817uup{color:var(--colorBrandBackground);}"]
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 4,
+          "column": 25,
+          "index": 112
+        },
+        "end": {
+          "line": 11,
+          "column": 2,
+          "index": 303
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 5,
+            "column": 2,
+            "index": 127
+          },
+          "end": {
+            "line": 9,
+            "column": 3,
+            "index": 238
+          }
+        },
+        "rootPrimary": {
+          "start": {
+            "line": 10,
+            "column": 2,
+            "index": 242
+          },
+          "end": {
+            "line": 10,
+            "column": 59,
+            "index": 299
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
   }
 }

--- a/packages/transform/__fixtures__/unsupported-css-properties/output.meta.json
+++ b/packages/transform/__fixtures__/unsupported-css-properties/output.meta.json
@@ -1,5 +1,48 @@
 {
   "usedProcessing": true,
   "usedVMForEvaluation": false,
-  "cssRulesByBucket": {}
+  "cssRulesByBucket": {},
+  "metadata": {
+    "cssEntries": {
+      "useStyles": {
+        "root": []
+      }
+    },
+    "cssResetEntries": {},
+    "callExpressionLocations": {
+      "useStyles": {
+        "start": {
+          "line": 3,
+          "column": 25,
+          "index": 71
+        },
+        "end": {
+          "line": 16,
+          "column": 2,
+          "index": 576
+        }
+      }
+    },
+    "locations": {
+      "useStyles": {
+        "root": {
+          "start": {
+            "line": 6,
+            "column": 2,
+            "index": 183
+          },
+          "end": {
+            "line": 15,
+            "column": 3,
+            "index": 572
+          }
+        }
+      }
+    },
+    "resetLocations": {},
+    "commentDirectives": {
+      "useStyles": {}
+    },
+    "resetCommentDirectives": {}
+  }
 }

--- a/packages/transform/src/generateTransformMetadata.mts
+++ b/packages/transform/src/generateTransformMetadata.mts
@@ -1,0 +1,296 @@
+import type { Comment, ObjectExpression, Program } from 'oxc-parser';
+import { normalizeCSSBucketEntry, type CSSClassesMapBySlot, type CSSRulesByBucket } from '@griffel/core';
+
+import { createLineOffsetTable, type LineOffsetTable } from './sourceLocation.mjs';
+import type {
+  StyleCall,
+  TransformMetadata,
+  TransformMetadataCommentDirective,
+  TransformMetadataSourceLocation,
+} from './types.mjs';
+
+/** CSS output produced while transforming a `makeStyles()` call. */
+export type StylesCSSOutput = {
+  classnamesMapping: CSSClassesMapBySlot<string>;
+  resolvedCSSRules: CSSRulesByBucket;
+};
+
+/** CSS output produced while transforming a `makeResetStyles()` call. */
+export type ResetCSSOutput = string[] | CSSRulesByBucket;
+
+/**
+ * A single style call paired with the CSS output produced while transforming it. This is the
+ * per-call contract consumed by `generateTransformMetadata()`: the caller emits one entry per style call,
+ * in source order, so that no lookup by declarator id is required.
+ */
+export type ProcessedStyleCall = { styleCall: StyleCall } & (
+  | { functionKind: 'makeStyles'; css: StylesCSSOutput }
+  | { functionKind: 'makeResetStyles'; css: ResetCSSOutput }
+  | { functionKind: 'makeStaticStyles' }
+);
+
+export type GenerateMetadataOptions = {
+  source: string;
+  program: Program;
+  comments: Comment[];
+  processedStyleCalls: ProcessedStyleCall[];
+};
+
+/**
+ * Builds transform metadata (CSS entries, source locations, comment directives) from the collected
+ * style calls and their resolved CSS output.
+ *
+ * Style calls are iterated in source order, so all entries (and their keys) are produced
+ * top-to-bottom, matching the order in which consumers (e.g. `@griffel/postcss-syntax`) emit CSS.
+ */
+export function generateTransformMetadata(options: GenerateMetadataOptions): TransformMetadata {
+  const { source, program, comments, processedStyleCalls } = options;
+
+  const offsets = createLineOffsetTable(source);
+  const metadata: TransformMetadata = {
+    cssEntries: {},
+    cssResetEntries: {},
+    callExpressionLocations: {},
+    locations: {},
+    resetLocations: {},
+    commentDirectives: {},
+    resetCommentDirectives: {},
+  };
+
+  for (const processed of processedStyleCalls) {
+    const { styleCall } = processed;
+    const { declaratorId, argumentNode } = styleCall;
+
+    metadata.callExpressionLocations[declaratorId] = offsets.locate(styleCall.callStart, styleCall.callEnd);
+
+    switch (processed.functionKind) {
+      case 'makeStyles': {
+        metadata.cssEntries[declaratorId] = getSlotCSSEntries(
+          processed.css.classnamesMapping,
+          processed.css.resolvedCSSRules,
+        );
+
+        if (argumentNode.type === 'ObjectExpression') {
+          const slots = collectSlotMetadata(argumentNode, comments, offsets);
+
+          metadata.locations[declaratorId] = slots.locations;
+          metadata.commentDirectives[declaratorId] = slots.commentDirectives;
+        }
+
+        break;
+      }
+
+      case 'makeResetStyles': {
+        metadata.cssResetEntries[declaratorId] = getResetCSSEntries(processed.css);
+
+        if (argumentNode.type === 'ObjectExpression') {
+          metadata.resetLocations[declaratorId] = offsets.locate(argumentNode.start, argumentNode.end);
+        }
+
+        const directives = collectResetCommentDirectives(styleCall, program, comments);
+
+        if (directives.length > 0) {
+          metadata.resetCommentDirectives[declaratorId] = directives;
+        }
+
+        break;
+      }
+
+      case 'makeStaticStyles': {
+        // `makeStaticStyles()` produces no per-slot metadata.
+        break;
+      }
+    }
+  }
+
+  return metadata;
+}
+
+/**
+ * Maps each `makeStyles()` slot to its unique CSS rules, matching class names against the resolved
+ * rules produced by `resolveStyleRulesForSlots()`.
+ *
+ * Rules are deduplicated: at-rules group every class sharing the same condition into a single rule
+ * (e.g. `@media (min-width: 600px){.a{…}.b{…}}`), so multiple class names of a slot can resolve to
+ * the very same rule.
+ */
+function getSlotCSSEntries(
+  classnamesMapping: CSSClassesMapBySlot<string>,
+  resolvedCSSRules: CSSRulesByBucket,
+): Record<string, string[]> {
+  const cssRules = flattenCSSRules(resolvedCSSRules);
+
+  const slotEntries = Object.entries(classnamesMapping).map(([slot, cssClassesMap]) => {
+    const classNames = new Set<string>();
+
+    for (const cssClasses of Object.values(cssClassesMap)) {
+      if (typeof cssClasses === 'string') {
+        classNames.add(cssClasses);
+      } else if (Array.isArray(cssClasses)) {
+        for (const cssClass of cssClasses) {
+          classNames.add(cssClass);
+        }
+      }
+    }
+
+    const rules = new Set<string>();
+
+    for (const cssClass of classNames) {
+      const cssRule = cssRules.find(rule => rule.includes(cssClass));
+
+      if (cssRule) {
+        rules.add(cssRule);
+      }
+    }
+
+    return [slot, Array.from(rules)] as const;
+  });
+
+  return Object.fromEntries(slotEntries);
+}
+
+/**
+ * Flattens the CSS rules from every bucket of a `makeResetStyles()` call into a single list.
+ */
+function getResetCSSEntries(cssRules: ResetCSSOutput): string[] {
+  const cssRulesByBucket: CSSRulesByBucket = Array.isArray(cssRules) ? { d: cssRules } : cssRules;
+
+  return Object.values(cssRulesByBucket).flatMap(bucketEntries =>
+    bucketEntries.map(bucketEntry => {
+      if (Array.isArray(bucketEntry)) {
+        throw new Error(
+          `CSS rules in buckets for "makeResetStyles()" should not contain arrays, got: ${JSON.stringify(
+            bucketEntry,
+          )})}`,
+        );
+      }
+
+      return bucketEntry;
+    }),
+  );
+}
+
+function flattenCSSRules(cssRulesByBucket: CSSRulesByBucket): string[] {
+  return Object.values(cssRulesByBucket).flatMap(bucketEntries =>
+    bucketEntries.map(bucketEntry => normalizeCSSBucketEntry(bucketEntry)[0]),
+  );
+}
+
+/**
+ * Collects the source location and comment directives of every named slot in a `makeStyles()`
+ * object argument, in a single pass over its properties.
+ */
+function collectSlotMetadata(
+  objectExpression: ObjectExpression,
+  comments: Comment[],
+  offsets: LineOffsetTable,
+): {
+  locations: Record<string, TransformMetadataSourceLocation>;
+  commentDirectives: Record<string, TransformMetadataCommentDirective[]>;
+} {
+  const locations: Record<string, TransformMetadataSourceLocation> = {};
+  const commentDirectives: Record<string, TransformMetadataCommentDirective[]> = {};
+
+  // Comment directives attached to a slot live between the previous property and this one.
+  let precedingEnd = objectExpression.start;
+
+  for (const property of objectExpression.properties) {
+    const commentRangeStart = precedingEnd;
+    precedingEnd = property.end;
+
+    if (property.type !== 'Property') {
+      continue;
+    }
+
+    const { key } = property;
+
+    if (key.type !== 'Identifier') {
+      continue;
+    }
+
+    locations[key.name] = offsets.locate(property.start, property.end);
+
+    const directives = parseCommentDirectives(comments, commentRangeStart, property.start);
+
+    if (directives.length > 0) {
+      commentDirectives[key.name] = directives;
+    }
+  }
+
+  return { locations, commentDirectives };
+}
+
+/**
+ * Collects comment directives that precede the top-level statement containing a `makeResetStyles()`
+ * call (i.e. the `VariableDeclaration` or `ExportNamedDeclaration`).
+ */
+function collectResetCommentDirectives(
+  styleCall: StyleCall,
+  program: Program,
+  comments: Comment[],
+): TransformMetadataCommentDirective[] {
+  const leadingRange = getLeadingCommentRange(program, styleCall.callStart, styleCall.callEnd);
+
+  if (!leadingRange) {
+    return [];
+  }
+
+  return parseCommentDirectives(comments, leadingRange.start, leadingRange.end);
+}
+
+/**
+ * Returns the offset range in which leading comments for the top-level statement containing
+ * `[callStart, callEnd)` can appear: from the end of the previous statement to the statement start.
+ */
+function getLeadingCommentRange(
+  program: Program,
+  callStart: number,
+  callEnd: number,
+): { start: number; end: number } | undefined {
+  // `program.body` is in source order, so the previous statement's end is the last one we saw
+  // before reaching the statement that contains the call.
+  let previousStatementEnd = 0;
+
+  for (const statement of program.body) {
+    if (statement.start <= callStart && statement.end >= callEnd) {
+      return { start: previousStatementEnd, end: statement.start };
+    }
+
+    previousStatementEnd = statement.end;
+  }
+
+  return undefined;
+}
+
+/**
+ * Parses `griffel-` prefixed line comments within `[rangeStart, rangeEnd)` into `[name, value]`
+ * directives.
+ */
+function parseCommentDirectives(
+  comments: Comment[],
+  rangeStart: number,
+  rangeEnd: number,
+): TransformMetadataCommentDirective[] {
+  const directives: TransformMetadataCommentDirective[] = [];
+
+  for (const comment of comments) {
+    if (comment.type !== 'Line') {
+      continue;
+    }
+
+    if (comment.start < rangeStart || comment.start >= rangeEnd) {
+      continue;
+    }
+
+    const value = comment.value.trim();
+
+    if (!value.startsWith('griffel-')) {
+      continue;
+    }
+
+    const [name, directiveValue] = value.split(' ');
+    directives.push([name, directiveValue]);
+  }
+
+  return directives;
+}

--- a/packages/transform/src/index.mts
+++ b/packages/transform/src/index.mts
@@ -11,3 +11,8 @@ export { transformSync, type TransformOptions, type TransformResult } from './tr
 export { DEOPT, type Deopt } from './evaluation/astEvaluator.mjs';
 export type { AstEvaluatorPlugin, AstEvaluatorContext, TransformPerfIssue } from './evaluation/types.mjs';
 export { fluentTokensPlugin } from './evaluation/fluentTokensPlugin.mjs';
+export type {
+  TransformMetadata,
+  TransformMetadataSourceLocation,
+  TransformMetadataCommentDirective,
+} from './types.mjs';

--- a/packages/transform/src/sourceLocation.mts
+++ b/packages/transform/src/sourceLocation.mts
@@ -1,0 +1,50 @@
+import type { TransformMetadataSourceLocation } from './types.mjs';
+
+export type LineOffsetTable = {
+  /** Resolves a `[start, end)` byte range into a source location with line/column positions. */
+  locate(start: number, end: number): TransformMetadataSourceLocation;
+};
+
+/**
+ * Precomputes the byte offset of every line start in `source`, enabling fast
+ * offset → { line, column } lookups via binary search.
+ */
+export function createLineOffsetTable(source: string): LineOffsetTable {
+  const lineStartOffsets = computeLineStartOffsets(source);
+
+  function positionAt(offset: number) {
+    // Binary search for the line whose start offset is closest to (but not after) `offset`.
+    let low = 0;
+    let high = lineStartOffsets.length - 1;
+
+    while (low < high) {
+      const middle = (low + high + 1) >> 1;
+
+      if (lineStartOffsets[middle] <= offset) {
+        low = middle;
+      } else {
+        high = middle - 1;
+      }
+    }
+
+    return { line: low + 1, column: offset - lineStartOffsets[low], index: offset };
+  }
+
+  return {
+    locate(start, end) {
+      return { start: positionAt(start), end: positionAt(end) };
+    },
+  };
+}
+
+function computeLineStartOffsets(source: string): number[] {
+  const offsets = [0];
+
+  for (let index = 0; index < source.length; index++) {
+    if (source[index] === '\n') {
+      offsets.push(index + 1);
+    }
+  }
+
+  return offsets;
+}

--- a/packages/transform/src/sourceLocation.test.mts
+++ b/packages/transform/src/sourceLocation.test.mts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { createLineOffsetTable } from './sourceLocation.mjs';
+
+describe('createLineOffsetTable', () => {
+  it('resolves offsets on the first line', () => {
+    const table = createLineOffsetTable('const a = 1;');
+
+    expect(table.locate(0, 5)).toEqual({
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 1, column: 5, index: 5 },
+    });
+  });
+
+  it('resolves offsets on later lines relative to their line start', () => {
+    const source = ['const a = 1;', 'const b = 2;'].join('\n');
+    const table = createLineOffsetTable(source);
+
+    const start = source.indexOf('const b');
+    const end = source.length;
+
+    expect(table.locate(start, end)).toEqual({
+      start: { line: 2, column: 0, index: start },
+      end: { line: 2, column: 12, index: end },
+    });
+  });
+
+  it('resolves a range spanning several lines', () => {
+    // Offsets: a=0, \n=1, b=2, b=3, \n=4, c=5, c=6, c=7 (length 8).
+    const table = createLineOffsetTable(['a', 'bb', 'ccc'].join('\n'));
+
+    expect(table.locate(0, 8)).toEqual({
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 3, column: 3, index: 8 },
+    });
+  });
+});

--- a/packages/transform/src/transformSync.mts
+++ b/packages/transform/src/transformSync.mts
@@ -9,11 +9,9 @@ import {
   resolveStyleRulesForSlots,
   resolveResetStyleRules,
   resolveStaticStyleRules,
-  normalizeCSSBucketEntry,
   type GriffelStyle,
   type GriffelStaticStyles,
   type CSSRulesByBucket,
-  type CSSClassesMapBySlot,
   type GriffelResetStyle,
 } from '@griffel/core';
 
@@ -21,7 +19,8 @@ import { batchEvaluator } from './evaluation/batchEvaluator.mjs';
 import { fluentTokensPlugin } from './evaluation/fluentTokensPlugin.mjs';
 import type { AstEvaluatorPlugin } from './evaluation/types.mjs';
 import { dedupeCSSRules } from './utils/dedupeCSSRules.mjs';
-import type { StyleCall } from './types.mjs';
+import { generateTransformMetadata, type ProcessedStyleCall } from './generateTransformMetadata.mjs';
+import type { StyleCall, TransformMetadata } from './types.mjs';
 
 export type TransformOptions = {
   filename: string;
@@ -62,6 +61,7 @@ export type TransformResult = {
   usedProcessing: boolean;
   usedVMForEvaluation: boolean;
   perfIssues?: TransformPerfIssue[];
+  metadata?: TransformMetadata;
 };
 
 type FunctionKinds = 'makeStyles' | 'makeResetStyles' | 'makeStaticStyles';
@@ -88,73 +88,6 @@ const RUNTIME_IDENTIFIERS = new Map<FunctionKinds, string>([
   ['makeStaticStyles', '__staticCSS'],
 ]);
 
-/**
- * Extracts CSS rules from evaluated reset styles to metadata
- */
-function buildCSSResetEntriesMetadata(
-  cssResetEntries: Record<string, string[]>,
-  cssRules: string[] | CSSRulesByBucket,
-  declaratorId: string,
-) {
-  const cssRulesByBucket: CSSRulesByBucket = Array.isArray(cssRules) ? { d: cssRules } : cssRules;
-  cssResetEntries[declaratorId] ??= [];
-  cssResetEntries[declaratorId] = Object.values(cssRulesByBucket).flatMap(bucketEntries => {
-    return bucketEntries.map(bucketEntry => {
-      if (Array.isArray(bucketEntry)) {
-        throw new Error(
-          `CSS rules in buckets for "makeResetStyles()" should not contain arrays, got: ${JSON.stringify(
-            bucketEntry,
-          )})}`,
-        );
-      }
-
-      return bucketEntry;
-    });
-  });
-}
-
-/**
- * Extracts CSS rules from evaluated styles to metadata
- */
-function buildCSSEntriesMetadata(
-  cssEntries: Record<string, Record<string, string[]>>,
-  classnamesMapping: CSSClassesMapBySlot<string>,
-  cssRulesByBucket: CSSRulesByBucket,
-  declaratorId: string,
-) {
-  const classesBySlot: Record<string, string[]> = Object.fromEntries(
-    Object.entries(classnamesMapping).map(([slot, cssClassesMap]) => {
-      const uniqueClasses = new Set<string>();
-      Object.values(cssClassesMap).forEach(cssClasses => {
-        if (typeof cssClasses === 'string') {
-          uniqueClasses.add(cssClasses);
-        } else if (Array.isArray(cssClasses)) {
-          cssClasses.forEach(cssClass => uniqueClasses.add(cssClass));
-        }
-      });
-      return [slot, Array.from(uniqueClasses)];
-    }),
-  );
-
-  const cssRules: string[] = Object.values(cssRulesByBucket).flatMap(cssRulesByBucket => {
-    return cssRulesByBucket.map(bucketEntry => {
-      const [cssRule] = normalizeCSSBucketEntry(bucketEntry);
-      return cssRule;
-    });
-  });
-
-  cssEntries[declaratorId] = Object.fromEntries(
-    Object.entries(classesBySlot).map(([slot, cssClasses]) => {
-      return [
-        slot,
-        cssClasses.map(cssClass => {
-          return cssRules.find(rule => rule.includes(cssClass))!;
-        }),
-      ];
-    }),
-  );
-}
-
 function concatCSSRulesByBucket(bucketA: CSSRulesByBucket = {}, bucketB: CSSRulesByBucket) {
   // eslint-disable-next-line guard-for-in
   for (const cssBucketName in bucketB) {
@@ -164,7 +97,9 @@ function concatCSSRulesByBucket(bucketA: CSSRulesByBucket = {}, bucketB: CSSRule
     if (bucketA[bucketName]) {
       bucketA[bucketName].push(...bucketBEntries);
     } else {
-      bucketA[bucketName] = bucketBEntries;
+      // Copy instead of borrowing the reference: later calls push into `bucketA[bucketName]`,
+      // which would otherwise mutate the caller's array (and the CSS rules captured for metadata).
+      bucketA[bucketName] = [...bucketBEntries];
     }
   }
 
@@ -188,12 +123,12 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
     astEvaluationPlugins = [fluentTokensPlugin],
   } = options;
 
-  const importsToTransformSet = new Set(importsToTransform);
-  const functionsToTransformSet = new Set<FunctionKinds>(functionsToTransform);
-
   if (!filename) {
     throw new Error('Transform error: "filename" option is required');
   }
+
+  const importsToTransformSet = new Set(importsToTransform);
+  const functionsToTransformSet = new Set<FunctionKinds>(functionsToTransform);
 
   const parseResult = parseSync(filename, sourceCode);
 
@@ -215,7 +150,9 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
   const hasGriffelImports = parseResult.module.staticImports.some(
     si =>
       importsToTransformSet.has(si.moduleRequest.value) &&
-      si.entries.some(e => e.importName.kind === 'Name' && functionsToTransformSet.has(e.importName.name as FunctionKinds)),
+      si.entries.some(
+        e => e.importName.kind === 'Name' && functionsToTransformSet.has(e.importName.name as FunctionKinds),
+      ),
   );
 
   if (!hasGriffelImports) {
@@ -223,8 +160,10 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
   }
 
   const styleCalls: StyleCall[] = [];
-  const cssEntries: Record<string, Record<string, string[]>> = {};
-  const cssResetEntries: Record<string, string[]> = {};
+
+  // Per-call metadata inputs, filled by index during processing to preserve source order and
+  // consumed by generateTransformMetadata(); one entry per style call.
+  const processedStyleCalls: ProcessedStyleCall[] = [];
 
   let cssRulesByBucket: CSSRulesByBucket = {};
 
@@ -351,7 +290,11 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
           const uniqueCSSRules = dedupeCSSRules(resolvedCSSRules);
 
           if (generateMetadata) {
-            buildCSSEntriesMetadata(cssEntries, classnamesMapping, uniqueCSSRules, styleCall.declaratorId);
+            processedStyleCalls[i] = {
+              styleCall,
+              functionKind: 'makeStyles',
+              css: { classnamesMapping, resolvedCSSRules },
+            };
           }
 
           // Replace the function call arguments
@@ -367,7 +310,7 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
           const [ltrClassName, rtlClassName, cssRules] = resolveResetStyleRules(styles, classNameHashSalt);
 
           if (generateMetadata) {
-            buildCSSResetEntriesMetadata(cssResetEntries, cssRules, styleCall.declaratorId);
+            processedStyleCalls[i] = { styleCall, functionKind: 'makeResetStyles', css: cssRules };
           }
 
           // Replace the function call arguments
@@ -388,6 +331,10 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
           const styles = evaluationResult as GriffelStaticStyles | GriffelStaticStyles[];
           const stylesSet: GriffelStaticStyles[] = Array.isArray(styles) ? styles : [styles];
           const cssRules = resolveStaticStyleRules(stylesSet);
+
+          if (generateMetadata) {
+            processedStyleCalls[i] = { styleCall, functionKind: 'makeStaticStyles' };
+          }
 
           // Replace the function call arguments with the resolved CSS rules bucket
           magicString.overwrite(styleCall.argumentStart, styleCall.argumentEnd, JSON.stringify({ d: cssRules }));
@@ -421,5 +368,13 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
     usedProcessing: true,
     usedVMForEvaluation,
     perfIssues,
+    ...(generateMetadata && {
+      metadata: generateTransformMetadata({
+        source: sourceCode,
+        program: programAst,
+        comments: parseResult.comments,
+        processedStyleCalls,
+      }),
+    }),
   };
 }

--- a/packages/transform/src/transformSync.test.mts
+++ b/packages/transform/src/transformSync.test.mts
@@ -23,7 +23,9 @@ const nodeResolve: TransformResolver = (id, opts) => {
     }
 
     return {
-      path: (NativeModule as unknown as { _resolveFilename: (id: string, options: unknown) => string })._resolveFilename(id, opts),
+      path: (
+        NativeModule as unknown as { _resolveFilename: (id: string, options: unknown) => string }
+      )._resolveFilename(id, opts),
       builtin: false,
     };
   } finally {
@@ -58,11 +60,7 @@ const fixturesDir = path.join(__dirname, '..', '__fixtures__');
  *
  * Only applied when the meta output contains asset tags; other fixtures pass through unchanged.
  */
-function normalizeAssetOutputs(
-  code: string,
-  meta: string,
-  fixtureDir: string,
-): { code: string; meta: string } {
+function normalizeAssetOutputs(code: string, meta: string, fixtureDir: string): { code: string; meta: string } {
   if (meta.indexOf(ASSET_TAG_OPEN) === -1) {
     return { code, meta };
   }
@@ -250,7 +248,9 @@ const TESTS: TestCase[] = [
     fixture: path.resolve(fixturesDir, 'config-evaluation-rules', 'code.ts'),
     outputFixture: path.resolve(fixturesDir, 'config-evaluation-rules', 'output.ts'),
     transformOptions: {
-      evaluationRules: [{ action: require(path.resolve(fixturesDir, 'config-evaluation-rules', 'sampleEvaluator.cjs')).default }],
+      evaluationRules: [
+        { action: require(path.resolve(fixturesDir, 'config-evaluation-rules', 'sampleEvaluator.cjs')).default },
+      ],
     },
   },
 
@@ -401,29 +401,44 @@ export const useStyles = makeStyles({
         return;
       }
 
-      const { code, cssRulesByBucket, usedProcessing, usedVMForEvaluation } = transformSync(sourceCode, {
+      const { code, cssRulesByBucket, metadata, usedProcessing, usedVMForEvaluation } = transformSync(sourceCode, {
         filename: testCase.fixture,
         resolveModule: nodeResolve,
+        generateMetadata: true,
         ...transformOptions,
       });
-      const outputCode = await format(code, { ...prettierConfig, parser: 'typescript' });
-      const outputMeta = await format(
-        JSON.stringify({ usedProcessing, usedVMForEvaluation, cssRulesByBucket }, null, 2),
-        {
-          ...prettierConfig,
-          parser: 'json',
-        },
+      const fixtureDir = path.dirname(testCase.fixture);
+      // Normalization shortens asset paths, so it has to happen before formatting to keep the
+      // committed fixtures stable under Prettier.
+      const normalized = normalizeAssetOutputs(
+        code,
+        JSON.stringify({ usedProcessing, usedVMForEvaluation, cssRulesByBucket, metadata }, null, 2),
+        fixtureDir,
       );
 
-      const fixtureDir = path.dirname(testCase.fixture);
-      const normalized = normalizeAssetOutputs(outputCode, outputMeta, fixtureDir);
+      const outputCode = await format(normalized.code, { ...prettierConfig, parser: 'typescript' });
+      const outputMeta = await format(normalized.meta, { ...prettierConfig, parser: 'json' });
 
-      await expect(normalized.code).toMatchFileSnapshot(testCase.outputFixture!);
-      await expect(normalized.meta).toMatchFileSnapshot(testCase.outputFixture!.replace(/\.ts$/, '.meta.json'));
+      await expect(outputCode).toMatchFileSnapshot(testCase.outputFixture!);
+      await expect(outputMeta).toMatchFileSnapshot(testCase.outputFixture!.replace(/\.ts$/, '.meta.json'));
 
       if (typeof teardown === 'function') {
         teardown?.();
       }
     });
   }
+});
+
+describe('transformSync: metadata', () => {
+  it('does not return metadata unless "generateMetadata" is enabled', () => {
+    const sourceCode = `
+import { makeStyles } from '@griffel/react';
+
+export const useStyles = makeStyles({ root: { color: 'red' } });
+`;
+
+    const result = transformSync(sourceCode, { filename: 'metadata.styles.ts', resolveModule: nodeResolve });
+
+    expect(result.metadata).toBeUndefined();
+  });
 });

--- a/packages/transform/src/types.mts
+++ b/packages/transform/src/types.mts
@@ -11,3 +11,20 @@ export interface StyleCall {
   callEnd: number;
   importId: string;
 }
+
+export interface TransformMetadataSourceLocation {
+  start: { line: number; column: number; index: number };
+  end: { line: number; column: number; index: number };
+}
+
+export type TransformMetadataCommentDirective = [string, string];
+
+export interface TransformMetadata {
+  cssEntries: Record<string, Record<string, string[]>>;
+  cssResetEntries: Record<string, string[]>;
+  callExpressionLocations: Record<string, TransformMetadataSourceLocation>;
+  locations: Record<string, Record<string, TransformMetadataSourceLocation>>;
+  resetLocations: Record<string, TransformMetadataSourceLocation>;
+  commentDirectives: Record<string, Record<string, TransformMetadataCommentDirective[]>>;
+  resetCommentDirectives: Record<string, TransformMetadataCommentDirective[]>;
+}


### PR DESCRIPTION
## Summary

Split out of #810.

Completes the `generateMetadata` feature in `@griffel/transform`. Previously `transformSync` accepted `generateMetadata` and internally built `cssEntries`/`cssResetEntries`, but never returned them — the feature was effectively dead. This PR wires it up and returns a full `metadata` object.

When `generateMetadata` is enabled, `transformSync` now returns `metadata`:

- **`cssEntries` / `cssResetEntries`** — generated CSS rules per declarator/slot, seeded in **source order** so consumers emit rules top-to-bottom (the processing loop walks calls in reverse to keep `MagicString` offsets valid, so entries are pre-seeded to preserve order).
- **`callExpressionLocations`** — source location of each `makeStyles`/`makeResetStyles` call.
- **`locations` / `resetLocations`** — source locations of style slots and reset objects (populated only for inline `ObjectExpression` arguments).
- **`commentDirectives` / `resetCommentDirectives`** — `griffel-` prefixed comment directives attached to slots.

Adds `SourceLocation`, `CommentDirective` and `TransformMetadata` types (exported from the package entry).

## Testing

- Adds a `transformSync: metadata` test suite (7 tests) covering: no metadata unless `generateMetadata`; `cssEntries` + `locations` for `makeStyles`; `callExpressionLocations` per declarator; `cssResetEntries` + `resetLocations` for `makeResetStyles`; comment directives; and preservation of declarator/slot source order.
- `@griffel/transform`: 86 tests pass, type-check ✓, lint ✓.

## Notes

This is the foundational transform change extracted from #810; the `@griffel/postcss-syntax` migration in #810 builds on top of this.