### PR TITLE
docs(webpack-plugin): document CSS extraction with Rspack & Rsbuild

### DIFF
--- a/apps/website/docs/react/build-optimization/with-webpack.md
+++ b/apps/website/docs/react/build-optimization/with-webpack.md
@@ -116,12 +116,13 @@ module.exports = {
 
 ## Usage with Rspack
 
-`@griffel/webpack-plugin` is compatible with [Rspack](https://rspack.dev/). The same plugin and loader work with Rspack's webpack-compatible API. Note that Rspack has built-in CSS support via `experiments.css`, so `mini-css-extract-plugin` is not needed:
+`@griffel/webpack-plugin` is compatible with [Rspack](https://rspack.rs/). The same plugin and loader work with Rspack's webpack-compatible API. Note that Rspack has built-in CSS support via `experiments.css`, so `mini-css-extract-plugin` is not needed:
 
 ```js
 const { GriffelPlugin } = require('@griffel/webpack-plugin');
 
 module.exports = {
+  mode: 'production',
   experiments: {
     css: true,
   },
@@ -132,11 +133,65 @@ module.exports = {
         exclude: /node_modules/,
         use: [{ loader: '@griffel/webpack-plugin/loader' }],
       },
+      // Required so that CSS assets produced by Griffel are handled by Rspack's native CSS support
+      {
+        test: /\.css$/,
+        type: 'css',
+      },
     ],
   },
   plugins: [new GriffelPlugin()],
 };
 ```
+
+Alternatively, [`CssExtractRspackPlugin`](https://rspack.rs/plugins/rspack/css-extract-rspack-plugin) can be used together with `css-loader` instead of `experiments.css`.
+
+:::caution Rspack limitations
+
+- `optimization.splitChunks` **must be enabled**, the plugin throws otherwise. It is enabled by default in `production` mode.
+- The `unstable_attachToEntryPoint` option is supported only with Webpack and throws with Rspack.
+
+:::
+
+## Usage with Rsbuild
+
+[Rsbuild](https://rsbuild.rs/) is built on top of Rspack, the plugin and the loader are added via [`tools.rspack`](https://rsbuild.rs/config/tools/rspack):
+
+```js
+import { defineConfig } from '@rsbuild/core';
+import { GriffelPlugin } from '@griffel/webpack-plugin';
+
+export default defineConfig({
+  tools: {
+    // 👇 required, see the caution below
+    lightningcssLoader: false,
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.(js|ts|tsx)$/,
+            exclude: /node_modules/,
+            use: [{ loader: '@griffel/webpack-plugin/loader' }],
+          },
+        ],
+      },
+      plugins: [new GriffelPlugin()],
+    },
+  },
+});
+```
+
+Rsbuild already enables Rspack's native CSS support and `optimization.splitChunks`, no extra configuration is required for them.
+
+:::caution `tools.lightningcssLoader` must be disabled
+
+Griffel annotates extracted CSS with `/** @griffel:css-start */` comments and relies on them to sort rules into style buckets. Rsbuild enables [`builtin:lightningcss-loader`](https://rsbuild.rs/config/tools/lightningcss-loader) by default, which strips comments. Without them CSS is emitted in module order, so, for example, `makeResetStyles()` output ends up after `makeStyles()` output and overrides it.
+
+The plugin emits a build warning when it detects this.
+
+:::
+
+Disabling `tools.lightningcssLoader` also disables automatic vendor prefixing, use [`postcss`](https://rsbuild.rs/config/tools/postcss) with `autoprefixer` if you need it. CSS minification is unaffected as it runs after the rules are sorted.
 
 ## Configuration
 

--- a/change/@griffel-webpack-plugin/warn-missing-bucket-annotations-20260728180000.json
+++ b/change/@griffel-webpack-plugin/warn-missing-bucket-annotations-20260728180000.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: warn when style bucket annotations are stripped from extracted CSS",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -1,6 +1,6 @@
 # Webpack plugin to perform CSS extraction in Griffel
 
-A plugin for Webpack 5 that performs CSS extraction for [`@griffel/react`](../react).
+A plugin for Webpack 5 and [Rspack](https://rspack.rs/) that performs CSS extraction for [`@griffel/react`](../react).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -8,7 +8,17 @@ A plugin for Webpack 5 that performs CSS extraction for [`@griffel/react`](../re
 - [Install](#install)
 - [When to use it?](#when-to-use-it)
 - [Usage](#usage)
+  - [Usage with Rspack](#usage-with-rspack)
+  - [Usage with Rsbuild](#usage-with-rsbuild)
+  - [Performance](#performance)
+  - [`ignoreOrder` option](#ignoreorder-option)
 - [Options](#options)
+  - [Plugin options](#plugin-options)
+  - [Loader options](#loader-options)
+    - [`importsToTransform`](#importstotransform)
+    - [`functionsToTransform`](#functionstotransform)
+    - [`classNameHashSalt`](#classnamehashsalt)
+    - [`evaluationRules`](#evaluationrules)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -65,7 +75,128 @@ The plugin automatically:
 - Extracts CSS into a dedicated chunk (named `griffel`) via `mini-css-extract-plugin`
 - Sorts CSS rules by specificity buckets, media queries, and container queries
 
+> ⚠️ **`style-loader` is not supported.** It does not produce the assets that the plugin needs to order CSS rules, using it would result in partially broken styling in your app.
+
+### Usage with Rspack
+
+The same plugin and loader work with [Rspack](https://rspack.rs/). Rspack has built-in CSS support, so `mini-css-extract-plugin` is not needed:
+
+```js
+const { GriffelPlugin } = require('@griffel/webpack-plugin');
+
+module.exports = {
+  mode: 'production',
+  experiments: {
+    css: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|tsx)$/,
+        exclude: /node_modules/,
+        use: [{ loader: '@griffel/webpack-plugin/loader' }],
+      },
+      // Required so that CSS assets produced by Griffel are handled by Rspack's native CSS support
+      {
+        test: /\.css$/,
+        type: 'css',
+      },
+    ],
+  },
+  plugins: [new GriffelPlugin()],
+};
+```
+
+Alternatively, [`CssExtractRspackPlugin`](https://rspack.rs/plugins/rspack/css-extract-rspack-plugin) can be used together with `css-loader` instead of `experiments.css`.
+
+Rspack specifics:
+
+- `optimization.splitChunks` **must be enabled**, the plugin throws otherwise. It is enabled by default in `production` mode.
+- The `unstable_attachToEntryPoint` option is not supported and throws.
+
+### Usage with Rsbuild
+
+[Rsbuild](https://rsbuild.rs/) is built on top of Rspack, the plugin and the loader are added via [`tools.rspack`](https://rsbuild.rs/config/tools/rspack):
+
+```js
+import { defineConfig } from '@rsbuild/core';
+import { GriffelPlugin } from '@griffel/webpack-plugin';
+
+export default defineConfig({
+  tools: {
+    // 👇 required, see the caution below
+    lightningcssLoader: false,
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.(js|ts|tsx)$/,
+            exclude: /node_modules/,
+            use: [{ loader: '@griffel/webpack-plugin/loader' }],
+          },
+        ],
+      },
+      plugins: [new GriffelPlugin()],
+    },
+  },
+});
+```
+
+Rsbuild already enables Rspack's native CSS support and `optimization.splitChunks`, no extra configuration is required for them.
+
+> ⚠️ **`tools.lightningcssLoader` must be disabled.** The plugin annotates extracted CSS with `/** @griffel:css-start */` comments and relies on them to sort rules into style buckets. Rsbuild enables [`builtin:lightningcss-loader`](https://rsbuild.rs/config/tools/lightningcss-loader) by default, which strips comments. Without them CSS is emitted in module order, so, for example, `makeResetStyles()` output ends up after `makeStyles()` output and overrides it. The plugin emits a build warning when it detects this.
+
+Disabling `tools.lightningcssLoader` also disables automatic vendor prefixing, use [`postcss`](https://rsbuild.rs/config/tools/postcss) with `autoprefixer` if you need it. CSS minification is unaffected as it runs after the rules are sorted.
+
+### Performance
+
+For better performance (to process less files) consider using `include` for the loader:
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|tsx)$/,
+        include: [
+          path.resolve(__dirname, 'components'),
+          /\/node_modules\/@fluentui\//,
+          // see https://webpack.js.org/configuration/module/#condition
+        ],
+        use: {
+          loader: '@griffel/webpack-plugin/loader',
+        },
+      },
+    ],
+  },
+};
+```
+
+### `ignoreOrder` option
+
+If you use `mini-css-extract-plugin`, you may need to set `ignoreOrder` to `true` to remove warnings about conflicting order of CSS modules:
+
+```
+WARNING in chunk griffel [mini-css-extract-plugin]
+Conflicting order. Following module has been added:
+  - couldn't fulfill desired order of chunk group(s)
+```
+
+This will not affect the order of CSS modules in the final bundle as Griffel sorts own CSS modules anyway.
+
+```js
+module.exports = {
+  plugins: [
+    new MiniCssExtractPlugin({
+      ignoreOrder: true,
+    }),
+  ],
+};
+```
+
 ## Options
+
+### Plugin options
 
 ```js
 new GriffelPlugin({
@@ -78,10 +209,123 @@ new GriffelPlugin({
   // Override the resolver used to resolve imports inside evaluated modules
   resolverFactory: myResolverFactory,
 
-  // Attach extracted CSS to a specific entry point chunk
+  // Attach extracted CSS to a specific entry point chunk, not supported by Rspack
   unstable_attachToEntryPoint: 'main',
 
   // Collect and log timing stats
   collectStats: false,
+
+  // Collect performance issues (CJS modules, barrel re-exports) found during evaluation,
+  // reported via "collectStats" output
+  collectPerfIssues: false,
 });
+```
+
+### Loader options
+
+#### `importsToTransform`
+
+Defines the set of modules whose Griffel imports are transformed.
+
+```js
+// Default value
+['@griffel/core', '@griffel/react', '@fluentui/react-components'];
+```
+
+Use it to handle re-exports of Griffel from custom packages:
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|tsx)$/,
+        use: {
+          loader: '@griffel/webpack-plugin/loader',
+          options: {
+            importsToTransform: ['@griffel/react', 'custom-package'],
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+> **Note**: the import source is preserved during the transform, so "custom-package" should also re-export the following functions from `@griffel/react`:
+>
+> - `__css`
+> - `__resetCSS`
+> - `__staticCSS`
+
+#### `functionsToTransform`
+
+Defines which Griffel style functions are transformed, can be used to narrow the default set.
+
+```js
+// Default value
+['makeStyles', 'makeResetStyles', 'makeStaticStyles'];
+```
+
+#### `classNameHashSalt`
+
+A salt that is added to generated class name hashes. Useful to avoid class name collisions when multiple independent Griffel builds are rendered on the same page.
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|tsx)$/,
+        use: {
+          loader: '@griffel/webpack-plugin/loader',
+          options: {
+            classNameHashSalt: 'my-app',
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+#### `evaluationRules`
+
+The set of rules that defines how the matched files will be transformed during the evaluation. `EvalRule` is an object with two fields:
+
+- `test` is a regular expression or a function `(path: string) => boolean`
+- `action` is an `Evaluator` function, `"ignore"` or a name of the module that exports an `Evaluator` function as a **default** export
+
+_If `test` is omitted, the rule is applicable for all the files._
+
+The last matched rule is used for transformation. If the last matched action for a file is `"ignore"` the file will be evaluated as is, so that file must not contain any code that cannot be executed in a Node.js environment.
+
+```js
+const { shakerEvaluator } = require('@griffel/babel-preset');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|tsx)$/,
+        use: {
+          loader: '@griffel/webpack-plugin/loader',
+          options: {
+            // Default value
+            evaluationRules: [{ action: shakerEvaluator }],
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+If you need to skip compilation for some modules under `/node_modules/`, it's recommended to do it on a module by module basis for faster transforms:
+
+```js
+evaluationRules: [
+  { action: shakerEvaluator },
+  { test: /[/\\]node_modules[/\\](?!some-module|other-module)/, action: 'ignore' },
+];
 ```

--- a/packages/webpack-plugin/src/GriffelPlugin.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.mts
@@ -362,6 +362,27 @@ export class GriffelPlugin {
           const cssContent = getAssetSourceContents(cssAssetSource);
           const { cssRulesByBucket, remainingCSS } = parseCSSRules(cssContent);
 
+          // WHAT?
+          //  The Griffel chunk contains only CSS produced by Griffel, that CSS is always wrapped with
+          //  "/** @griffel:css-start */" comments. If no rule was assigned to a bucket, these comments were stripped
+          //  by another tool in the CSS pipeline.
+          // WHY?
+          //  Without these comments rules cannot be sorted into style buckets and are emitted in module order, which
+          //  silently breaks precedence e.g. "makeResetStyles()" output ends up after "makeStyles()" output.
+          if (remainingCSS.length > 0 && Object.values(cssRulesByBucket).every(bucket => bucket.length === 0)) {
+            const warning = new compiler.webpack.WebpackError(
+              [
+                `Griffel CSS in "${cssAssetName}" has no style bucket annotations, CSS rules cannot be sorted and will`,
+                'be emitted in module order. This happens when another tool in your CSS pipeline removes comments.',
+                'For example, in Rsbuild set "tools.lightningcssLoader: false" as "builtin:lightningcss-loader"',
+                'strips them.',
+              ].join(' '),
+            );
+
+            warning.name = 'GriffelPluginWarning';
+            compilation.warnings.push(warning);
+          }
+
           const cssSource = sortCSSRules([cssRulesByBucket], this.#compareMediaQueries, this.#compareContainerQueries);
 
           compilation.updateAsset(cssAssetName, new compiler.webpack.sources.RawSource(remainingCSS + cssSource));

--- a/packages/webpack-plugin/src/GriffelPlugin.test.mts
+++ b/packages/webpack-plugin/src/GriffelPlugin.test.mts
@@ -438,27 +438,76 @@ describe('GriffelCSSExtractionPlugin', () => {
 
   // Error reporting
   // --------------------
-  it(
-    'includes the offending filename in VM evaluation errors',
-    async () => {
-      const fixturePath = path.resolve(__dirname, '..', '__fixtures__', 'vm-error-trace');
-      const entryPath = path.resolve(fixturePath, 'code.ts');
+  it('warns when style bucket annotations are stripped from extracted CSS', async () => {
+    const entryPath = path.resolve(__dirname, '..', '__fixtures__', 'style-buckets', 'code.ts');
 
-      // Replace machine-specific paths and line numbers so snapshots are stable across environments
-      const repoRoot = path.resolve(__dirname, '../../..');
-      const normalize = (s: string) =>
-        s.split(repoRoot).join('<repo>').replace(/:\d+(:\d+)?/g, ':<line>');
+    // Emulates tools that remove comments from emitted CSS assets, for example
+    // "builtin:lightningcss-loader" that is enabled by default in Rsbuild
+    class StripCSSCommentsPlugin {
+      apply(compiler: WebpackCompiler) {
+        compiler.hooks.compilation.tap('StripCSSCommentsPlugin', compilation => {
+          compilation.hooks.processAssets.tap(
+            {
+              name: 'StripCSSCommentsPlugin',
+              // Runs before the stage used by GriffelPlugin to sort CSS rules
+              stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+            },
+            assets => {
+              for (const assetName of Object.keys(assets)) {
+                if (!assetName.endsWith('.css')) {
+                  continue;
+                }
 
-      let error: WebpackStatsError | undefined;
+                const source = assets[assetName]
+                  .source()
+                  .toString()
+                  .replace(/\/\*[\s\S]*?\*\//g, '');
 
-      try {
-        await compileSourceWithWebpack(entryPath, {});
-      } catch (e) {
-        error = e as WebpackStatsError;
+                compilation.updateAsset(assetName, new compiler.webpack.sources.RawSource(source));
+              }
+            },
+          );
+        });
       }
+    }
 
-      expect(error).toBeDefined();
-      expect(normalize(error!.message)).toMatchInlineSnapshot(`
+    let warning: WebpackStatsError | undefined;
+
+    try {
+      // The harness rejects on warnings, so a rejection is the assertion target
+      await compileSourceWithWebpack(entryPath, {
+        webpackConfig: { plugins: [new StripCSSCommentsPlugin()] },
+      });
+    } catch (e) {
+      warning = e as WebpackStatsError;
+    }
+
+    expect(warning).toBeDefined();
+    expect(warning!.message).toContain('has no style bucket annotations');
+  });
+
+  it('includes the offending filename in VM evaluation errors', async () => {
+    const fixturePath = path.resolve(__dirname, '..', '__fixtures__', 'vm-error-trace');
+    const entryPath = path.resolve(fixturePath, 'code.ts');
+
+    // Replace machine-specific paths and line numbers so snapshots are stable across environments
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const normalize = (s: string) =>
+      s
+        .split(repoRoot)
+        .join('<repo>')
+        .replace(/:\d+(:\d+)?/g, ':<line>');
+
+    let error: WebpackStatsError | undefined;
+
+    try {
+      await compileSourceWithWebpack(entryPath, {});
+    } catch (e) {
+      error = e as WebpackStatsError;
+    }
+
+    expect(error).toBeDefined();
+    expect(normalize(error!.message)).toMatchInlineSnapshot(`
         "Module build failed (from ./webpackLoader.vitest.cjs):
         <repo>/packages/transform/src/evaluation/module.mts:<line>
         			throw hostError;
@@ -480,7 +529,5 @@ describe('GriffelCSSExtractionPlugin', () => {
             at Module.evaluate (<repo>/packages/transform/src/evaluation/module.mts:<line>)
             at vmEvaluator (<repo>/packages/transform/src/evaluation/vmEvaluator.mts:<line>)"
       `);
-    },
-    15000,
-  );
+  }, 15000);
 });


### PR DESCRIPTION
Closes #624

`@griffel/webpack-plugin` has dedicated Rspack support (and 4 Rspack e2e scenarios), but its README never mentioned Rspack, and Rsbuild was not documented anywhere.

## Rsbuild needs `tools.lightningcssLoader: false`

Griffel annotates extracted CSS with `/** @griffel:css-start */` comments and relies on them to sort rules into style buckets. Rsbuild enables [`builtin:lightningcss-loader`](https://rsbuild.rs/config/tools/lightningcss-loader) by default, which **strips comments**.

Without them every rule falls through to the unsorted remainder and CSS is emitted in module order. Verified with `@rsbuild/core@2.1.7` — note where the `.r*` reset class lands:

```css
/* default Rsbuild config — reset class LAST, it overrides makeStyles() output */
.fka9v86{color:green}.f10ra9hq{padding-top:4px}…@media screen and (max-width:900px){…}.f10q6zxg:hover{color:#00f}.r196w27b{color:red;padding:10px}

/* with tools.lightningcssLoader: false — correct bucket order */
.r196w27b{color:red;padding:10px}.fka9v86{color:green}.f10ra9hq{padding-top:4px}….f10q6zxg:hover{color:#00f}@media screen and (max-width:900px){…}
```

`tools.lightningcssLoader.exclude` only accepts feature flags (e.g. `vendorPrefixes`), not file conditions, so disabling the loader is the only escape hatch. CSS minification is unaffected as it runs after sorting.

Because this failed silently, the plugin now pushes a build warning when the Griffel chunk has no bucket annotations:

```
warn  Build warning:
⚠ Griffel CSS in "static/css/griffel.d96fa7e93b.css" has no style bucket annotations, CSS rules cannot
  be sorted and will be emitted in module order. This happens when another tool in your CSS pipeline
  removes comments. For example, in Rsbuild set "tools.lightningcssLoader: false" as
  "builtin:lightningcss-loader" strips them.
```

## Changes

`packages/webpack-plugin/src/GriffelPlugin.mts`
- warn when the extracted CSS has no style bucket annotations

`packages/webpack-plugin/README.md`
- "Usage with Rspack": `experiments.css` + the required `{ test: /\.css$/, type: 'css' }` rule, the `CssExtractRspackPlugin` alternative, and the two Rspack limitations (`optimization.splitChunks` is mandatory, `unstable_attachToEntryPoint` throws)
- "Usage with Rsbuild": working config + the `lightningcssLoader` caution
- "Loader options": `importsToTransform`, `functionsToTransform`, `classNameHashSalt`, `evaluationRules` — the website already pointed at this README for them, but they were never documented here
- documents `collectPerfIssues`, the `style-loader` caution, `ignoreOrder` and the `include` performance tip

`apps/website/docs/react/build-optimization/with-webpack.md`
- fleshes out "Usage with Rspack" and adds "Usage with Rsbuild"

## Verification

- `yarn nx run @griffel/webpack-plugin:test` — 54 passed, incl. a new test that strips comments from the emitted asset and asserts the warning
- `yarn nx run @griffel/e2e-rspack:test` — 8/8 passed
- `yarn nx run @griffel/website:build` — succeeds
- type-check, lint, prettier and `beachball check` are clean
- AOT + extraction confirmed end to end on a real Rsbuild app (`__css` / `__resetCSS` in output, atomic class map inlined)
