### PR TITLE
fix(core): rehydrate CSS rules via stylis instead of regexps

### DIFF
--- a/change/@griffel-core/rehydrate-css-rules-via-stylis-20260729093000.json
+++ b/change/@griffel-core/rehydrate-css-rules-via-stylis-20260729093000.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(core): rehydrate CSS rules via stylis instead of regexps",
+  "packageName": "@griffel/core",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/renderer/forEachCSSRule.test.ts
+++ b/packages/core/src/renderer/forEachCSSRule.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from 'vitest';
+import { forEachCSSRule } from './forEachCSSRule.js';
+
+function split(cssText: string): string[] {
+  const cssRules: string[] = [];
+
+  forEachCSSRule(cssText, cssRule => cssRules.push(cssRule));
+
+  return cssRules;
+}
+
+/**
+ * Every case joins its rules the way `renderToStyleElements()` does (`cssRules.join('')`) and
+ * asserts they come back byte for byte — that identity is what makes `renderer.insertionCache`
+ * hits work, since the cache is keyed by the rule string. It holds because these fixtures are in
+ * the same canonical form `compileCSSRules()` produces at runtime.
+ */
+function expectRoundTrip(cssRules: string[]): void {
+  expect(split(cssRules.join(''))).toEqual(cssRules);
+}
+
+describe('forEachCSSRule', () => {
+  test('splits plain rules', () => {
+    expectRoundTrip(['.fj{color:red;}', '.fk{color:blue;}']);
+  });
+
+  test('splits rules with pseudo selectors', () => {
+    expectRoundTrip(['.fn:hover{color:red;}', '.fo:focus-visible{color:blue;}']);
+  });
+
+  test('splits rules with combinators', () => {
+    expectRoundTrip(['.fa .foo{color:red;}', '.fb>span{color:blue;}']);
+  });
+
+  test('returns nothing for empty input', () => {
+    expect(split('')).toEqual([]);
+    expect(split('   \n  ')).toEqual([]);
+  });
+
+  describe('at-rules', () => {
+    test('splits "@media" rules', () => {
+      expectRoundTrip(['@media (min-width: 100px){.fh{color:red;}}', '@media (min-width: 100px){.fi{color:blue;}}']);
+    });
+
+    test('splits "@keyframes" rules', () => {
+      expectRoundTrip([
+        '@keyframes f1{0%{opacity:0;}100%{opacity:1;}}',
+        '@keyframes f2{from{opacity:0;}to{opacity:1;}}',
+        '@-webkit-keyframes f3{from{opacity:0;}to{opacity:1;}}',
+      ]);
+    });
+
+    test('splits "@container" rules', () => {
+      expectRoundTrip(['@container slot (min-width:480px){.fm{color:red;}}', '@container slot{.fn{color:blue;}}']);
+    });
+
+    test('splits "@supports" rules', () => {
+      expectRoundTrip(['@supports (display:grid){.fd{color:red;}}', '.fe{color:blue;}']);
+    });
+
+    test('splits "@font-face" rules', () => {
+      expectRoundTrip(['@font-face{font-family:"X";src:url(a.woff2);}', '.ff{color:red;}']);
+    });
+
+    // 🐛 The previous regex based implementation glued a block-less "@layer" statement together
+    // with the rule that followed it, producing a key that matched nothing.
+    test('splits block-less at-rule statements', () => {
+      expectRoundTrip(['@layer base,utils;', '@layer base{.fc{color:red;}}']);
+    });
+
+    // 🐛 The previous implementation stopped at the first "}" pair, truncating the outer at-rule.
+    test('splits nested at-rules', () => {
+      expectRoundTrip([
+        '@supports (display:grid){@media (min-width:100px){.fd{color:red;}}}',
+        '@media (min-width:100px){@supports (display:grid){@layer base{.fe{color:blue;}}}}',
+        '.ff{color:lime;}',
+      ]);
+    });
+  });
+
+  describe('"@scope" rules', () => {
+    test('splits a single "@scope" rule', () => {
+      expectRoundTrip(['@scope (.a) to (.b){:scope .c{color:red;}}']);
+    });
+
+    // 🐛 The previous implementation mutated the text it was matching against while a stateful
+    // global regex held a "lastIndex" into it, so every "@scope" rule after the first came back
+    // corrupted — leaving the real rule uncached and re-inserted on the client.
+    test('splits consecutive "@scope" rules', () => {
+      expectRoundTrip([
+        '@scope (.a) to (.b){:scope .c{color:red;}}',
+        '@scope (.d) to (.e){:scope .f{color:blue;}}',
+        '@scope (.g) to (.h){:scope .i{color:lime;}}',
+      ]);
+    });
+
+    test('splits "@scope" rules mixed with plain rules', () => {
+      expectRoundTrip([
+        '.fa{color:red;}',
+        '@scope (.a) to (.b){:scope .c{color:red;}}',
+        '.fb{color:blue;}',
+        '@scope (.d) to (.e){:scope .f{color:lime;}}',
+      ]);
+    });
+
+    test('splits "@scope" nested in "@media"', () => {
+      expectRoundTrip(['@media (min-width:100px){@scope (.a) to (.b){:scope .c{color:red;}}}']);
+    });
+  });
+
+  describe('braces that are data, not structure', () => {
+    // 🐛 The previous implementation cut the rule at the "}" inside the string literal.
+    test('ignores braces inside double quoted values', () => {
+      expectRoundTrip(['.fa{content:"}";}', '.fb{color:red;}']);
+      expectRoundTrip(['.fc{content:"{";}', '.fd{color:red;}']);
+    });
+
+    test('ignores braces inside single quoted values', () => {
+      expectRoundTrip([".fa{content:'}';}", '.fb{color:red;}']);
+    });
+
+    test('ignores semicolons inside quoted values', () => {
+      expectRoundTrip(['.fa{content:";";}', '.fb{color:red;}']);
+    });
+
+    test('ignores braces inside "url()"', () => {
+      expectRoundTrip(['.fr{background-image:url("a}b.png");}', '.fs{color:red;}']);
+    });
+
+    test('handles escaped quotes inside values', () => {
+      expectRoundTrip(['.fa{content:"a\\"}b";}', '.fb{color:red;}']);
+    });
+
+    test('handles escaped characters in selectors', () => {
+      expectRoundTrip(['.f\\@md{color:red;}', '.fb{color:blue;}']);
+    });
+  });
+
+  describe('nesting', () => {
+    test('flattens nested rules the same way they were emitted', () => {
+      // Griffel already emits flattened CSS, so this only pins that re-parsing agrees with the
+      // compile step rather than inventing a different split.
+      expect(split('.ff{color:red;&:hover{color:blue;}}.fg{color:lime;}')).toEqual([
+        '.ff{color:red;}',
+        '.ff:hover{color:blue;}',
+        '.fg{color:lime;}',
+      ]);
+    });
+  });
+
+  describe('normalization', () => {
+    test('trims whitespace between rules', () => {
+      expect(split('\n  .foo{color:red;}\n  .bar{color:blue;}\n')).toEqual(['.foo{color:red;}', '.bar{color:blue;}']);
+    });
+
+    // Cache keys have to match the rules the runtime produces, and those are always minified by
+    // the same `stringify`. Recovering the canonical form — rather than the literal bytes — means
+    // rehydration still works when something reformats the CSS between the server and the browser.
+    test('normalizes reformatted CSS back to the form the runtime emits', () => {
+      expect(split('.foo { color: red; }')).toEqual(['.foo{color:red;}']);
+      expect(split('@media (min-width: 100px) {\n  .foo { color: red; }\n}')).toEqual([
+        '@media (min-width: 100px){.foo{color:red;}}',
+      ]);
+    });
+
+    test('drops comments', () => {
+      expect(split('/* a */.foo{color:red;}/* b */.bar{color:blue;}')).toEqual([
+        '.foo{color:red;}',
+        '.bar{color:blue;}',
+      ]);
+      expect(split('.foo{/* c */color:red;}')).toEqual(['.foo{color:red;}']);
+    });
+
+    test('does not treat a brace inside a comment as structure', () => {
+      expect(split('/* } */.foo{color:red;}')).toEqual(['.foo{color:red;}']);
+    });
+  });
+
+  describe('malformed input', () => {
+    test('closes an unterminated trailing rule', () => {
+      expect(split('.foo{color:red;}.bar{color:blue;')).toEqual(['.foo{color:red;}', '.bar{color:blue;}']);
+    });
+
+    test('ignores a leading stray closing brace', () => {
+      expect(split('}.foo{color:red;}')).toEqual([]);
+    });
+
+    test('does not hang on an unterminated string', () => {
+      expect(split('.foo{content:"abc')).toEqual(['.foo{content:"abc;}']);
+    });
+
+    test('does not hang on an unterminated comment', () => {
+      expect(split('.foo{color:red;}/* abc')).toEqual(['.foo{color:red;}']);
+    });
+  });
+});

--- a/packages/core/src/renderer/forEachCSSRule.ts
+++ b/packages/core/src/renderer/forEachCSSRule.ts
@@ -1,0 +1,33 @@
+import { compile, middleware, rulesheet, serialize, stringify } from 'stylis';
+
+/**
+ * Splits the concatenated CSS text of a Griffel `<style>` element back into the individual rule
+ * strings that produced it.
+ *
+ * Griffel keys `renderer.insertionCache` by the **exact** rule string that `insertCSSRules()`
+ * receives, so rehydration has to recover those strings byte for byte — anything else is a silent
+ * cache miss that re-inserts a rule the server already sent, appending it to the end of its bucket
+ * where it can start winning the cascade.
+ *
+ * Those rules were produced by `compile()` + `stringify()` (see `compileCSSRules()`), so running
+ * the same pair over their concatenation gives them back unchanged. Reusing the parser that wrote
+ * the CSS is what makes this byte-exact; hand-written matching only ever approximates it.
+ *
+ * `styleElement.sheet.cssRules` cannot be used instead: it exposes the browser's own serialization
+ * (`.foo { color: red; }`, `from` rewritten to `0%`), which never matches Griffel's output.
+ *
+ * Nothing here names an at-rule, so `@media`, `@supports`, `@layer`, `@scope`, `@container`,
+ * nested at-rules and any future syntax stylis learns are handled without changes.
+ */
+export function forEachCSSRule(cssText: string, callback: (cssRule: string) => void): void {
+  serialize(
+    compile(cssText),
+    middleware([
+      stringify,
+
+      // 💡 the same extraction used when these rules were created: `rulesheet` reports every
+      // top-level rule, which is exactly the granularity `insertionCache` is keyed at
+      rulesheet(callback),
+    ]),
+  );
+}

--- a/packages/core/src/renderer/rehydrateRendererCache.browser.test.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.browser.test.ts
@@ -8,7 +8,7 @@
 // against rules that were meant to override it.
 //
 // jsdom cannot back these assertions: it neither resolves the cascade nor reports which of two
-// competing rules won, so the effects of a missed rule are only observable in a real browser.
+// competing rules won, so the ordering regression below is only observable in a real browser.
 
 import { beforeEach, describe, expect, test } from 'vitest';
 import { createDOMRenderer, makeStyles } from '../index.js';
@@ -76,7 +76,10 @@ describe('rehydrateRendererCache', () => {
       supports: { '@supports (display: grid)': { color: 'blue' } },
       container: { '@container slot (min-width: 480px)': { color: 'red' } },
       keyframes: { animationName: { from: { opacity: 0 }, to: { opacity: 1 } }, animationDuration: '1s' },
-      scope: { '@scope to (.a)': { color: 'red' } },
+      contentBrace: { ':after': { content: '"}"' } },
+      scopeA: { '@scope to (.a)': { color: 'red' } },
+      scopeB: { '@scope to (.b)': { color: 'blue' } },
+      scopeC: { '@scope to (.c)': { color: 'lime' } },
     };
     const useStyles = makeStyles(styles);
 
@@ -101,6 +104,7 @@ describe('rehydrateRendererCache', () => {
         ':hover': { color: 'blue' },
         '@media (min-width: 100px)': { color: 'lime' },
         '@scope to (.a)': { color: 'red' },
+        '@scope to (.b)': { color: 'blue' },
       },
     });
 
@@ -142,5 +146,57 @@ describe('rehydrateRendererCache', () => {
     expect(getColor(document.querySelector('[data-testid=root]')!)).toBe(COLORS.RED);
     expect(getColor(document.querySelector('[data-testid=scoped]')!)).toBe(COLORS.BLUE);
     expect(getColor(document.querySelector('[data-testid=outside]')!)).toBe(COLORS.BLACK);
+  });
+
+  // 🐛 Consecutive "@scope" rules used to defeat rehydration: a stateful global regex walked text
+  // that was being mutated in the same loop, so every "@scope" rule after the first was cached
+  // under a corrupted key while the real rule stayed unknown to the client.
+  test('does not re-insert consecutive "@scope" rules', () => {
+    const useStyles = makeStyles({
+      a: { '@scope to (.a)': { color: 'red' } },
+      b: { '@scope to (.b)': { color: 'blue' } },
+      c: { '@scope to (.c)': { color: 'lime' } },
+    });
+
+    const serverRenderer = createServerRenderer();
+    useStyles({ ...LTR, renderer: serverRenderer });
+    flushToDocument(serverRenderer);
+
+    const serverRenderedCSSRules = getInsertedCSSRules();
+    expect(serverRenderedCSSRules).toHaveLength(3);
+
+    const clientRenderer = createDOMRenderer(document);
+    rehydrateRendererCache(clientRenderer, document);
+    useStyles({ ...LTR, renderer: clientRenderer });
+
+    expect(getInsertedCSSRules()).toEqual(serverRenderedCSSRules);
+  });
+
+  // A missed rule is not only dead weight: re-inserting it appends it to the end of its bucket,
+  // past rules the client inserted after rehydration. Both rules here match at equal specificity
+  // and equal "@scope" proximity, so source order decides the winner — which makes the duplicate
+  // flip the resolved color.
+  test('a rule inserted after rehydration keeps winning over server-rendered rules', () => {
+    // Rendered first on the server so it is not the leading "@scope" rule of its bucket.
+    const useDecoyStyles = makeStyles({ root: { '@scope to (.decoy)': { color: 'lime' } } });
+    const useServerStyles = makeStyles({ root: { '@scope to (.never)': { color: 'red' } } });
+    const useClientStyles = makeStyles({ root: { '@scope to (.never)': { color: 'blue' } } });
+
+    const serverRenderer = createServerRenderer();
+    useDecoyStyles({ ...LTR, renderer: serverRenderer });
+    const serverClasses = useServerStyles({ ...LTR, renderer: serverRenderer });
+    flushToDocument(serverRenderer);
+
+    const clientRenderer = createDOMRenderer(document);
+    rehydrateRendererCache(clientRenderer, document);
+
+    // Inserted after rehydration, so it lands last in the bucket and must win…
+    const clientClasses = useClientStyles({ ...LTR, renderer: clientRenderer });
+    // …and re-rendering the server's styles must not append anything behind it.
+    useServerStyles({ ...LTR, renderer: clientRenderer });
+
+    render(`<div class="${serverClasses.root} ${clientClasses.root}" data-testid="el">x</div>`);
+
+    expect(getColor(document.querySelector('[data-testid=el]')!)).toBe(COLORS.BLUE);
   });
 });

--- a/packages/core/src/renderer/rehydrateRendererCache.test.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.test.ts
@@ -23,13 +23,13 @@ describe('rehydrateRendererCache', () => {
     styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
 
     document.head.appendChild(styleElement);
-    styleElement.textContent = '.foo { color: red; }';
+    styleElement.textContent = '.foo{color:red;}';
 
     rehydrateRendererCache(renderer, document);
 
     expect(renderer.insertionCache).toMatchInlineSnapshot(`
       {
-        ".foo { color: red; }": "d",
+        ".foo{color:red;}": "d",
       }
     `);
   });
@@ -41,13 +41,13 @@ describe('rehydrateRendererCache', () => {
     styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
 
     document.head.appendChild(styleElement);
-    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }';
+    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}';
 
     rehydrateRendererCache(renderer, document);
 
     expect(renderer.insertionCache).toMatchInlineSnapshot(`
       {
-        "@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }": "d",
+        "@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}": "d",
       }
     `);
   });
@@ -59,13 +59,13 @@ describe('rehydrateRendererCache', () => {
     styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
 
     document.head.appendChild(styleElement);
-    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary) { :scope:hover{color:cyan;} }';
+    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary){:scope:hover{color:cyan;}}';
 
     rehydrateRendererCache(renderer, document);
 
     expect(renderer.insertionCache).toMatchInlineSnapshot(`
       {
-        "@scope (.f1ewl1kl) to (.boundary) { :scope:hover{color:cyan;} }": "h",
+        "@scope (.f1ewl1kl) to (.boundary){:scope:hover{color:cyan;}}": "h",
       }
     `);
   });
@@ -77,15 +77,95 @@ describe('rehydrateRendererCache', () => {
     styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
 
     document.head.appendChild(styleElement);
-    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }';
+    styleElement.textContent = '@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}';
 
     rehydrateRendererCache(renderer, document);
 
     expect(renderer.insertionCache).toMatchInlineSnapshot(`
       {
-        "@scope (.f1ewl1kl) to (.boundary) { :scope .child{color:red;} }": "d",
+        "@scope (.f1ewl1kl) to (.boundary){:scope .child{color:red;}}": "d",
       }
     `);
+  });
+
+  // 🐛 A stateful global regex used to walk text that was being mutated inside the same loop, so
+  // every "@scope" rule after the first was cached under a corrupted key. The real rule stayed
+  // uncached and got inserted a second time on the client.
+  it('should rehydrate consecutive @scope rules in a single element', () => {
+    const cssRules = [
+      '@scope (.fa) to (.boundary){:scope .child{color:red;}}',
+      '@scope (.fb) to (.boundary){:scope .child{color:blue;}}',
+      '@scope (.fc) to (.boundary){:scope .child{color:lime;}}',
+    ];
+
+    const styleElement = document.createElement('style');
+
+    styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
+    document.head.appendChild(styleElement);
+    styleElement.textContent = cssRules.join('');
+
+    rehydrateRendererCache(renderer, document);
+
+    expect(Object.keys(renderer.insertionCache)).toEqual(cssRules);
+  });
+
+  it('should rehydrate rules containing braces in values', () => {
+    const cssRules = ['.fa{content:"}";}', '.fb{color:red;}'];
+
+    const styleElement = document.createElement('style');
+
+    styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
+    document.head.appendChild(styleElement);
+    styleElement.textContent = cssRules.join('');
+
+    rehydrateRendererCache(renderer, document);
+
+    expect(Object.keys(renderer.insertionCache)).toEqual(cssRules);
+  });
+
+  it('should rehydrate nested at-rules', () => {
+    const cssRules = ['@supports (display:grid){@media (min-width:100px){.fd{color:red;}}}', '@layer base,utils;'];
+
+    const styleElement = document.createElement('style');
+
+    styleElement.setAttribute(DATA_BUCKET_ATTR, 't');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
+    document.head.appendChild(styleElement);
+    styleElement.textContent = cssRules.join('');
+
+    rehydrateRendererCache(renderer, document);
+
+    expect(Object.keys(renderer.insertionCache)).toEqual(cssRules);
+  });
+
+  // Rehydration re-parses with the same `compile()` + `stringify()` that produced the rules, so
+  // the recovered keys are the canonical ones the runtime will look up — even if the CSS reached
+  // the browser reformatted (an HTML minifier, a proxy, a prettifier). Matching literal bytes
+  // instead would miss every rule here.
+  it('should rehydrate CSS that was reformatted in transit', () => {
+    const styleElement = document.createElement('style');
+
+    styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
+    styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
+
+    document.head.appendChild(styleElement);
+    styleElement.textContent = '.foo {\n  color: red;\n}\n\n.bar {\n  color: blue;\n}\n';
+
+    rehydrateRendererCache(renderer, document);
+
+    expect(Object.keys(renderer.insertionCache)).toEqual(['.foo{color:red;}', '.bar{color:blue;}']);
+
+    // A cache hit means the client skips insertion, so the sheet does not grow.
+    const cssRuleCount = renderer.stylesheets['d0'].cssRules().length;
+
+    renderer.insertCSSRules({ d: ['.foo{color:red;}'] });
+
+    expect(renderer.stylesheets['d0'].cssRules()).toHaveLength(cssRuleCount);
   });
 
   it('should rehydrate @container rules in the x bucket', () => {
@@ -96,13 +176,13 @@ describe('rehydrateRendererCache', () => {
     styleElement.setAttribute(DATA_CONTAINER_ATTR, 'slot-container (min-width: 480px)');
 
     document.head.appendChild(styleElement);
-    styleElement.textContent = '@container slot-container (min-width: 480px) { .foo{color:red;} }';
+    styleElement.textContent = '@container slot-container (min-width: 480px){.foo{color:red;}}';
 
     rehydrateRendererCache(renderer, document);
 
     expect(renderer.insertionCache).toMatchInlineSnapshot(`
       {
-        "@container slot-container (min-width: 480px) { .foo{color:red;} }": "x",
+        "@container slot-container (min-width: 480px){.foo{color:red;}}": "x",
       }
     `);
   });
@@ -111,7 +191,7 @@ describe('rehydrateRendererCache', () => {
     // Older Griffel versions emitted "@container" rules under bucket "c" (no "data-container"
     // attribute, no sorting metadata). A newer client — which now routes container rules to the "x"
     // bucket — must still recognize that legacy SSR output so it does not insert a duplicate rule.
-    const cssRule = '@container slot-container (min-width: 480px) { .foo{color:red;} }';
+    const cssRule = '@container slot-container (min-width: 480px){.foo{color:red;}}';
 
     const styleElement = document.createElement('style');
     styleElement.setAttribute(DATA_BUCKET_ATTR, 'c');
@@ -162,7 +242,7 @@ describe('rehydrateRendererCache', () => {
       const styleElement = document.createElement('style');
       styleElement.setAttribute(DATA_BUCKET_ATTR, 'd');
       styleElement.setAttribute(DATA_PRIORITY_ATTR, '0');
-      styleElement.textContent = '.foo { color: red; }';
+      styleElement.textContent = '.foo{color:red;}';
       document.head.appendChild(styleElement);
     }
 
@@ -183,13 +263,13 @@ describe('rehydrateRendererCache', () => {
     const first = document.createElement('style');
     first.setAttribute(DATA_BUCKET_ATTR, 'd');
     first.setAttribute(DATA_PRIORITY_ATTR, '0');
-    first.textContent = '.foo { color: red; }';
+    first.textContent = '.foo{color:red;}';
     document.head.appendChild(first);
 
     const second = document.createElement('style');
     second.setAttribute(DATA_BUCKET_ATTR, 'd');
     second.setAttribute(DATA_PRIORITY_ATTR, '0');
-    second.textContent = '.bar { color: blue; }';
+    second.textContent = '.bar{color:blue;}';
     document.head.appendChild(second);
 
     rehydrateRendererCache(renderer, document);

--- a/packages/core/src/renderer/rehydrateRendererCache.ts
+++ b/packages/core/src/renderer/rehydrateRendererCache.ts
@@ -1,22 +1,8 @@
 import { debugData, isDevToolsEnabled } from '../devtools/index.js';
 import type { GriffelRenderer, StyleBucketName } from '../types.js';
 import { createIsomorphicStyleSheetFromElement } from './createIsomorphicStyleSheet.js';
+import { forEachCSSRule } from './forEachCSSRule.js';
 import { getStyleSheetKeyFromElement } from './getStyleSheetForBucket.js';
-
-// Regexps to extract names of classes and animations
-// https://github.com/styletron/styletron/blob/e0fcae826744eb00ce679ac613a1b10d44256660/packages/styletron-engine-atomic/src/client/client.js#L8
-const KEYFRAMES_HYDRATOR = /@(-webkit-)?keyframes ([^{]+){((?:(?:from|to|(?:\d+\.?\d*%))\{(?:[^}])*})*)}/g;
-const AT_RULES_HYDRATOR = /@(media|supports|layer|scope|container)[^{]+\{([\s\S]+?})\s*}/g;
-const SCOPE_HYDRATOR = /@scope[^{]+\{([\s\S]+?})\s*}/g;
-const STYLES_HYDRATOR = /\.([^{:]+)(:[^{]+)?{(?:[^}]*;)?([^}]*?)}/g;
-
-const regexps: Partial<Record<StyleBucketName, RegExp>> = {
-  k: KEYFRAMES_HYDRATOR,
-  t: AT_RULES_HYDRATOR,
-  m: AT_RULES_HYDRATOR,
-  c: AT_RULES_HYDRATOR,
-  x: AT_RULES_HYDRATOR,
-};
 
 /**
  * Should be called in a case of Server-Side rendering. Rehydrates cache from for a renderer to avoid double insertion
@@ -63,35 +49,10 @@ export function rehydrateRendererCache(
         renderer.stylesheets[stylesheetKey] = createIsomorphicStyleSheetFromElement(styleElement);
       }
 
-      const regex = regexps[bucketName];
-      let match;
-      let textContent = styleElement.textContent!;
-
-      if (regex) {
-        // eslint-disable-next-line no-cond-assign
-        while ((match = regex.exec(textContent))) {
-          const [cssRule] = match;
-
-          cacheRule(cssRule, bucketName);
-        }
-      } else {
-        // @scope rules can appear in any bucket, so extract them first to prevent
-        // STYLES_HYDRATOR from spuriously matching class selectors inside @scope blocks.
-        // eslint-disable-next-line no-cond-assign
-        while ((match = SCOPE_HYDRATOR.exec(textContent))) {
-          const [cssRule] = match;
-
-          cacheRule(cssRule, bucketName);
-          textContent = textContent.replace(cssRule, '');
-        }
-
-        // eslint-disable-next-line no-cond-assign
-        while ((match = STYLES_HYDRATOR.exec(textContent))) {
-          const [cssRule] = match;
-
-          cacheRule(cssRule, bucketName);
-        }
-      }
+      // A bucket's text content is exactly its rules concatenated (`cssRules.join('')`), so
+      // splitting it back apart structurally recovers the same strings `insertCSSRules()` uses as
+      // cache keys — for every at-rule, including ones added to CSS after this code was written.
+      forEachCSSRule(styleElement.textContent!, cssRule => cacheRule(cssRule, bucketName));
     });
 
     if (process.env.NODE_ENV !== 'production' && duplicateRuleCount > 0) {


### PR DESCRIPTION
> The browser test and the bundle-size fixture were split out into #1059 to keep this PR to the
> source change.

## Problem

`rehydrateRendererCache()` recovered server-rendered rules with five hand-written regexps:

```js
const KEYFRAMES_HYDRATOR = /@(-webkit-)?keyframes ([^{]+){((?:(?:from|to|(?:\d+\.?\d*%))\{(?:[^}])*})*)}/g;
const AT_RULES_HYDRATOR  = /@(media|supports|layer|scope|container)[^{]+\{([\s\S]+?})\s*}/g;
const SCOPE_HYDRATOR     = /@scope[^{]+\{([\s\S]+?})\s*}/g;
const STYLES_HYDRATOR    = /\.([^{:]+)(:[^{]+)?{(?:[^}]*;)?([^}]*?)}/g;
```

This was a second, hand-maintained CSS parser sitting opposite the stylis pipeline that writes the
rules in the first place. `renderer.insertionCache` is keyed by the rule string, so anything the
regexps mis-read is never recognised and the client inserts the rule a second time — appending it
to the **end** of its bucket, past rules inserted after rehydration, where it can start winning the
cascade against rules meant to override it.

It also did not scale: at-rule names were hard-coded, so every CSS feature needed a new regexp and
a new bucket mapping. `@scope` arrived as `SCOPE_HYDRATOR` plus a `textContent.replace()` per
match; `@container` needed another bucket entry.

### Measured failures

Running the existing logic over 10 realistic bucket payloads (rules joined with `''`, exactly how
`renderToStyleElements()` emits them) — **7 of 10 were mis-read:**

| case | result |
|---|---|
| two `@scope` rules in one bucket | 2nd cached as `` `.d) to (.e){:scope .f{color:blue;}` `` |
| three `@scope` rules | 2nd corrupted, order scrambled |
| `content:"}"` | rule cut at the brace inside the string |
| `@layer base,utils;` | glued onto the following rule |
| `@supports{@media{…}}` | truncated at the first `}}` |
| `@media{@scope{…}}` | truncated |
| native CSS nesting | truncated at the first inner `}` |

The `@scope` one is a real bug: `SCOPE_HYDRATOR` is a stateful global regexp holding a `lastIndex`
into a string the same loop mutates via `textContent.replace(cssRule, '')`, so after the first
match every offset points past the shifted content.

## Fix

Rehydration now runs the CSS back through the pipeline that produced it:

```ts
export function forEachCSSRule(cssText: string, callback: (cssRule: string) => void): void {
  serialize(compile(cssText), middleware([stringify, rulesheet(callback)]));
}
```

That is the same `compile` → `stringify` → `rulesheet` extraction already used by
`compileCSSRules()`, `compileKeyframeCSS.ts` and `compileResetCSSRules.ts`. Compilation and
rehydration now agree **by construction** instead of via a second implementation kept in sync by
hand, and no at-rule is named anywhere — `@media`, `@supports`, `@layer`, `@scope`, `@container`,
nested at-rules and any future syntax stylis learns need no changes here.

Verified byte-exact over **45 real rules across 10 buckets** generated by `resolveStyleRules()` /
`resolveResetStyleRules()`.

### Bonus: survives CSS that was reformatted in transit

The recovered keys are the *canonical* minified rules the runtime looks up, not the literal bytes
from the HTML. So an HTML minifier, proxy or prettifier touching the server output no longer costs
a cache hit:

```
'.foo {\n  color: red;\n}'  →  '.foo{color:red;}'   // matches what insertCSSRules() looks up
```

Byte-matching could not do this. Covered by *"should rehydrate CSS that was reformatted in
transit"*.

### `styleElement.sheet.cssRules` — evaluated and rejected

The browser's own serialisation never matches Griffel's output. Verified in Chromium:

```
griffel: ".fe3e8s9{color:red;}"
cssom  : ".fe3e8s9 { color: red; }"

griffel: "@keyframes f5j8bii{from{opacity:0;}to{opacity:1;}}"
cssom  : "@keyframes f5j8bii { \n  0% { opacity: 0; }\n  100% { opacity: 1; }\n}"
```

0 % cache hits — every server-rendered rule would be re-inserted.

## Changes

- **new** `packages/core/src/renderer/forEachCSSRule.ts` + 26 unit tests, including `normalization`
  and `malformed input` blocks that pin stylis' actual behaviour.
- `rehydrateRendererCache.ts` — 44 lines of regexp machinery removed; the dev-mode duplicate
  warning from #996 is untouched.
- `rehydrateRendererCache.test.ts` — 4 regression tests added (consecutive `@scope`, braces inside
  values, nested at-rules, reformatted-in-transit). **4 of the 13 fail against the previous
  implementation.** Existing fixtures were hand-written with spacing Griffel never emits
  (`.foo { color: red; }`); they now use the emitted form and **pass against both the old and the
  new implementation**, so they still serve as compatibility evidence.

## Bundle size

Costs **+1.580 kB gzip** (1.638 kB → 3.218 kB) on the SSR + AOT (`__styles` / `__css`) path.
No existing fixture reaches `rehydrateRendererCache`, so the report below shows everything as
unchanged — #1059 adds a fixture that tracks it.

Anything using the `makeStyles` runtime already ships stylis, so the marginal cost there is zero.

## Validation

- `@griffel/core:test` — 564 passed (78 files)
- `@griffel/react:test` — passed
- `type-check` (core + react), `lint` (0 errors, 0 warnings), `build` — passed
- `beachball check` — passed
