### PR TITLE
fix: allow to opt a file out of CSS extraction

### DIFF
--- a/change/@griffel-react-css-extraction-disable.json
+++ b/change/@griffel-react-css-extraction-disable.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: opt style function wrappers out of CSS extraction to avoid a build time error",
+  "packageName": "@griffel/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-transform-css-extraction-disable.json
+++ b/change/@griffel-transform-css-extraction-disable.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: do not fail on files that cannot be processed and are marked to be skipped",
+  "packageName": "@griffel/transform",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/makeResetStyles.ts
+++ b/packages/react/src/makeResetStyles.ts
@@ -1,5 +1,8 @@
 'use client';
 
+// griffel-css-extraction-disable
+// These wrappers forward user styles to @griffel/core, there is nothing to extract ahead of time
+
 import { makeResetStyles as vanillaMakeResetStyles } from '@griffel/core';
 import type { GriffelResetStyle } from '@griffel/core';
 

--- a/packages/react/src/makeStaticStyles.ts
+++ b/packages/react/src/makeStaticStyles.ts
@@ -1,5 +1,8 @@
 'use client';
 
+// griffel-css-extraction-disable
+// These wrappers forward user styles to @griffel/core, there is nothing to extract ahead of time
+
 import { makeStaticStyles as vanillaMakeStaticStyles } from '@griffel/core';
 import type { GriffelStaticStyles, MakeStaticStylesOptions } from '@griffel/core';
 

--- a/packages/react/src/makeStyles.ts
+++ b/packages/react/src/makeStyles.ts
@@ -1,5 +1,8 @@
 'use client';
 
+// griffel-css-extraction-disable
+// These wrappers forward user styles to @griffel/core, there is nothing to extract ahead of time
+
 import { makeStyles as vanillaMakeStyles } from '@griffel/core';
 import type { GriffelStyle } from '@griffel/core';
 

--- a/packages/transform/__fixtures__/css-extraction-disabled/code.ts
+++ b/packages/transform/__fixtures__/css-extraction-disabled/code.ts
@@ -1,0 +1,14 @@
+'use client';
+
+// griffel-css-extraction-disable
+
+import { makeStyles as vanillaMakeStyles, type GriffelInsertionFactory, type GriffelStyle } from '@griffel/core';
+
+// A wrapper cannot be extracted ahead of time: the styles are only known at runtime. Without the
+// marker on top of the file this throws instead of being left as is.
+export function makeStyles<Slots extends string>(
+  stylesBySlots: Record<Slots, GriffelStyle>,
+  insertionFactory: GriffelInsertionFactory,
+) {
+  return vanillaMakeStyles(stylesBySlots, insertionFactory);
+}

--- a/packages/transform/__fixtures__/css-extraction-disabled/output.meta.json
+++ b/packages/transform/__fixtures__/css-extraction-disabled/output.meta.json
@@ -1,0 +1,4 @@
+{
+  "usedProcessing": false,
+  "usedVMForEvaluation": false
+}

--- a/packages/transform/__fixtures__/css-extraction-disabled/output.ts
+++ b/packages/transform/__fixtures__/css-extraction-disabled/output.ts
@@ -1,0 +1,14 @@
+'use client';
+
+// griffel-css-extraction-disable
+
+import { makeStyles as vanillaMakeStyles, type GriffelInsertionFactory, type GriffelStyle } from '@griffel/core';
+
+// A wrapper cannot be extracted ahead of time: the styles are only known at runtime. Without the
+// marker on top of the file this throws instead of being left as is.
+export function makeStyles<Slots extends string>(
+  stylesBySlots: Record<Slots, GriffelStyle>,
+  insertionFactory: GriffelInsertionFactory,
+) {
+  return vanillaMakeStyles(stylesBySlots, insertionFactory);
+}

--- a/packages/transform/src/constants.mts
+++ b/packages/transform/src/constants.mts
@@ -1,2 +1,8 @@
 export const ASSET_TAG_OPEN = '<griffel-asset>';
 export const ASSET_TAG_CLOSE = '</griffel-asset>';
+
+/**
+ * A file level marker that opts a module out of the build time CSS extraction, it has to be placed
+ * in a comment on top of a file.
+ */
+export const CSS_EXTRACTION_DISABLE_COMMENT = 'griffel-css-extraction-disable';

--- a/packages/transform/src/transformSync.mts
+++ b/packages/transform/src/transformSync.mts
@@ -1,4 +1,4 @@
-import { parseSync, type Node } from 'oxc-parser';
+import { parseSync, type Node, type ParseResult } from 'oxc-parser';
 import { walk, ScopeTracker, type ScopeTrackerImport } from 'oxc-walker';
 import MagicString from 'magic-string';
 import shakerEvaluator from '@griffel/transform-shaker';
@@ -18,6 +18,7 @@ import {
 import { batchEvaluator } from './evaluation/batchEvaluator.mjs';
 import { fluentTokensPlugin } from './evaluation/fluentTokensPlugin.mjs';
 import type { AstEvaluatorPlugin } from './evaluation/types.mjs';
+import { CSS_EXTRACTION_DISABLE_COMMENT } from './constants.mjs';
 import { dedupeCSSRules } from './utils/dedupeCSSRules.mjs';
 import { generateTransformMetadata, type ProcessedStyleCall } from './generateTransformMetadata.mjs';
 import type { StyleCall, TransformMetadata } from './types.mjs';
@@ -88,6 +89,14 @@ const RUNTIME_IDENTIFIERS = new Map<FunctionKinds, string>([
   ['makeStaticStyles', '__staticCSS'],
 ]);
 
+/**
+ * The marker is only recognized as the first comment of a file to keep it predictable: a mention
+ * of it anywhere else (including in a string) does not silently disable the extraction.
+ */
+function hasCSSExtractionDisableComment(parseResult: ParseResult): boolean {
+  return parseResult.comments[0]?.value.trim() === CSS_EXTRACTION_DISABLE_COMMENT;
+}
+
 function concatCSSRulesByBucket(bucketA: CSSRulesByBucket = {}, bucketB: CSSRulesByBucket) {
   // eslint-disable-next-line guard-for-in
   for (const cssBucketName in bucketB) {
@@ -134,6 +143,10 @@ export function transformSync(sourceCode: string, options: TransformOptions): Tr
 
   if (parseResult.errors.length > 0) {
     throw new Error(`Failed to parse "${filename}": ${parseResult.errors.map(e => e.message).join(', ')}`);
+  }
+
+  if (hasCSSExtractionDisableComment(parseResult)) {
+    return { code: sourceCode, usedProcessing: false, usedVMForEvaluation: false };
   }
 
   if (parseResult.program.body.length > 0 && !parseResult.module.hasModuleSyntax) {

--- a/packages/transform/src/transformSync.test.mts
+++ b/packages/transform/src/transformSync.test.mts
@@ -343,6 +343,11 @@ const TESTS: TestCase[] = [
     },
   },
   {
+    title: 'css extraction disabled by a comment on top of a file',
+    fixture: path.resolve(fixturesDir, 'css-extraction-disabled', 'code.ts'),
+    outputFixture: path.resolve(fixturesDir, 'css-extraction-disabled', 'output.ts'),
+  },
+  {
     title: 'errors: throws on invalid argument count',
     fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
     error: /function accepts only a single param/,


### PR DESCRIPTION
## Problem

`@griffel/react` wraps the style functions of `@griffel/core` and calls them with a second argument:

```js
import { makeStyles as vanillaMakeStyles } from '@griffel/core';

export function makeStyles(stylesBySlots) {
  return vanillaMakeStyles(stylesBySlots, insertionFactory);
}
```

`@griffel/transform` sees an import of `makeStyles` from `@griffel/core`, treats the wrapper as a user land call and throws:

```
makeStyles() function accepts only a single param, got 2 in .../@griffel/react/makeStyles.js
```

It affects `makeStyles()`, `makeResetStyles()` and `makeStaticStyles()` of `@griffel/react`. Running the transform over the built output of the package reproduces it on exactly those three files, `@griffel/core` is not affected as it declares the functions rather than importing them.

This breaks any bundler integration that does not exclude `node_modules` — which is exactly what [the README of `@griffel/webpack-plugin`](https://github.com/microsoft/griffel/blob/main/packages/webpack-plugin/README.md) suggests when dependencies use Griffel, and what `@griffel/vite-plugin` (#1058) does by default.

## Solution

A file can now opt out of the extraction with a `griffel-css-extraction-disable` comment placed on top of it, in which case `transformSync()` returns the source code as is:

```js
'use client';

// griffel-css-extraction-disable
// These wrappers forward user styles to @griffel/core, there is nothing to extract ahead of time

import { makeStyles as vanillaMakeStyles } from '@griffel/core';
```

It has to be **the first comment of a file** and nothing else may share that comment, so a stray mention deeper in a file, or inside a string, does not silently disable the extraction. Anything that is not a comment is allowed above it, which matters here because every affected file starts with a `'use client'` directive.

The marker is applied to the three wrappers of `@griffel/react`. `tsc` preserves comments, so it survives the build and ships to NPM — verified against `dist`, where the transform now reports zero errors and removing the marker brings back exactly the three original ones.

**It is intentionally undocumented**: the constant is not exported from the entrypoint and it is not mentioned in any README, so we are free to change or drop it later.

## Alternative that was dropped

The first revision skipped `node_modules/@griffel/` by path in `@griffel/webpack-plugin`. It fixed the symptom in one bundler only and did nothing for user land wrappers, so it was replaced by the marker.

Note that consumers only benefit after upgrading `@griffel/react` — the published files of older versions carry no marker.

