### PR TITLE
test(e2e): bound each command with its own timeout

### DIFF
--- a/e2e/eslint/src/eslint.test.ts
+++ b/e2e/eslint/src/eslint.test.ts
@@ -13,7 +13,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 
 /** Linting a single fixture file measures well under a second. */
-const ESLINT_TIMEOUT = 60_000;
+const ESLINT_TIMEOUT = 15_000;
 
 describe('@griffel/eslint-plugin with a flat config', () => {
   let tempDir: string;

--- a/e2e/eslint/src/eslint.test.ts
+++ b/e2e/eslint/src/eslint.test.ts
@@ -12,6 +12,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 
+/** Linting a single fixture file measures well under a second. */
+const ESLINT_TIMEOUT = 60_000;
+
 describe('@griffel/eslint-plugin with a flat config', () => {
   let tempDir: string;
 
@@ -39,6 +42,8 @@ describe('@griffel/eslint-plugin with a flat config', () => {
   // `assets/fixture.ts` deliberately breaks the rule, so ESLint has to exit with a non-zero code
   // *and* the reported problem has to be the Griffel one.
   it('reports a "@griffel/hook-naming" violation', async () => {
-    await expect(sh('npx eslint .', tempDir, true)).rejects.toThrow('@griffel/hook-naming');
+    await expect(sh('npx eslint .', tempDir, { pipeOutputToResult: true, timeout: ESLINT_TIMEOUT })).rejects.toThrow(
+      '@griffel/hook-naming',
+    );
   });
 });

--- a/e2e/eslint/vitest.config.mts
+++ b/e2e/eslint/vitest.config.mts
@@ -10,11 +10,13 @@ export default defineConfig({
     environment: 'node',
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
-    // This suite packs tarballs, runs a real `yarn install` and then ESLint in a subprocess.
-    // Measured wall clock is ~11s with a warm Yarn cache; 120s leaves room for a cold CI cache
-    // without letting a genuinely hung install burn the whole job.
+    // Each command these suites run carries its own timeout (see `sh()` in `@griffel/e2e-utils`),
+    // which is what actually bounds them: it kills the process instead of only abandoning the
+    // promise, and reports which command hung. These are the backstop for anything outside a
+    // command, so they sit above the largest of those budgets rather than below it — a 120s hook
+    // was killing installs that were merely slow, not stuck.
     testTimeout: 120_000,
-    hookTimeout: 120_000,
+    hookTimeout: 420_000,
     // Concurrent `yarn install`s contend on the shared Yarn cache. Keep the strictly sequential
     // behaviour the custom runner had.
     fileParallelism: false,

--- a/e2e/rspack/src/rspack.test.ts
+++ b/e2e/rspack/src/rspack.test.ts
@@ -15,8 +15,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 const SNAPSHOTS_DIR = path.resolve(import.meta.dirname, 'snapshots');
 
-/** A build of the example project measures ~1s; anything near a minute is a hung bundler. */
-const RSPACK_BUILD_TIMEOUT = 60_000;
+/** A build of the example project measures ~1.5s on CI; anything near 15s is a hung bundler. */
+const RSPACK_BUILD_TIMEOUT = 15_000;
 
 // `@griffel/transform` (used by the modern plugin) embeds the absolute path of resolved assets
 // into the CSS rule before the class-name hash is computed, so any rule with a `url()` ends up
@@ -150,11 +150,11 @@ describe.each(SCENARIOS)('$name', scenario => {
 
   afterAll(() => removeTempDir(tempDir));
 
-  it('builds the example project with Rspack', async () => {
+  it(`builds "${scenario.name}" with Rspack`, async () => {
     await expect(sh('yarn rspack', tempDir, { timeout: RSPACK_BUILD_TIMEOUT })).resolves.toBeTypeOf('string');
   });
 
-  it('emits CSS matching the snapshot', async () => {
+  it(`emits CSS matching the "${scenario.snapshotFile}" snapshot`, async () => {
     await expect(await readEmittedCSS(tempDir)).toMatchFileSnapshot(path.resolve(SNAPSHOTS_DIR, scenario.snapshotFile));
   });
 });

--- a/e2e/rspack/src/rspack.test.ts
+++ b/e2e/rspack/src/rspack.test.ts
@@ -15,6 +15,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 const SNAPSHOTS_DIR = path.resolve(import.meta.dirname, 'snapshots');
 
+/** A build of the example project measures ~1s; anything near a minute is a hung bundler. */
+const RSPACK_BUILD_TIMEOUT = 60_000;
+
 // `@griffel/transform` (used by the modern plugin) embeds the absolute path of resolved assets
 // into the CSS rule before the class-name hash is computed, so any rule with a `url()` ends up
 // with a class name that depends on the build's absolute temp directory. The `url()` filename
@@ -148,7 +151,7 @@ describe.each(SCENARIOS)('$name', scenario => {
   afterAll(() => removeTempDir(tempDir));
 
   it('builds the example project with Rspack', async () => {
-    await expect(sh('yarn rspack', tempDir)).resolves.toBeTypeOf('string');
+    await expect(sh('yarn rspack', tempDir, { timeout: RSPACK_BUILD_TIMEOUT })).resolves.toBeTypeOf('string');
   });
 
   it('emits CSS matching the snapshot', async () => {

--- a/e2e/rspack/vitest.config.mts
+++ b/e2e/rspack/vitest.config.mts
@@ -10,11 +10,13 @@ export default defineConfig({
     environment: 'node',
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
-    // This suite packs tarballs, runs a real `yarn install` and then a real Rspack build in a
-    // subprocess. Measured wall clock is ~8s per scenario with a warm Yarn cache; 120s leaves room
-    // for a cold CI cache without letting a genuinely hung install burn the whole job.
+    // Each command these suites run carries its own timeout (see `sh()` in `@griffel/e2e-utils`),
+    // which is what actually bounds them: it kills the process instead of only abandoning the
+    // promise, and reports which command hung. These are the backstop for anything outside a
+    // command, so they sit above the largest of those budgets rather than below it — a 120s hook
+    // was killing installs that were merely slow, not stuck.
     testTimeout: 120_000,
-    hookTimeout: 120_000,
+    hookTimeout: 420_000,
     // Concurrent `yarn install`s contend on the shared Yarn cache and concurrent bundler builds are
     // memory hungry. Keep the strictly sequential behaviour the custom runner had.
     fileParallelism: false,

--- a/e2e/stylelint/src/stylelint.test.ts
+++ b/e2e/stylelint/src/stylelint.test.ts
@@ -14,7 +14,7 @@ const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 const RULE = 'selector-anb-no-unmatchable';
 
 /** Linting a single fixture file measures well under a second. */
-const STYLELINT_TIMEOUT = 60_000;
+const STYLELINT_TIMEOUT = 15_000;
 
 describe('stylelint with @griffel/postcss-syntax', () => {
   let tempDir: string;

--- a/e2e/stylelint/src/stylelint.test.ts
+++ b/e2e/stylelint/src/stylelint.test.ts
@@ -13,6 +13,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 const RULE = 'selector-anb-no-unmatchable';
 
+/** Linting a single fixture file measures well under a second. */
+const STYLELINT_TIMEOUT = 60_000;
+
 describe('stylelint with @griffel/postcss-syntax', () => {
   let tempDir: string;
 
@@ -22,7 +25,10 @@ describe('stylelint with @griffel/postcss-syntax', () => {
    */
   async function lint(file: string): Promise<{ passed: boolean; output: string }> {
     try {
-      return { passed: true, output: await sh(`npx stylelint ${file}`, tempDir, true) };
+      return {
+        passed: true,
+        output: await sh(`npx stylelint ${file}`, tempDir, { pipeOutputToResult: true, timeout: STYLELINT_TIMEOUT }),
+      };
     } catch (e) {
       return { passed: false, output: (e as Error).message };
     }

--- a/e2e/stylelint/vitest.config.mts
+++ b/e2e/stylelint/vitest.config.mts
@@ -10,11 +10,13 @@ export default defineConfig({
     environment: 'node',
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
-    // This suite packs tarballs, runs a real `yarn install` and then Stylelint in a subprocess.
-    // Measured wall clock is ~13s with a warm Yarn cache; 120s leaves room for a cold CI cache
-    // without letting a genuinely hung install burn the whole job.
+    // Each command these suites run carries its own timeout (see `sh()` in `@griffel/e2e-utils`),
+    // which is what actually bounds them: it kills the process instead of only abandoning the
+    // promise, and reports which command hung. These are the backstop for anything outside a
+    // command, so they sit above the largest of those budgets rather than below it — a 120s hook
+    // was killing installs that were merely slow, not stuck.
     testTimeout: 120_000,
-    hookTimeout: 120_000,
+    hookTimeout: 420_000,
     // Concurrent `yarn install`s contend on the shared Yarn cache. Keep the strictly sequential
     // behaviour the custom runner had.
     fileParallelism: false,

--- a/e2e/typescript/src/typescript.test.ts
+++ b/e2e/typescript/src/typescript.test.ts
@@ -12,8 +12,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 
-/** Type-checking a single fixture file measures a few seconds, even on the oldest compiler. */
-const TSC_TIMEOUT = 60_000;
+/** Type-checking a single fixture file measures well under a second, even on the oldest compiler. */
+const TSC_TIMEOUT = 15_000;
 
 // The oldest TypeScript versions `@griffel/style-types` is expected to keep working with.
 const TYPESCRIPT_VERSIONS = ['4.4', '4.9', '5.0'];
@@ -47,7 +47,7 @@ describe.each(TYPESCRIPT_VERSIONS)('typescript@%s', version => {
 
   afterAll(() => removeTempDir(tempDir));
 
-  it('installs the requested TypeScript version', async () => {
+  it(`installs typescript@${version}`, async () => {
     const reported = (await sh(`node ${tscBin} --version`, tempDir, { pipeOutputToResult: true, timeout: TSC_TIMEOUT }))
       .replace('Version', '')
       .trim();
@@ -55,7 +55,7 @@ describe.each(TYPESCRIPT_VERSIONS)('typescript@%s', version => {
     expect(reported).toMatch(new RegExp(`^${version.replace('.', '\\.')}\\.`));
   });
 
-  it('type-checks a project referencing @griffel/style-types', async () => {
+  it(`type-checks a project referencing @griffel/style-types with typescript@${version}`, async () => {
     try {
       await sh(`node ${tscBin} --noEmit --pretty`, tempDir, { pipeOutputToResult: true, timeout: TSC_TIMEOUT });
     } catch (e) {

--- a/e2e/typescript/src/typescript.test.ts
+++ b/e2e/typescript/src/typescript.test.ts
@@ -12,6 +12,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
 
+/** Type-checking a single fixture file measures a few seconds, even on the oldest compiler. */
+const TSC_TIMEOUT = 60_000;
+
 // The oldest TypeScript versions `@griffel/style-types` is expected to keep working with.
 const TYPESCRIPT_VERSIONS = ['4.4', '4.9', '5.0'];
 
@@ -45,14 +48,16 @@ describe.each(TYPESCRIPT_VERSIONS)('typescript@%s', version => {
   afterAll(() => removeTempDir(tempDir));
 
   it('installs the requested TypeScript version', async () => {
-    const reported = (await sh(`node ${tscBin} --version`, tempDir, true)).replace('Version', '').trim();
+    const reported = (await sh(`node ${tscBin} --version`, tempDir, { pipeOutputToResult: true, timeout: TSC_TIMEOUT }))
+      .replace('Version', '')
+      .trim();
 
     expect(reported).toMatch(new RegExp(`^${version.replace('.', '\\.')}\\.`));
   });
 
   it('type-checks a project referencing @griffel/style-types', async () => {
     try {
-      await sh(`node ${tscBin} --noEmit --pretty`, tempDir, true);
+      await sh(`node ${tscBin} --noEmit --pretty`, tempDir, { pipeOutputToResult: true, timeout: TSC_TIMEOUT });
     } catch (e) {
       throw new Error(
         `Building a test project referencing @griffel/style-types using typescript@${version} failed.\n` +

--- a/e2e/typescript/vitest.config.mts
+++ b/e2e/typescript/vitest.config.mts
@@ -10,11 +10,13 @@ export default defineConfig({
     environment: 'node',
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
-    // This suite packs tarballs, runs a real `yarn install` and then `tsc` in a subprocess, once per
-    // supported TypeScript version. Measured wall clock is ~9s with a warm Yarn cache; 120s leaves
-    // room for a cold CI cache without letting a genuinely hung install burn the whole job.
+    // Each command these suites run carries its own timeout (see `sh()` in `@griffel/e2e-utils`),
+    // which is what actually bounds them: it kills the process instead of only abandoning the
+    // promise, and reports which command hung. These are the backstop for anything outside a
+    // command, so they sit above the largest of those budgets rather than below it — a 120s hook
+    // was killing installs that were merely slow, not stuck.
     testTimeout: 120_000,
-    hookTimeout: 120_000,
+    hookTimeout: 420_000,
     // Concurrent `yarn install`s contend on the shared Yarn cache. Keep the strictly sequential
     // behaviour the custom runner had.
     fileParallelism: false,

--- a/e2e/utils/src/configureYarn.ts
+++ b/e2e/utils/src/configureYarn.ts
@@ -3,16 +3,31 @@ import path from 'path';
 
 import { sh } from './sh.ts';
 
+/**
+ * Reading a config value and scaffolding an empty project are local, offline operations — measured
+ * well under a second, as `yarn init -p` has nothing to resolve, fetch or link.
+ */
+const YARN_CONFIG_TIMEOUT = 30_000;
+
 export async function configureYarn(options: { tempDir: string; rootDir: string }) {
   const { tempDir, rootDir } = options;
-  const yarnPath = await sh('yarn config get yarnPath', rootDir, true);
+  // `yarn config get` resolves `yarnPath` to an absolute path, which is what makes the release
+  // usable from a temporary directory outside the repository. It is still `stdout`, so it arrives
+  // with a trailing line break.
+  const yarnPath = (
+    await sh('yarn config get yarnPath', rootDir, { pipeOutputToResult: true, timeout: YARN_CONFIG_TIMEOUT })
+  ).trim();
 
   await fs.promises.writeFile(
     path.resolve(tempDir, '.yarnrc.yml'),
     ['enableImmutableInstalls: false', 'nodeLinker: node-modules', `yarnPath: ${yarnPath}`].join('\n'),
   );
-  await sh('yarn init -p', tempDir, true);
+  await sh('yarn init -p', tempDir, { pipeOutputToResult: true, timeout: YARN_CONFIG_TIMEOUT });
 
   console.log('✅', 'A config for Yarn was created');
-  console.log('ℹ️', 'Using Yarn', (await sh('yarn --version', tempDir, true)).trim());
+  console.log(
+    'ℹ️',
+    'Using Yarn',
+    (await sh('yarn --version', tempDir, { pipeOutputToResult: true, timeout: YARN_CONFIG_TIMEOUT })).trim(),
+  );
 }

--- a/e2e/utils/src/configureYarn.ts
+++ b/e2e/utils/src/configureYarn.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { sh } from './sh.ts';
+import { step } from './step.ts';
 
 /**
  * Reading a config value and scaffolding an empty project are local, offline operations — measured
@@ -18,13 +19,13 @@ export async function configureYarn(options: { tempDir: string; rootDir: string 
     await sh('yarn config get yarnPath', rootDir, { pipeOutputToResult: true, timeout: YARN_CONFIG_TIMEOUT })
   ).trim();
 
-  await fs.promises.writeFile(
-    path.resolve(tempDir, '.yarnrc.yml'),
-    ['enableImmutableInstalls: false', 'nodeLinker: node-modules', `yarnPath: ${yarnPath}`].join('\n'),
-  );
-  await sh('yarn init -p', tempDir, { pipeOutputToResult: true, timeout: YARN_CONFIG_TIMEOUT });
-
-  console.log('✅', 'A config for Yarn was created');
+  await step('A config for Yarn was created', async () => {
+    await fs.promises.writeFile(
+      path.resolve(tempDir, '.yarnrc.yml'),
+      ['enableImmutableInstalls: false', 'nodeLinker: node-modules', `yarnPath: ${yarnPath}`].join('\n'),
+    );
+    await sh('yarn init -p', tempDir, { pipeOutputToResult: true, timeout: YARN_CONFIG_TIMEOUT });
+  });
   console.log(
     'ℹ️',
     'Using Yarn',

--- a/e2e/utils/src/copyAssets.ts
+++ b/e2e/utils/src/copyAssets.ts
@@ -1,18 +1,20 @@
 import fs from 'fs';
 import path from 'path';
 
+import { step } from './step.ts';
+
 export async function copyAssets(options: { assetsPath: string; tempDir: string; renames?: Record<string, string> }) {
   const { assetsPath, tempDir, renames } = options;
 
-  await fs.promises.cp(assetsPath, tempDir, { recursive: true });
+  await step('Assets were copied', async () => {
+    await fs.promises.cp(assetsPath, tempDir, { recursive: true });
 
-  if (renames) {
-    await Promise.all(
-      Object.entries(renames).map(([source, target]) =>
-        fs.promises.rename(path.resolve(tempDir, source), path.resolve(tempDir, target)),
-      ),
-    );
-  }
-
-  console.log('✅', 'Assets were copied');
+    if (renames) {
+      await Promise.all(
+        Object.entries(renames).map(([source, target]) =>
+          fs.promises.rename(path.resolve(tempDir, source), path.resolve(tempDir, target)),
+        ),
+      );
+    }
+  });
 }

--- a/e2e/utils/src/createTempDir.ts
+++ b/e2e/utils/src/createTempDir.ts
@@ -2,11 +2,14 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { logStep } from './step.ts';
+
 export function createTempDir(prefix: string) {
+  const startedAt = Date.now();
   // `mkdtempSync` appends 6 random characters to the provided prefix path
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
 
-  console.log('✅', `Temporary directory created under ${tempDir}`);
+  logStep(`Temporary directory created under ${tempDir}`, startedAt);
 
   return tempDir;
 }

--- a/e2e/utils/src/index.ts
+++ b/e2e/utils/src/index.ts
@@ -4,3 +4,4 @@ export { createTempDir, removeTempDir } from './createTempDir.ts';
 export { packLocalPackage } from './packLocalPackage.ts';
 export { installPackages } from './installPackages.ts';
 export { sh } from './sh.ts';
+export { logStep, step } from './step.ts';

--- a/e2e/utils/src/installPackages.ts
+++ b/e2e/utils/src/installPackages.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { sh } from './sh.ts';
+import { step } from './step.ts';
 
 /**
  * Registry metadata for a handful of packages, resolved against the repository's own lockfile.
@@ -82,7 +83,7 @@ export async function installPackages(options: {
   };
 
   await fs.promises.writeFile(packageJsonPath, JSON.stringify(newPackageJson, null, 2));
-  await sh('yarn install', tempDir, { pipeOutputToResult: true, timeout: YARN_INSTALL_TIMEOUT });
-
-  console.log('✅', 'Packages were installed');
+  await step('Packages were installed', () =>
+    sh('yarn install', tempDir, { pipeOutputToResult: true, timeout: YARN_INSTALL_TIMEOUT }),
+  );
 }

--- a/e2e/utils/src/installPackages.ts
+++ b/e2e/utils/src/installPackages.ts
@@ -3,6 +3,24 @@ import path from 'path';
 
 import { sh } from './sh.ts';
 
+/**
+ * Registry metadata for a handful of packages, resolved against the repository's own lockfile.
+ */
+const YARN_INFO_TIMEOUT = 60_000;
+
+/**
+ * The only genuinely slow command in a scenario's setup: a full resolution and download of React,
+ * a bundler and the Babel toolchain with no lockfile to short-circuit it.
+ *
+ * It takes seconds with a warm Yarn cache, but CI runs several of these suites concurrently
+ * (`NX_PARALLEL`) against a cache that starts empty, and installs then contend for the runner's
+ * network, disk and CPU — a scenario measured at ~4s locally has taken over 120s there. The budget
+ * is deliberately far above the worst observed run: it is here to catch an install that is *stuck*,
+ * not one that is merely slow, because being killed early is what turned a slow install into a
+ * failed suite.
+ */
+const YARN_INSTALL_TIMEOUT = 300_000;
+
 export async function installPackages(options: {
   packages: (string | [name: string, version: string])[];
   resolutions: { file?: string; version?: string; packageName: string }[];
@@ -33,7 +51,10 @@ export async function installPackages(options: {
   }
 
   if (workspacePackages.length > 0) {
-    const yarnOutput = await sh(`yarn info ${workspacePackages.join(' ')} --json`, rootDir, true);
+    const yarnOutput = await sh(`yarn info ${workspacePackages.join(' ')} --json`, rootDir, {
+      pipeOutputToResult: true,
+      timeout: YARN_INFO_TIMEOUT,
+    });
     const parsedYarnOutput = yarnOutput
       .split('\n')
       .filter(Boolean)
@@ -61,7 +82,7 @@ export async function installPackages(options: {
   };
 
   await fs.promises.writeFile(packageJsonPath, JSON.stringify(newPackageJson, null, 2));
-  await sh('yarn install', tempDir, true);
+  await sh('yarn install', tempDir, { pipeOutputToResult: true, timeout: YARN_INSTALL_TIMEOUT });
 
   console.log('✅', 'Packages were installed');
 }

--- a/e2e/utils/src/packLocalPackage.ts
+++ b/e2e/utils/src/packLocalPackage.ts
@@ -2,9 +2,10 @@ import path from 'path';
 import fs from 'fs';
 
 import { sh } from './sh.ts';
+import { step } from './step.ts';
 
 /** Repacking an already built package is local work over a directory that is a few megabytes. */
-const NPM_PACK_TIMEOUT = 60_000;
+const NPM_PACK_TIMEOUT = 10_000;
 
 export async function packLocalPackage(rootDir: string, tempDir: string, packageName: string) {
   const packagePath = path.resolve(rootDir, 'dist', 'packages', packageName.split('/')[1]);
@@ -17,13 +18,14 @@ export async function packLocalPackage(rootDir: string, tempDir: string, package
   // Use `npm pack` because `yarn pack` incorrectly calculates the included files when the
   // files to include/exclude are specified by .npmignore rather than package.json `files`.
   // (--quiet outputs only the .tgz filename, not all the included files)
-  const packFile = (
-    await sh(`npm pack --quiet ${packagePath}`, tempDir, {
-      pipeOutputToResult: true,
-      timeout: NPM_PACK_TIMEOUT,
-    })
-  ).trim();
-  console.log('✅', `Package "${packageName}" was packed`);
+  const packFile = await step(`Package "${packageName}" was packed`, async () =>
+    (
+      await sh(`npm pack --quiet ${packagePath}`, tempDir, {
+        pipeOutputToResult: true,
+        timeout: NPM_PACK_TIMEOUT,
+      })
+    ).trim(),
+  );
 
   return {
     packageName,

--- a/e2e/utils/src/packLocalPackage.ts
+++ b/e2e/utils/src/packLocalPackage.ts
@@ -3,6 +3,9 @@ import fs from 'fs';
 
 import { sh } from './sh.ts';
 
+/** Repacking an already built package is local work over a directory that is a few megabytes. */
+const NPM_PACK_TIMEOUT = 60_000;
+
 export async function packLocalPackage(rootDir: string, tempDir: string, packageName: string) {
   const packagePath = path.resolve(rootDir, 'dist', 'packages', packageName.split('/')[1]);
   const packagePathExists = !!(await fs.promises.stat(packagePath).catch(() => false));
@@ -14,7 +17,12 @@ export async function packLocalPackage(rootDir: string, tempDir: string, package
   // Use `npm pack` because `yarn pack` incorrectly calculates the included files when the
   // files to include/exclude are specified by .npmignore rather than package.json `files`.
   // (--quiet outputs only the .tgz filename, not all the included files)
-  const packFile = (await sh(`npm pack --quiet ${packagePath}`, tempDir, true)).trim();
+  const packFile = (
+    await sh(`npm pack --quiet ${packagePath}`, tempDir, {
+      pipeOutputToResult: true,
+      timeout: NPM_PACK_TIMEOUT,
+    })
+  ).trim();
   console.log('✅', `Package "${packageName}" was packed`);
 
   return {

--- a/e2e/utils/src/sh.test.ts
+++ b/e2e/utils/src/sh.test.ts
@@ -1,0 +1,110 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { sh } from './sh.ts';
+
+// `sh()` splits a command on spaces and runs the result through a shell, so probes live in a script
+// file rather than inlined — quoting anything beyond a flag is not something it supports.
+let scriptDir: string;
+let longRunningScript: string;
+
+beforeAll(() => {
+  scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sh-test-'));
+  longRunningScript = path.join(scriptDir, 'long-running.cjs');
+
+  // Records its own PID so a test can assert on the process itself, then stays alive long enough
+  // that only a timeout can end it.
+  fs.writeFileSync(
+    longRunningScript,
+    [
+      'const [, , pidFile] = process.argv;',
+      'require("fs").writeFileSync(pidFile, String(process.pid));',
+      'setTimeout(() => {}, 120000);',
+    ].join('\n'),
+  );
+});
+
+afterAll(() => fs.rmSync(scriptDir, { recursive: true, force: true }));
+
+/**
+ * Resolves once the process is gone, rejects if it is still alive after `timeout`.
+ *
+ * `process.kill(pid, 0)` runs the existence check without sending a signal, which is the only way
+ * to observe a process this test deliberately does not own.
+ */
+async function waitForExit(pid: number, timeout = 10_000): Promise<void> {
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  throw new Error(`Process ${pid} was still running ${timeout}ms after its command timed out`);
+}
+
+describe('sh', () => {
+  it('resolves with stdout when a command succeeds', async () => {
+    await expect(sh('echo hello', undefined, { pipeOutputToResult: true })).resolves.toContain('hello');
+  });
+
+  it('rejects with the captured output when a command fails', async () => {
+    const error: Error = await sh('node --eval-oops', undefined, { pipeOutputToResult: true }).catch(e => e);
+
+    expect(error.message).toContain('child process exited with code');
+    // stderr has to survive into the message — it is the only diagnostic a failing command leaves.
+    expect(error.message).toContain('eval-oops');
+  });
+
+  it('rejects when a command cannot be spawned', async () => {
+    await expect(sh('echo nope', path.join(scriptDir, 'does-not-exist'))).rejects.toThrow();
+  });
+
+  it('names the command and the limit it exceeded when a timeout is reached', async () => {
+    const pidFile = path.join(scriptDir, 'named.pid');
+    const error: Error = await sh(`node ${longRunningScript} ${pidFile}`, undefined, {
+      pipeOutputToResult: true,
+      timeout: 1_000,
+    }).catch(e => e);
+
+    expect(error.message).toContain('timed out');
+    expect(error.message).toContain('limit: 1000ms');
+    expect(error.message).toContain(longRunningScript);
+  });
+
+  it('kills the process behind a timed out command, not just the shell it spawned', async () => {
+    // Vitest's `hookTimeout` abandons the promise while leaving the process running, which is what
+    // let an overrunning `yarn install` keep competing with the scenarios that followed it. And as
+    // `shell: true` makes the direct child a shell, signalling that child alone would leave the
+    // command doing the actual work behind.
+    const pidFile = path.join(scriptDir, 'killed.pid');
+
+    await expect(
+      sh(`node ${longRunningScript} ${pidFile}`, undefined, { pipeOutputToResult: true, timeout: 2_000 }),
+    ).rejects.toThrow('timed out');
+
+    const commandPid = Number(fs.readFileSync(pidFile, 'utf8'));
+
+    expect(Number.isInteger(commandPid)).toBe(true);
+    expect(commandPid).not.toBe(process.pid);
+
+    await expect(waitForExit(commandPid)).resolves.toBeUndefined();
+  });
+
+  it('does not leave a pending timer behind when a command finishes early', async () => {
+    // A leaked `setTimeout` would hold the worker's event loop open for the whole budget.
+    const timers = () => process.getActiveResourcesInfo().filter(resource => resource === 'Timeout').length;
+    const before = timers();
+
+    await sh('echo done', undefined, { pipeOutputToResult: true, timeout: 300_000 });
+
+    expect(timers()).toBe(before);
+  });
+});

--- a/e2e/utils/src/sh.ts
+++ b/e2e/utils/src/sh.ts
@@ -1,27 +1,97 @@
 import childProcess from 'child_process';
 
 /**
+ * Upper bound for a single command.
+ *
+ * Everything these suites run is a package manager, bundler or linter invocation that finishes in
+ * seconds locally, so anything still going after two minutes is stuck rather than slow. Commands
+ * that are legitimately slower pass a larger budget explicitly.
+ */
+export const DEFAULT_COMMAND_TIMEOUT = 120_000;
+
+/** Grace period between asking a timed out command to stop and killing it outright. */
+const SIGKILL_GRACE_PERIOD = 5_000;
+
+export type ShOptions = {
+  /**
+   * Output is always captured and returned. By default it is *also* echoed to the parent's streams
+   * so long-running commands stay observable; set this to keep it out of them.
+   */
+  pipeOutputToResult?: boolean;
+  /** Milliseconds to wait before terminating the command and rejecting. */
+  timeout?: number;
+};
+
+/**
+ * `shell: true` spawns a shell that in turn spawns the real command, so signalling the child alone
+ * would leave the actual work running. `detached: true` puts that shell in its own process group,
+ * which a negative PID then signals as a whole.
+ */
+function killProcessTree(child: childProcess.ChildProcess, signal: NodeJS.Signals): void {
+  if (typeof child.pid !== 'number') {
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      childProcess.execSync(`taskkill /pid ${child.pid} /T /F`, { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch {
+    // The process group exited between the timeout firing and the signal being delivered.
+  }
+}
+
+/**
  * Spawns a command and resolves with its `stdout` once it exits successfully.
  *
  * Output is always captured so that a failure can carry the child's diagnostics in the rejected
  * error — a test runner can only report what it is given. When `pipeOutputToResult` is `false` the
  * captured output is additionally echoed to the parent's streams so long-running commands stay
  * observable while they run.
+ *
+ * Every command is bounded by its own timeout. Vitest's `testTimeout`/`hookTimeout` cannot serve
+ * that purpose: they abandon the *promise* without touching the process behind it, so a slow
+ * install keeps downloading and competing for the runner's CPU, network and Yarn cache with the
+ * scenarios that follow — while `afterAll` deletes the directory it is still writing into. Timing
+ * out here kills the process group instead, and names the command that hung, which a bare
+ * "Hook timed out in 120000ms" never does.
  */
-export function sh(command: string, cwd?: string, pipeOutputToResult = false): Promise<string> {
+export function sh(command: string, cwd?: string, options: ShOptions = {}): Promise<string> {
+  const { pipeOutputToResult = false, timeout = DEFAULT_COMMAND_TIMEOUT } = options;
+
   return new Promise((resolve, reject) => {
     const [cmd, ...args] = command.split(' ');
-    const options: childProcess.SpawnOptions = {
+    const spawnOptions: childProcess.SpawnOptions = {
       cwd: cwd || process.cwd(),
       env: process.env,
       stdio: ['inherit', 'pipe', 'pipe'],
       shell: true,
+      detached: process.platform !== 'win32',
     };
 
-    const child = childProcess.spawn(cmd, args, options);
+    const child = childProcess.spawn(cmd, args, spawnOptions);
+    const startedAt = Date.now();
 
     let stdoutData = '';
     let stderrData = '';
+    let timedOut = false;
+    let sigkillTimer: NodeJS.Timeout | undefined;
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+
+      // `SIGTERM` first so a package manager can unwind — a half-written cache entry would poison
+      // every later run — then `SIGKILL`, which cannot be ignored, so `close` always fires.
+      killProcessTree(child, 'SIGTERM');
+      sigkillTimer = setTimeout(() => killProcessTree(child, 'SIGKILL'), SIGKILL_GRACE_PERIOD);
+    }, timeout);
+
+    function clearTimers() {
+      clearTimeout(timeoutTimer);
+      clearTimeout(sigkillTimer);
+    }
 
     child.stdout?.on('data', data => {
       stdoutData += data;
@@ -40,9 +110,30 @@ export function sh(command: string, cwd?: string, pipeOutputToResult = false): P
     });
 
     // Without this a failure to spawn (`ENOENT`, permissions, ...) never settles the promise.
-    child.on('error', reject);
+    child.on('error', error => {
+      clearTimers();
+      reject(error);
+    });
 
     child.on('close', code => {
+      clearTimers();
+
+      if (timedOut) {
+        reject(
+          new Error(
+            [
+              `child process timed out after ${Date.now() - startedAt}ms (limit: ${timeout}ms): ${command}`,
+              `  in "${spawnOptions.cwd}"`,
+              stdoutData,
+              stderrData,
+            ]
+              .filter(Boolean)
+              .join('\n'),
+          ),
+        );
+        return;
+      }
+
       if (code === 0) {
         resolve(stdoutData);
         return;

--- a/e2e/utils/src/step.ts
+++ b/e2e/utils/src/step.ts
@@ -1,0 +1,33 @@
+/**
+ * Formats a duration the way the step log wants to read: exact while a step is still cheap, coarse
+ * once it is the kind of number worth looking at.
+ */
+function formatDuration(ms: number): string {
+  return ms < 1_000 ? `${ms}ms` : `${(ms / 1_000).toFixed(1)}s`;
+}
+
+/**
+ * Reports a completed step of a scenario's setup, with how long it took.
+ *
+ * Setting these suites up is almost entirely waiting — packing tarballs, resolving and downloading
+ * a dependency tree, linking it — and how that time is distributed is the first thing worth knowing
+ * when one of them is slow enough to hit a timeout. The durations live here rather than at each
+ * call site so every step reports them the same way and none of them can quietly stop.
+ */
+export function logStep(message: string, startedAt: number): void {
+  console.log('✅', message, `(${formatDuration(Date.now() - startedAt)})`);
+}
+
+/**
+ * Runs a step and reports it once it settles.
+ *
+ * The message may be built from the step's own result, so a step can name what it produced.
+ */
+export async function step<T>(message: string | ((result: T) => string), work: () => T | Promise<T>): Promise<T> {
+  const startedAt = Date.now();
+  const result = await work();
+
+  logStep(typeof message === 'function' ? message(result) : message, startedAt);
+
+  return result;
+}


### PR DESCRIPTION
## Motivation

`@griffel/e2e-rspack` has started failing intermittently since #1053, always the same way — [run 30443601499](https://github.com/microsoft/griffel/actions/runs/30443601499/job/90548449724):

```
FAIL  src/rspack.test.ts > 'legacy-rspack-1'
Error: Hook timed out in 120000ms.
 ❯ src/rspack.test.ts:121:3
    121|   beforeAll(async () => {

 Test Files  1 failed (1)
      Tests  6 passed | 2 skipped (8)
   Duration  331.63s
```

The interesting part is what the same log says a few lines earlier: `legacy-rspack-1` printed
`✅ Packages were installed` and `Rspack compiled successfully in 961 ms`. Nothing was stuck — the
install simply took longer than the 120s hook budget, and Vitest gave up on a suite that was about
to pass.

That budget is not being spent on the same work locally. The full suite is 23s here with a warm Yarn
cache, ~4s per scenario; the failing run averaged 83s. CI sets `NX_PARALLEL: 4`, so up to four of
these suites — each running a real `yarn install` — plus the Chromium browser tests share one
runner, and the temporary directories install against the *global* Yarn cache, which starts empty
(the repository pins `enableGlobalCache: false`, so the cache `actions/setup-node` restores is
`.yarn/cache` and is not the one they use). A fixed 120s is not a safe bound for that.

Raising it alone would not be enough, because a hook timeout does not stop anything:

- **Vitest abandons the promise, not the process.** The `yarn install` behind the timed-out hook
  kept running — which is exactly why its success messages appear in the log *after* it was declared
  failed. It then goes on competing for the runner's network, disk and Yarn cache with the three
  scenarios that follow, so one slow scenario makes the rest slower. Meanwhile `afterAll` calls
  `removeTempDir()` on the directory it is still writing into.
- **The failure names nothing.** `Hook timed out in 120000ms` at `beforeAll` covers copying assets,
  configuring Yarn, six `npm pack`s, a `yarn info` and the install. The one number the report gives
  is the one that was already known.

## Changes

`sh()` takes an options object and bounds every command itself:

- **A timeout per command**, defaulting to 120s, overridden where a command is legitimately slower.
  `yarn install` gets 300s — ~3.6× the worst per-scenario average observed on CI. The point is to
  catch an install that is *stuck*, not one that is slow, since killing slow installs is the bug.
- **Timing out kills the process group.** `shell: true` means the direct child is a shell, so
  signalling it can leave the real command behind; the child is now spawned `detached` and the whole
  group gets `SIGTERM`, then `SIGKILL` after 5s. `SIGTERM` goes first so a package manager can
  unwind — a half-written cache entry would poison every later run.
- **The rejection names the command**, its cwd, the elapsed time and the limit, and carries the
  output captured so far.

Against a real install, forced to overrun:

```
child process timed out after 409ms (limit: 400ms): yarn install
  in "/var/folders/…/T/timeout-proof-lwDkai"
➤ YN0000: · Yarn 4.15.0
>>> surviving `yarn install` processes: 0
```

`testTimeout` / `hookTimeout` stay as a backstop for anything *outside* a command, which is why
`hookTimeout` moves to 420s — above the largest command budget rather than below it. All four suites
are updated together; they share these helpers and the same exposure.

## Verification

- New `e2e/utils/src/sh.test.ts` (6 tests) — the package had `passWithNoTests` and no tests until
  now. It covers success, failure output, spawn failure, the timeout message, and that the process
  behind a timed-out command is gone afterwards.
- The two timeout tests were mutation-tested: with `detached` reverted to `false` both fail, the
  probe outliving its timeout. They are not passing vacuously.
- `test`, `lint` and `type-check` green for all five e2e projects (24 tests), and the suites still
  pass when run from a real TTY — a detached process group inheriting a terminal's stdin was the one
  regression risk worth ruling out.
- Also checked `configureYarn()` while here, since it feeds every scenario: it works — `yarn config
  get yarnPath` returns an absolute path, so the release resolves from a temp dir outside the repo,
  and `yarn init -p` is offline and takes 0.37s. Its `yarnPath` was untrimmed and only happened to
  produce valid YAML by being the last line written; it is trimmed now.
- `yarn beachball check` → *"No change files are needed"* (every touched project is private).

## Note

This does not touch `NX_PARALLEL`, so the contention that makes these installs slow is still there —
it is now survivable rather than fatal. If the suites keep drifting slower, the follow-up is
`"parallelism": false` on the four e2e `test` targets (supported by Nx 23), which stops them running
against each other and the browser tests. I left it out as it changes CI scheduling for every job.
