### PR TITLE
chore: switch monosize to "monosize-storage-git"

### DIFF
--- a/.github/workflows/bundle-size-baseline.yml
+++ b/.github/workflows/bundle-size-baseline.yml
@@ -29,7 +29,13 @@ jobs:
       - name: Measure all packages
         run: yarn nx run-many --all --target=bundle-size --nxBail
 
-      - name: Upload results
+      - name: Prepare report
         run: yarn monosize upload-report --branch main --commit-sha ${{ github.sha }}
-        env:
-          UPSTASH_WRITE_TOKEN: ${{ secrets.UPSTASH_WRITE_TOKEN }}
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: monosize-report
+          retention-days: 30
+          if-no-files-found: error
+          path: dist/monosize-report.json

--- a/.github/workflows/bundle-size-pr.yml
+++ b/.github/workflows/bundle-size-pr.yml
@@ -36,6 +36,8 @@ jobs:
         id: compare
         continue-on-error: true
         run: npx monosize compare-reports --branch main --output markdown --quiet > ./monosize.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save PR number
         run: echo ${{ github.event.number }} > pr.txt

--- a/monosize.config.mjs
+++ b/monosize.config.mjs
@@ -1,10 +1,11 @@
 import path from 'node:path';
-import upstashStorage from 'monosize-storage-upstash';
+import gitStorage from 'monosize-storage-git';
 import webpackBundler from 'monosize-bundler-webpack';
 
 const dirname = new URL('.', import.meta.url).pathname;
 
-export default {
+/** @type {import('monosize').MonoSizeConfig} */
+const config = {
   repository: 'https://github.com/microsoft/griffel',
   bundler: webpackBundler(config => ({
     ...config,
@@ -23,8 +24,12 @@ export default {
     },
   })),
   threshold: '1.5kB',
-  storage: upstashStorage({
-    url: 'https://welcome-giraffe-61766.upstash.io',
-    readonlyToken: 'AvFGAAIgcDHzHKwMeSqS_FCutK3bcM-AI7c7zSKbRYbAM14_ZiwUmg',
+  storage: gitStorage({
+    owner: 'microsoft',
+    repo: 'griffel',
+    workflowFileName: 'bundle-size-baseline.yml',
+    outputPath: path.resolve(dirname, './dist/monosize-report.json'),
   }),
 };
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "mini-css-extract-plugin": "2.10.2",
     "monosize": "0.10.0",
     "monosize-bundler-webpack": "0.4.1",
-    "monosize-storage-upstash": "0.0.28",
+    "monosize-storage-git": "0.3.5",
     "nano-staged": "~1.0.2",
     "nx": "23.0.1",
     "playwright": "^1.62.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5599,6 +5599,131 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/auth-token@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@octokit/auth-token@npm:6.0.0"
+  checksum: 10/a30f5c4c984964b57193de5b6f67169f74e4779fedbe716157dd3558dd9de3ca5c105cae521b7bd8ce1ae180773a2ef01afe2306ad5a329f4fd291eba2b7c7d1
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^7.0.6":
+  version: 7.0.6
+  resolution: "@octokit/core@npm:7.0.6"
+  dependencies:
+    "@octokit/auth-token": "npm:^6.0.0"
+    "@octokit/graphql": "npm:^9.0.3"
+    "@octokit/request": "npm:^10.0.6"
+    "@octokit/request-error": "npm:^7.0.2"
+    "@octokit/types": "npm:^16.0.0"
+    before-after-hook: "npm:^4.0.0"
+    universal-user-agent: "npm:^7.0.0"
+  checksum: 10/852d41fc3150d2a891156427dd0575c77889f1c7a109894ee541594e3fd47c0d4e0a93fee22966c507dfd6158b522e42846c2ac46b9d896078194c95fa81f4ae
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "@octokit/endpoint@npm:11.0.3"
+  dependencies:
+    "@octokit/types": "npm:^16.0.0"
+    universal-user-agent: "npm:^7.0.2"
+  checksum: 10/21b67d76fb1ea28bd87ca467c12dfab648af55522b936760316d70f8ccdd638f170d636ee72606857f0cd8f343f40c8a4e8f55993d6b1f5b9ecf102e072044c5
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "@octokit/graphql@npm:9.0.3"
+  dependencies:
+    "@octokit/request": "npm:^10.0.6"
+    "@octokit/types": "npm:^16.0.0"
+    universal-user-agent: "npm:^7.0.0"
+  checksum: 10/7b16f281f8571dce55280b3986fbb8d15465a7236164a5f6497ded7597ff9ee95d5796924555b979903fe8c6706fe6be1b3e140d807297f85ac8edeadc28f9fe
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^27.0.0":
+  version: 27.0.0
+  resolution: "@octokit/openapi-types@npm:27.0.0"
+  checksum: 10/5cd2cdf4e41fdf522e15e3d53f3ece8380d98dda9173a6fc905828fb2c33e8733d5f5d2a757ae3a572525f4749748e66cb40e7939372132988d8eb4ba978d54f
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@octokit/plugin-paginate-rest@npm:14.0.0"
+  dependencies:
+    "@octokit/types": "npm:^16.0.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10/57ddd857528dad9c02431bc6254c2374c06057872cf9656a4a88b162ebe1c2bc9f34fbec360f2ccff72c940f29b120758ce14e8135bd027223d381eb1b8b6579
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-request-log@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@octokit/plugin-request-log@npm:6.0.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10/8a79973b1429bfead9113c4117f418aaef5ff368795daded3415ba14623d97d5fc08d1e822dbd566ecc9f041119e1a48a11853a9c48d9eb1caa62baa79c17f83
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:17.0.0"
+  dependencies:
+    "@octokit/types": "npm:^16.0.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10/e9d9ad4d9755cc7fb82fdcbfa870ddea8a432180f0f76c8469095557fd1e26f8caea8cae58401209be17c4f3d8cc48c0e16a3643e37e48f4d23c39e058bf2c55
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^7.0.2":
+  version: 7.1.0
+  resolution: "@octokit/request-error@npm:7.1.0"
+  dependencies:
+    "@octokit/types": "npm:^16.0.0"
+  checksum: 10/c1d447ff7482382c69f7a4b2eaa44c672906dd111d8a9196a5d07f2adc4ae0f0e12ec4ce0063f14f9b2fb5f0cef4451c95ec961a7a711bd900e5d6441d546570
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^10.0.6":
+  version: 10.0.11
+  resolution: "@octokit/request@npm:10.0.11"
+  dependencies:
+    "@octokit/endpoint": "npm:^11.0.3"
+    "@octokit/request-error": "npm:^7.0.2"
+    "@octokit/types": "npm:^16.0.0"
+    content-type: "npm:^2.0.0"
+    json-with-bigint: "npm:^3.5.3"
+    universal-user-agent: "npm:^7.0.2"
+  checksum: 10/036640f49e4ab63470130dccafb828822a18cf9ce060b8170e56ba9ce7173029db92b3c37ad7474acf2c097180d5127754b69d3ffbe60162489aed4324b3cb8f
+  languageName: node
+  linkType: hard
+
+"@octokit/rest@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "@octokit/rest@npm:22.0.1"
+  dependencies:
+    "@octokit/core": "npm:^7.0.6"
+    "@octokit/plugin-paginate-rest": "npm:^14.0.0"
+    "@octokit/plugin-request-log": "npm:^6.0.0"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^17.0.0"
+  checksum: 10/ec2e94cfa8766716faeb3ca18527d9af746482d35aaa6e4265a30cb669ae3f31f4ebb6235edebe5ae62bc2cec2b8e88902584f698df2e7cabac3a15fd27da665
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "@octokit/types@npm:16.0.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^27.0.0"
+  checksum: 10/03d5cfc29556a9b53eae8beb1bf15c0b704dc722db2c51b53f093f3c3ee6c1d8e20b682be8117a3a17034b458be7746d1b22aaefb959ceb5152ad7589b39e2c9
+  languageName: node
+  linkType: hard
+
 "@one-ini/wasm@npm:0.2.1":
   version: 0.2.1
   resolution: "@one-ini/wasm@npm:0.2.1"
@@ -9088,15 +9213,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@upstash/redis@npm:^1.38.0":
-  version: 1.38.0
-  resolution: "@upstash/redis@npm:1.38.0"
-  dependencies:
-    uncrypto: "npm:^0.1.3"
-  checksum: 10/02cbf44e2b28d5db01029607bafe5c14f06a0a79f9249b80f95d08ecfd3a4e67bb39fe4d6099efb457c9aaea8200d10d8e28a37611a6237b90749157bfc5b600
-  languageName: node
-  linkType: hard
-
 "@vercel/detect-agent@npm:^1.2.1":
   version: 1.2.3
   resolution: "@vercel/detect-agent@npm:1.2.3"
@@ -9592,6 +9708,13 @@ __metadata:
   version: 2.0.3
   resolution: "address@npm:2.0.3"
   checksum: 10/b367b0166fc3b295f742a71989f333c62f2b6a1e0ad30355e8d003fd6ed034792c353a6edf28b279c2d9eba992931c4f6c9e4f0b5ebca7b924e04689326f6faa
+  languageName: node
+  linkType: hard
+
+"adm-zip@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "adm-zip@npm:0.6.0"
+  checksum: 10/6a49ab39055d8f716958d3a2055491ab86fe3359c4afeed9b14bbce78fb847bcd3cbaa0ff4921aaa19824aaa29d06691def1f53263db5224d06c068f922c5ba2
   languageName: node
   linkType: hard
 
@@ -10374,6 +10497,13 @@ __metadata:
   bin:
     beachball: bin/beachball.js
   checksum: 10/b7e0c08a5eaeed94df8369208bdbdad9ecbdf60e9100b960f1b2f0864f3ba295a9fc30ed274c9ab79a5f8e8ce8c72fe567d7fb5ce1861ce7549d39bebca0bcef
+  languageName: node
+  linkType: hard
+
+"before-after-hook@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "before-after-hook@npm:4.0.0"
+  checksum: 10/9fd52bc0c3cca0fb115e04dacbeeaacff38fa23e1af725d62392254c31ef433b15da60efcba61552e44d64e26f25ea259f72dba005115924389e88d2fd56e19f
   languageName: node
   linkType: hard
 
@@ -11384,6 +11514,13 @@ __metadata:
   dependencies:
     safe-buffer: "npm:5.2.1"
   checksum: 10/b7f4ce176e324f19324be69b05bf6f6e411160ac94bc523b782248129eb1ef3be006f6cff431aaea5e337fe5d176ce8830b8c2a1b721626ead8933f0cbe78720
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "content-type@npm:2.0.0"
+  checksum: 10/0bbb276b790ba7e86c479c7d69fae1861b2e908ff3ce2cb01975b516f93eede2216d242902ed6c5b15cd554014611ce9dfdcf51cd35b16569e45a979e50d0cef
   languageName: node
   linkType: hard
 
@@ -14707,7 +14844,7 @@ __metadata:
     mini-css-extract-plugin: "npm:2.10.2"
     monosize: "npm:0.10.0"
     monosize-bundler-webpack: "npm:0.4.1"
-    monosize-storage-upstash: "npm:0.0.28"
+    monosize-storage-git: "npm:0.3.5"
     nano-staged: "npm:~1.0.2"
     nx: "npm:23.0.1"
     oxc-parser: "npm:^0.140.0"
@@ -16819,6 +16956,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-with-bigint@npm:^3.5.3":
+  version: 3.5.10
+  resolution: "json-with-bigint@npm:3.5.10"
+  checksum: 10/d9d5b41f30e7ac648296947162cb18bdc7030e46a264231e19561a93e8ee6fb127efe447c86ef6d571106ac32e4656ddeb10d8220a88b2a5edf5b7f263465003
+  languageName: node
+  linkType: hard
+
 "json5@npm:2.2.3, json5@npm:^2.1.2, json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
@@ -18834,14 +18978,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"monosize-storage-upstash@npm:0.0.28":
-  version: 0.0.28
-  resolution: "monosize-storage-upstash@npm:0.0.28"
+"monosize-storage-git@npm:0.3.5":
+  version: 0.3.5
+  resolution: "monosize-storage-git@npm:0.3.5"
   dependencies:
-    "@upstash/redis": "npm:^1.38.0"
+    "@octokit/rest": "npm:^22.0.1"
+    adm-zip: "npm:^0.6.0"
     monosize: "npm:^0.10.0"
     tslib: "npm:^2.4.1"
-  checksum: 10/f702d7b5eecdda2c174948131cf26967aef69cef60bf22e9c90ed7c2042a98ebaa24d33a0a785aa0c20ab47f30e38b18decc06d79e2d28442c3a66cf0e1509b9
+  checksum: 10/6794eae819856876bb943e769e3486125b649baafccd02b72425ecb54b3ea8a984cc26357a0df08dcc4b4ca200c171c12cdd168f9eda0000a513bf2352d35baf
   languageName: node
   linkType: hard
 
@@ -24069,13 +24214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uncrypto@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "uncrypto@npm:0.1.3"
-  checksum: 10/0020f74b0ce34723196d8982a73bb7f40cff455a41b8f88ae146b86885f4e66e41a1241fe80a887505c3bd2c7f07ed362b6ed041968370073c40a98496e6a737
-  languageName: node
-  linkType: hard
-
 "undici-types@npm:~8.3.0":
   version: 8.3.0
   resolution: "undici-types@npm:8.3.0"
@@ -24283,6 +24421,13 @@ __metadata:
     unist-util-is: "npm:^6.0.0"
     unist-util-visit-parents: "npm:^6.0.0"
   checksum: 10/f2bbde23641e9ade7640358c06ddeec0f38342322eb8e7819d9ee380b0f859d25d084dde22bf63db0280b3b2f36575f15aa1d6c23acf276c91c2493cf799e3b0
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
+  version: 7.0.3
+  resolution: "universal-user-agent@npm:7.0.3"
+  checksum: 10/c497e85f8b11eb8fa4dce584d7a39cc98710164959f494cafc3c269b51abb20fff269951838efd7424d15f6b3d001507f3cb8b52bb5676fdb642019dfd17e63e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces `monosize-storage-upstash` with [`monosize-storage-git`](https://github.com/microsoft/monosize/tree/main/packages/monosize-storage-git), which stores bundle size reports as GitHub Actions artifacts instead of an external Upstash instance.

This removes our dependency on a third party service (and the hardcoded readonly token in the config), and the `UPSTASH_WRITE_TOKEN` secret.

Follows the setup used in [`microsoft/keyborg`](https://github.com/microsoft/keyborg/blob/main/monosize.config.mjs).

## Changes

- `monosize.config.mjs`: swapped the storage adapter, reports are written to `dist/monosize-report.json`
- `bundle-size-baseline.yml`: dropped `UPSTASH_WRITE_TOKEN`, added an `actions/upload-artifact` step that publishes the `monosize-report` artifact
- `bundle-size-pr.yml`: passes `GITHUB_TOKEN` to `compare-reports`, it is required to read artifacts back via the GitHub API

The adapter reads the last 5 completed runs of `bundle-size-baseline.yml` on the target branch and picks the first `monosize-report` artifact it finds.

## Validation

- `monosize measure` + `upload-report` produce `dist/monosize-report.json` with the expected `{ commitSHA, data }` shape
- `compare-reports` authenticates, resolves baseline runs and renders the markdown report
- `beachball check` reports no change files are needed, this only touches root devDependencies and CI

## After merging

- The `UPSTASH_WRITE_TOKEN` secret can be deleted
- The first PR run will show all entries as "🆕 New entry" until one baseline build on `main` uploads the artifact
