### PR TITLE
feat(vite-plugin)!: reimplement the plugin to perform CSS extraction

### DIFF
--- a/apps/website/docs/react/build-optimization/introduction.md
+++ b/apps/website/docs/react/build-optimization/introduction.md
@@ -18,3 +18,4 @@ It's designed to be used **only** in applications. It is reasonable to introduce
 ## What to use?
 
 - [Webpack / Rspack plugin](/react/build-optimization/with-webpack)
+- [Vite plugin](/react/build-optimization/with-vite)

--- a/apps/website/docs/react/build-optimization/technical-details.md
+++ b/apps/website/docs/react/build-optimization/technical-details.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Technical details
@@ -32,7 +32,7 @@ You can look at the graph below which describes what work is done during style r
 
 ```mermaid
 stateDiagram-v2
-    
+
 
     INVOKE_USE_STYLES: useStyles() invocation
     COMPUTE_RTL_STYLES: Compute RTL styles

--- a/apps/website/docs/react/build-optimization/with-vite.md
+++ b/apps/website/docs/react/build-optimization/with-vite.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# With Vite
+
+:::info
+
+`@griffel/vite-plugin` requires Vite 8 or above and `@griffel/react` 1.7.7 or above.
+
+:::
+
+## Install
+
+<Tabs>
+<TabItem value="yarn" label="Yarn">
+
+```shell
+yarn add --dev @griffel/vite-plugin
+```
+
+</TabItem>
+<TabItem value="npm" label="NPM">
+
+```shell
+npm install --save-dev @griffel/vite-plugin
+```
+
+</TabItem>
+</Tabs>
+
+## Usage
+
+Add the plugin to your Vite configuration:
+
+```js
+import { defineConfig } from 'vite';
+import { griffel } from '@griffel/vite-plugin';
+
+export default defineConfig({
+  plugins: [griffel()],
+});
+```
+
+That's it, no additional configuration is required to handle the produced CSS: the plugin relies on Vite's own CSS pipeline.
+
+For better performance (to process less files) consider using `include`:
+
+```js
+import { defineConfig } from 'vite';
+import { griffel } from '@griffel/vite-plugin';
+
+export default defineConfig({
+  plugins: [
+    griffel({
+      include: [/src\//, /node_modules\/@fluentui\//],
+    }),
+  ],
+});
+```
+
+## How it works
+
+The plugin is a pair of Vite plugins:
+
+- a plugin with `enforce: 'pre'` evaluates `makeStyles()` & `makeResetStyles()` calls at build time and moves the produced CSS to virtual CSS modules
+- a plugin with `enforce: 'post'` collects these modules during `generateBundle()`, sorts the rules into style buckets and merges them into the stylesheets of your entrypoints
+
+## Caveats
+
+### Development mode
+
+The plugin applies to production builds only. A dev server has no bundling step, so there is no stylesheet to extract rules into, and Griffel handles styles in runtime there as it does without the plugin.
+
+### Non ESM files
+
+CSS is extracted only from ES modules. Files that are not ES modules are skipped and fall back to Griffel's runtime.
+
+## Configuration
+
+Please check [the README](https://github.com/microsoft/griffel/tree/main/packages/vite-plugin) of `@griffel/vite-plugin` to check how to configure module evaluation and imports.

--- a/change/@griffel-vite-plugin-implementation.json
+++ b/change/@griffel-vite-plugin-implementation.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: reimplement the plugin to perform CSS extraction, the previous implementation based on \"@wyw-in-js/vite\" is gone",
+  "packageName": "@griffel/vite-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -2,7 +2,17 @@
 
 A plugin for Vite that performs CSS extraction for [`@griffel/react`](../react).
 
-> ⚠️ This package is a scaffolding only, the implementation & the documentation follow in a separate pull request.
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Install](#install)
+- [Usage](#usage)
+- [Options](#options)
+- [How it works](#how-it-works)
+  - [Development mode](#development-mode)
+- [Caveats](#caveats)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Install
 
@@ -11,3 +21,91 @@ yarn add --dev @griffel/vite-plugin
 # or
 npm install --save-dev @griffel/vite-plugin
 ```
+
+> ⚠️ The plugin requires Vite 8 or above and `@griffel/react` 1.7.7 or above.
+
+## Usage
+
+Within your Vite configuration, add the plugin:
+
+```js
+import { defineConfig } from 'vite';
+import { griffel } from '@griffel/vite-plugin';
+
+export default defineConfig({
+  plugins: [griffel()],
+});
+```
+
+The plugin automatically:
+
+- Transforms `makeStyles()`, `makeResetStyles()`, and `makeStaticStyles()` calls at build time
+- Extracts CSS from these calls into stylesheets handled by Vite
+- Sorts CSS rules by specificity buckets, media queries, and container queries
+
+No extra configuration is required: CSS is handled by Vite itself, so `<link>` tags in production work as usual. In
+development the plugin does nothing and Griffel handles styles in runtime.
+
+## Options
+
+```js
+griffel({
+  // Files to process (default: /\.[cm]?[jt]sx?$/)
+  include: /\.[cm]?[jt]sx?$/,
+  // Files to skip, nothing is excluded by default as dependencies may also use Griffel
+  exclude: undefined,
+
+  // Compare function for sorting media queries (default: @griffel/core's defaultCompareMediaQueries)
+  compareMediaQueries: myCompareFunction,
+
+  // Compare function for sorting container queries (default: same comparator as compareMediaQueries)
+  compareContainerQueries: myCompareFunction,
+
+  // Override the resolver used to resolve imports inside evaluated modules
+  resolverFactory: myResolverFactory,
+
+  // A salt that is added to generated class names
+  classNameHashSalt: '',
+
+  // Modules that export Griffel functions (default: ["@griffel/core", "@griffel/react", "@fluentui/react-components"])
+  importsToTransform: ['@griffel/react'],
+
+  // Functions that should be treated as Griffel style calls
+  functionsToTransform: ['makeStyles', 'makeResetStyles', 'makeStaticStyles'],
+
+  // Rules that define how matched files are transformed during the evaluation
+  evaluationRules: undefined,
+
+  // Collect and log timing stats once a build is finished
+  collectStats: false,
+
+  // Collect and log dependencies that slow down evaluation (CJS modules, "export *" barrels)
+  collectPerfIssues: false,
+});
+```
+
+## How it works
+
+The plugin is a pair of Vite plugins:
+
+- `griffel:transform` runs before other transforms (`enforce: 'pre'`) and replaces Griffel calls with their evaluated
+  results. The extracted CSS is served from a virtual CSS module that is imported by a transformed file.
+- `griffel:extract` runs after the CSS assets are produced (`enforce: 'post'`) and merges the CSS of all chunks into
+  the assets of entrypoints, sorting & deduplicating rules on the way.
+
+Both apply to production builds only.
+
+Griffel relies on the order of CSS rules: rules are grouped in style buckets and can be overridden only by rules from
+the same or a later bucket. As Vite emits a stylesheet per chunk, the rules of a lazy loaded chunk would be applied
+after the rules of an application. The plugin avoids it by moving all Griffel rules into a single stylesheet, this
+matches the behavior of the dedicated `griffel` chunk in `@griffel/webpack-plugin`.
+
+### Development mode
+
+The plugin applies to production builds only (`apply: 'build'`). A dev server has no bundling step, so there is no
+stylesheet to extract rules into, and Griffel handles styles in runtime there as it does without the plugin.
+
+## Caveats
+
+- Files that are not ES modules are skipped, Griffel calls in them will be handled by the runtime.
+- If a project has multiple entrypoints, each of them gets a copy of all extracted Griffel CSS.

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -16,5 +16,14 @@
       "default": "./src/index.mjs"
     },
     "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@griffel/core": "^1.21.3",
+    "@griffel/css-extraction-utils": "^1.0.0",
+    "@griffel/transform": "^3.0.7",
+    "oxc-resolver": "^11.24.2"
+  },
+  "peerDependencies": {
+    "vite": "^8.0.0"
   }
 }

--- a/packages/vite-plugin/src/constants.mts
+++ b/packages/vite-plugin/src/constants.mts
@@ -1,0 +1,4 @@
+export const PLUGIN_NAME = 'griffel';
+
+/** Suffix used for virtual CSS modules that are emitted for each transformed source file. */
+export const GRIFFEL_CSS_SUFFIX = '.griffel.css';

--- a/packages/vite-plugin/src/griffelPlugin.mts
+++ b/packages/vite-plugin/src/griffelPlugin.mts
@@ -1,0 +1,352 @@
+import { defaultCompareMediaQueries, type CSSRulesByBucket, type GriffelRenderer } from '@griffel/core';
+import { EvalCache, transformSync, type TransformOptions } from '@griffel/transform';
+import { createFilter, type FilterPattern, type Plugin, type ResolvedConfig, type Rollup } from 'vite';
+
+import {
+  createStatsCollector,
+  generateCSSRules,
+  parseCSSRules,
+  resolveAssetPathsInCSSRules,
+  sortCSSRules,
+  CSS_START_MARKER,
+} from '@griffel/css-extraction-utils';
+
+import { GRIFFEL_CSS_SUFFIX, PLUGIN_NAME } from './constants.mjs';
+import { createResolverFactory, type TransformResolverFactory } from './resolver/createResolverFactory.mjs';
+
+type OutputBundle = Rollup.OutputBundle;
+
+const DEFAULT_INCLUDE = /\.[cm]?[jt]sx?$/;
+const DEFAULT_FUNCTIONS_TO_TRANSFORM = ['makeStyles', 'makeResetStyles', 'makeStaticStyles'] as const;
+
+export type GriffelPluginOptions = Omit<TransformOptions, 'filename' | 'generateMetadata' | 'resolveModule'> & {
+  /**
+   * Files to process, follows the Rollup/Vite filter convention.
+   * @default /\.[cm]?[jt]sx?$/
+   */
+  include?: FilterPattern;
+
+  /**
+   * Files to skip, follows the Rollup/Vite filter convention. Nothing is excluded by default as dependencies in
+   * "node_modules" may also use Griffel.
+   */
+  exclude?: FilterPattern;
+
+  /** Prints the time spent on transforms once a build is finished. */
+  collectStats?: boolean;
+
+  /** Prints dependencies that slow down evaluation (CJS modules, "export *" barrels) once a build is finished. */
+  collectPerfIssues?: boolean;
+
+  compareMediaQueries?: GriffelRenderer['compareMediaQueries'];
+
+  /**
+   * A custom comparator that orders "@container" query conditions, mirroring `compareMediaQueries`.
+   * Defaults to the `compareMediaQueries` comparator.
+   */
+  compareContainerQueries?: GriffelRenderer['compareContainerQueries'];
+
+  /** Allows to override resolver used to resolve imports inside evaluated modules. */
+  resolverFactory?: TransformResolverFactory;
+};
+
+function getAssetSourceContents(source: string | Uint8Array): string {
+  if (typeof source === 'string') {
+    return source;
+  }
+
+  return Buffer.from(source).toString('utf-8');
+}
+
+/** Splits a module id into a path and a query (`?direct`, `?t=` & others are appended by Vite). */
+function splitQuery(id: string): [path: string, query: string] {
+  const queryIndex = id.indexOf('?');
+
+  if (queryIndex === -1) {
+    return [id, ''];
+  }
+
+  return [id.slice(0, queryIndex), id.slice(queryIndex)];
+}
+
+/**
+ * A module cannot be transformed if it does not use ESM syntax. This is a common case for dependencies in
+ * "node_modules" that are shipped as CommonJS, they are handled by Vite itself and should not fail a build.
+ */
+function isNonESMError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('is not an ES module');
+}
+
+/**
+ * Picks assets that the sorted Griffel CSS should be written to.
+ *
+ * Every entry chunk gets the CSS of the chunk itself as the first item of "importedCss" (it's registered in
+ * "renderChunk" by Vite, while the CSS of imported chunks is appended later in "generateBundle"). Writing to it
+ * guarantees that Griffel CSS is loaded eagerly with an entry, exactly like a dedicated "griffel" chunk does in
+ * "@griffel/webpack-plugin".
+ */
+function resolveEntryCSSAssets(bundle: OutputBundle): Set<string> {
+  const entryAssets = new Set<string>();
+
+  for (const output of Object.values(bundle)) {
+    if (output.type !== 'chunk' || !output.isEntry) {
+      continue;
+    }
+
+    const ownCSSAsset = output.viteMetadata?.importedCss.values().next().value;
+
+    if (typeof ownCSSAsset === 'string') {
+      entryAssets.add(ownCSSAsset);
+    }
+  }
+
+  return entryAssets;
+}
+
+/**
+ * Returns names of all CSS assets, assets of entrypoints go first to keep the CSS of an application before the CSS
+ * of lazy loaded chunks. Rules with an equal priority are ordered by their appearance.
+ */
+function resolveCSSAssetsOrder(bundle: OutputBundle, entryAssets: Set<string>): string[] {
+  const restAssets: string[] = [];
+
+  for (const [fileName, output] of Object.entries(bundle)) {
+    if (output.type !== 'asset' || !fileName.endsWith('.css') || entryAssets.has(fileName)) {
+      continue;
+    }
+
+    restAssets.push(fileName);
+  }
+
+  return [...entryAssets, ...restAssets];
+}
+
+export function griffel(options: GriffelPluginOptions = {}): Plugin[] {
+  const {
+    include = DEFAULT_INCLUDE,
+    exclude,
+
+    collectStats = false,
+    collectPerfIssues = false,
+
+    compareMediaQueries = defaultCompareMediaQueries,
+    compareContainerQueries = compareMediaQueries,
+
+    resolverFactory = createResolverFactory(),
+
+    ...transformOptions
+  } = options;
+
+  const filter = createFilter(include, exclude);
+  const functionsToTransform = transformOptions.functionsToTransform ?? DEFAULT_FUNCTIONS_TO_TRANSFORM;
+
+  const stats = createStatsCollector({
+    collectStats,
+    collectPerfIssues,
+    transformLabel: 'Transform',
+    extractionLabel: 'Extraction',
+  });
+
+  /** Maps a virtual CSS module id to the source file that produced it. */
+  const cssModuleOwners = new Map<string, string>();
+  /** Maps a source file to the CSS rules extracted from it, asset paths are not resolved yet. */
+  const cssRulesByFile = new Map<string, CSSRulesByBucket>();
+
+  let resolveModule: TransformOptions['resolveModule'];
+
+  /** Returns `null` when a file should not be modified. */
+  function runTransform(
+    sourceCode: string,
+    filename: string,
+    addWatchFile: (watchedFile: string) => void = () => undefined,
+  ): { code: string; cssRulesByBucket?: CSSRulesByBucket } | null {
+    if (!filter(filename)) {
+      return null;
+    }
+
+    // Early return to handle cases when there is no Griffel usage in the file
+    if (!functionsToTransform.some(functionName => sourceCode.includes(functionName))) {
+      return null;
+    }
+
+    // Clear require cache to allow re-evaluation of modules
+    EvalCache.clearForFile(filename);
+
+    const startTime = stats.now();
+
+    try {
+      const result = transformSync(sourceCode, {
+        ...transformOptions,
+
+        filename,
+        collectPerfIssues,
+        resolveModule: (moduleId, params) => {
+          const resolved = resolveModule!(moduleId, params);
+
+          addWatchFile(resolved.path);
+
+          return resolved;
+        },
+      });
+
+      stats.register(filename, startTime, {
+        evaluationMode: result.usedVMForEvaluation ? 'vm' : 'ast',
+        perfIssues: result.perfIssues,
+      });
+
+      return result;
+    } catch (error) {
+      if (isNonESMError(error)) {
+        return null;
+      }
+
+      throw error;
+    }
+  }
+
+  const transformPlugin: Plugin = {
+    name: `${PLUGIN_NAME}:transform`,
+    // Runs before "vite:esbuild" & framework plugins to receive the original source code, this matches the loader
+    // order in Webpack where the Griffel loader is the last one in a chain
+    enforce: 'pre',
+    apply: 'build',
+
+    configResolved(config: ResolvedConfig) {
+      const alias = Array.isArray(config.resolve?.alias) ? undefined : config.resolve?.alias;
+
+      resolveModule = resolverFactory({ alias });
+    },
+
+    buildStart() {
+      cssModuleOwners.clear();
+      cssRulesByFile.clear();
+      stats.clear();
+    },
+
+    resolveId(source) {
+      const [cleanSource, query] = splitQuery(source);
+
+      if (cssModuleOwners.has(cleanSource)) {
+        return cleanSource + query;
+      }
+
+      return null;
+    },
+
+    load(id) {
+      const [cleanId] = splitQuery(id);
+      const sourceFilename = cssModuleOwners.get(cleanId);
+
+      if (typeof sourceFilename === 'undefined') {
+        return null;
+      }
+
+      const cssRules = cssRulesByFile.get(sourceFilename);
+
+      if (typeof cssRules === 'undefined') {
+        return '';
+      }
+
+      // Asset paths are resolved relatively to the virtual CSS module, it's placed next to the source file so that
+      // "url()" references keep working
+      return generateCSSRules(resolveAssetPathsInCSSRules(cssRules, cleanId));
+    },
+
+    transform(sourceCode, id) {
+      const [filename] = splitQuery(id);
+
+      if (id.includes('\0')) {
+        return null;
+      }
+
+      const result = runTransform(sourceCode, filename, watchedFile => this.addWatchFile(watchedFile));
+
+      if (result === null) {
+        return null;
+      }
+
+      if (!result.cssRulesByBucket) {
+        cssRulesByFile.delete(filename);
+        return { code: result.code, map: null };
+      }
+
+      cssRulesByFile.set(filename, result.cssRulesByBucket);
+
+      const cssModuleId = filename.replace(/\.[^.]+$/, GRIFFEL_CSS_SUFFIX);
+
+      cssModuleOwners.set(cssModuleId, filename);
+
+      return { code: `${result.code}\n\nimport ${JSON.stringify(cssModuleId)};`, map: null };
+    },
+  };
+
+  const extractPlugin: Plugin = {
+    name: `${PLUGIN_NAME}:extract`,
+    // Runs after "vite:css-post" that produces CSS assets, a plugin with "enforce: post" is the only way to observe
+    // and modify them
+    enforce: 'post',
+    apply: 'build',
+
+    generateBundle(_outputOptions, bundle) {
+      const startTime = stats.now();
+
+      const entryAssets = resolveEntryCSSAssets(bundle);
+
+      const cssRules: CSSRulesByBucket[] = [];
+      const assetsWithGriffelCSS: string[] = [];
+
+      for (const fileName of resolveCSSAssetsOrder(bundle, entryAssets)) {
+        const output = bundle[fileName];
+
+        if (output?.type !== 'asset') {
+          continue;
+        }
+
+        const assetContents = getAssetSourceContents(output.source);
+
+        if (!assetContents.includes(CSS_START_MARKER)) {
+          continue;
+        }
+
+        const { cssRulesByBucket, remainingCSS } = parseCSSRules(assetContents);
+
+        cssRules.push(cssRulesByBucket);
+        assetsWithGriffelCSS.push(fileName);
+
+        output.source = remainingCSS;
+      }
+
+      if (cssRules.length === 0) {
+        return;
+      }
+
+      // WHAT?
+      //   Merges the CSS of all chunks into assets of entrypoints & sorts it.
+      // WHY?
+      //   CSS rules should be sorted in the same order as it's done via style buckets by the Griffel runtime, it's
+      //   not possible to do it in multiple assets as they can be loaded in an arbitrary order.
+      const sortedCSS = sortCSSRules(cssRules, compareMediaQueries, compareContainerQueries);
+
+      // Library & SSR builds may have no entry chunks with CSS attached, in this case the CSS stays where it was found
+      const targetAssets = entryAssets.size > 0 ? entryAssets : new Set([assetsWithGriffelCSS[0]]);
+
+      for (const fileName of targetAssets) {
+        const output = bundle[fileName];
+
+        if (output?.type !== 'asset') {
+          continue;
+        }
+
+        output.source = getAssetSourceContents(output.source) + sortedCSS;
+      }
+
+      stats.registerExtraction(startTime);
+    },
+
+    closeBundle() {
+      stats.print();
+    },
+  };
+
+  return [transformPlugin, extractPlugin];
+}

--- a/packages/vite-plugin/src/index.mts
+++ b/packages/vite-plugin/src/index.mts
@@ -1,1 +1,7 @@
-export {};
+export { griffel, type GriffelPluginOptions } from './griffelPlugin.mjs';
+
+export {
+  createResolverFactory,
+  type ResolverFactoryOptions,
+  type TransformResolverFactory,
+} from './resolver/createResolverFactory.mjs';

--- a/packages/vite-plugin/src/resolver/createResolverFactory.mts
+++ b/packages/vite-plugin/src/resolver/createResolverFactory.mts
@@ -1,0 +1,60 @@
+import { ResolverFactory, type NapiResolveOptions } from 'oxc-resolver';
+import type { TransformResolver } from '@griffel/transform';
+import * as path from 'node:path';
+
+function isCJSOnlyPackage(id: string): boolean {
+  return id === 'tslib' || id.startsWith('@babel/runtime') || id.startsWith('@swc/helpers');
+}
+
+const RESOLVE_OPTIONS_DEFAULTS: NapiResolveOptions = {
+  conditionNames: ['require'],
+  extensions: ['.js', '.jsx', '.cjs', '.mjs', '.ts', '.tsx', '.json'],
+};
+
+/**
+ * Creates a resolver used to resolve imports inside modules that are evaluated during the transform.
+ *
+ * ⚠ Vite's own resolver (`this.resolve()`) is asynchronous, while the Griffel transform is synchronous, so an
+ * independent resolver is used instead. `alias` from the Vite config is passed in to keep custom aliases working.
+ */
+export function createResolverFactory(): TransformResolverFactory {
+  return function (options: ResolverFactoryOptions = {}): TransformResolver {
+    const cjsResolver = new ResolverFactory({
+      ...RESOLVE_OPTIONS_DEFAULTS,
+      ...(options.alias ? { alias: options.alias } : null),
+    });
+
+    // Clone shares the underlying cache; extensions must be re-specified as cloneWithOptions does not persist them
+    const esmResolver = cjsResolver.cloneWithOptions({
+      ...RESOLVE_OPTIONS_DEFAULTS,
+      ...(options.alias ? { alias: options.alias } : null),
+      conditionNames: ['import'],
+      mainFields: ['module', 'main'],
+    });
+
+    return function resolveModule(id, { filename }) {
+      const resolver = isCJSOnlyPackage(id) ? cjsResolver : esmResolver;
+      const resolved = resolver.sync(path.dirname(filename), id);
+
+      if (resolved.error) {
+        throw resolved.error;
+      }
+
+      if (!resolved.path) {
+        throw new Error(`oxc-resolver: Failed to resolve module "${id}"`);
+      }
+
+      return {
+        path: resolved.path,
+        builtin: !!resolved.builtin,
+      };
+    };
+  };
+}
+
+export type ResolverFactoryOptions = {
+  /** Aliases derived from `resolve.alias` of the Vite config. */
+  alias?: NapiResolveOptions['alias'];
+};
+
+export type TransformResolverFactory = (options: ResolverFactoryOptions) => TransformResolver;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,6 +3855,13 @@ __metadata:
 "@griffel/vite-plugin@workspace:packages/vite-plugin":
   version: 0.0.0-use.local
   resolution: "@griffel/vite-plugin@workspace:packages/vite-plugin"
+  dependencies:
+    "@griffel/core": "npm:^1.21.3"
+    "@griffel/css-extraction-utils": "npm:^1.0.0"
+    "@griffel/transform": "npm:^3.0.7"
+    oxc-resolver: "npm:^11.24.2"
+  peerDependencies:
+    vite: ^8.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Overview

Reimplements `@griffel/vite-plugin` with feature parity to `@griffel/webpack-plugin`.

The previous implementation (`0.1.16`, based on `@wyw-in-js/vite` & `@griffel/tag-processor`) was removed in #805, the package scaffolding landed in #1060. This one is built on `@griffel/transform`, the same package that powers the Webpack plugin, and is released as a **major** (`0.1.16` → `1.0.0`).

## Breaking changes

- the default export is replaced with a named `griffel` export
- `@griffel/tag-processor` is no longer a peer dependency, styles are no longer written as tagged templates
- the plugin now performs **CSS extraction** rather than ahead-of-time compilation only
- the plugin applies to **production builds only**, a dev server keeps using the Griffel runtime

## Implementation

`griffel()` returns a pair of plugins:

| Plugin | `enforce` | Responsibility |
| --- | --- | --- |
| `griffel:transform` | `pre` | Runs `@griffel/transform#transformSync` on matched modules, stores extracted rules and serves them through per-file virtual CSS modules (`resolveId` / `load`). Registers watch dependencies. |
| `griffel:extract` | `post` | In `generateBundle` parses every CSS asset that contains Griffel blocks, strips them out, globally sorts & dedupes them via `sortCSSRules()` and appends the result to the entry point stylesheets. |

`enforce: 'pre'` mirrors the Webpack plugin, where the Griffel loader runs first on raw TS/TSX (`oxc-parser` handles TypeScript natively).

`enforce: 'post'` is required because Vite orders user post plugins after both `vite:css-post` and `vite:build-html` — so the CSS assets already exist and are already linked from HTML by the time `generateBundle()` is called. Existing assets are therefore modified in place instead of emitting a new one, which would never receive a `<link>`.

### Parity with `@griffel/webpack-plugin`

- `include` / `exclude`
- `babelOptions`
- `compareMediaQueries` / `compareContainerQueries`
- `collectStats` / `collectPerfIssues`
- Custom resolver factory (`oxc-resolver` based, accepts `{ alias }` instead of a Webpack `Compilation`)
- `url()` asset path rewriting
- Identical style bucket ordering and deduplication logic

CSS parsing, sorting, rule generation, asset path resolution and stats reporting are shared with
`@griffel/webpack-plugin` through `@griffel/css-extraction-utils` (#1064).

`unstable_attachToEntryPoint` has no Vite counterpart — the Vite plugin always attaches CSS to entry points, which is the equivalent behaviour.

### Development mode

Both plugins are `apply: 'build'`. A dev server has no bundling step, so there is no stylesheet to merge the rules
into and no way to preserve the bucket order across separately served CSS modules. Griffel handles styles in runtime
there, exactly as it does without the plugin, so behaviour is unchanged rather than degraded.

Extraction in `serve` (an aggregated virtual CSS module plus hooking the dependencies optimizer to reach pre-bundled
dependencies) was implemented and then dropped from this PR to keep it reviewable. It can be added later without
changing the public API.

### Documentation

`apps/website/docs/react/build-optimization/with-vite.md` is added back (it was removed in #805) and is linked from the section introduction.

## Test plan

16 tests driven by real `vite.build()` runs over 12 on-disk fixtures:

- style buckets, resets, `makeStaticStyles()`, `shorthands`, mixed usage
- `url()` assets, existing CSS imports
- code split chunks merged into the entry stylesheet
- `build.cssCodeSplit: false`
- rule deduplication across modules
- `exclude` option
- HTML entry point: `<link rel="stylesheet">` is preserved & the linked asset contains app CSS + ordered Griffel rules

`lint`, `type-check`, `build`, `prettier`, `syncpack` and the website build all pass.

## Requirements

`@griffel/react` 1.7.7 or above is required: it is the first version carrying the `griffel-css-extraction-disable`
marker from #1063. The plugin excludes nothing by default, so without the marker a production build fails while
transforming `@griffel/react` own sources.

`vite` is declared as a `^8.0.0` peer dependency. The plugin only uses long lived APIs and would likely work on
earlier versions, but 8 is the only one covered by tests.

Both are documented in the README and on the website.
