### PR TITLE
test(e2e): add an end to end suite for `@griffel/vite-plugin`

### DIFF
--- a/e2e/vite/README.md
+++ b/e2e/vite/README.md
@@ -1,0 +1,31 @@
+# @griffel/e2e-vite
+
+End-to-end test that ensures AOT compilation & CSS extraction remain compatible with Vite.
+
+The suite packs the local Griffel packages into a temporary project, installs Vite, runs a real
+build of the app in [`src/fixture`](./src/fixture) and compares the emitted CSS against
+[`src/snapshot.css`](./src/snapshot.css).
+
+It also asserts that **exactly one** stylesheet is emitted: Griffel rules may only be overridden by
+rules from the same or a later style bucket, so they must not be spread over stylesheets that load
+in an arbitrary order.
+
+Unlike the Webpack & Rspack suites, `@griffel/react` is **not** externalized. The plugin excludes
+nothing by default, so its sources are transformed as part of the build — which is what keeps the
+`griffel-css-extraction-disable` marker they carry covered.
+
+Run it with:
+
+```sh
+yarn nx run @griffel/e2e-vite:test
+```
+
+Update the CSS snapshot after an intentional change with:
+
+```sh
+yarn nx run @griffel/e2e-vite:test --update
+```
+
+> [!NOTE]
+> Snapshots are formatted with Prettier, and class names for rules containing `url()` are redacted:
+> `@griffel/transform` hashes the resolved absolute asset path, which differs per machine.

--- a/e2e/vite/eslint.config.mjs
+++ b/e2e/vite/eslint.config.mjs
@@ -1,0 +1,36 @@
+import path from 'node:path';
+
+import baseConfig from '../../eslint.config.mjs';
+
+const workspaceRoot = path.resolve(import.meta.dirname, '..', '..');
+
+export default [
+  {
+    ignores: ['**/dist', '**/out-tsc'],
+  },
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+  {
+    // Everything under src/** is test harness code — assets, scenario configs,
+    // and the runner. Allow it to import devDependencies, and consult the
+    // workspace root package.json so workspace-level devDeps (e.g. vite) do not
+    // have to be re-declared here.
+    files: ['**/src/**/*.{ts,tsx,js,jsx,mjs}'],
+    rules: {
+      'import-x/no-extraneous-dependencies': [
+        'error',
+        {
+          devDependencies: true,
+          packageDir: [import.meta.dirname, workspaceRoot],
+        },
+      ],
+    },
+  },
+];

--- a/e2e/vite/package.json
+++ b/e2e/vite/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@griffel/e2e-vite",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "dependencies": {
+    "@griffel/css-extraction-utils": "^1.0.0",
+    "@griffel/e2e-utils": "*",
+    "@griffel/react": "^1.7.6",
+    "@griffel/vite-plugin": "^0.1.16"
+  }
+}

--- a/e2e/vite/project.json
+++ b/e2e/vite/project.json
@@ -1,0 +1,29 @@
+{
+  "name": "@griffel/e2e-vite",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "e2e/vite/src",
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "dependsOn": [
+        { "target": "build", "dependencies": true },
+        { "target": "build-cjs", "dependencies": true }
+      ],
+      "outputs": []
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "e2e/vite",
+        "commands": [{ "command": "tsc -b --pretty" }],
+        "outputPath": []
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  },
+  "tags": []
+}

--- a/e2e/vite/src/fixture/index.html
+++ b/e2e/vite/src/fixture/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@griffel/e2e-vite</title>
+  </head>
+  <body>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/e2e/vite/src/fixture/src/Component.js
+++ b/e2e/vite/src/fixture/src/Component.js
@@ -1,0 +1,37 @@
+import { makeResetStyles, makeStyles } from '@griffel/react';
+import { colors } from './colors.js';
+import lightBackgroundImage from './images/background.svg';
+
+const useClasses = makeStyles({
+  root: {
+    backgroundColor: colors.background,
+    color: colors.foreground,
+
+    ':focus': {
+      outlineOffset: '5px',
+    },
+
+    '@media (min-width: 968px) and (orientation: landscape)': {
+      width: '400px',
+    },
+  },
+  slot: {
+    border: '2px dashed magenta',
+    borderRadius: '5px',
+    gap: '5px',
+    padding: '10px',
+  },
+  lightBackground: {
+    backgroundImage: `url(${lightBackgroundImage})`,
+  },
+});
+
+const useBaseClass = makeResetStyles({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '200px',
+});
+
+export function Component() {
+  return [useBaseClass(), useClasses()];
+}

--- a/e2e/vite/src/fixture/src/colors.js
+++ b/e2e/vite/src/fixture/src/colors.js
@@ -1,0 +1,4 @@
+export const colors = {
+  background: 'blue',
+  foreground: 'red',
+};

--- a/e2e/vite/src/fixture/src/images/background.svg
+++ b/e2e/vite/src/fixture/src/images/background.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"><rect width="100" height="100" fill="#0078d4"/></svg>

--- a/e2e/vite/src/fixture/src/index.js
+++ b/e2e/vite/src/fixture/src/index.js
@@ -1,0 +1,3 @@
+import { Component } from './Component.js';
+
+console.log(Component);

--- a/e2e/vite/src/fixture/vite.config.mjs
+++ b/e2e/vite/src/fixture/vite.config.mjs
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import { griffel } from '@griffel/vite-plugin';
+
+export default defineConfig({
+  plugins: [griffel()],
+
+  build: {
+    minify: false,
+    // Vite inlines small assets as data URIs, emit a real file instead so that rewriting of "url()"
+    // references in the extracted CSS is covered
+    assetsInlineLimit: 0,
+
+    rollupOptions: {
+      output: {
+        // Content hashes would make the emitted file names differ per build, the suite asserts on them
+        assetFileNames: '[name][extname]',
+        entryFileNames: '[name].js',
+      },
+    },
+  },
+});

--- a/e2e/vite/src/snapshot.css
+++ b/e2e/vite/src/snapshot.css
@@ -1,0 +1,34 @@
+.rddpni4 {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+}
+.frolweh {
+  border: 2px dashed magenta;
+}
+.f4khpsj {
+  border-radius: 5px;
+}
+.f165xgdd {
+  gap: 5px;
+}
+.fbhmu18 {
+  padding: 10px;
+}
+.f1bh81bl {
+  background-color: blue;
+}
+.fe3e8s9 {
+  color: red;
+}
+.PATH_DEPENDANT_REDACTED {
+  background-image: url(/background.svg);
+}
+.f1ir1d6m:focus {
+  outline-offset: 5px;
+}
+@media (min-width: 968px) and (orientation: landscape) {
+  .f1tnsuik {
+    width: 400px;
+  }
+}

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -1,0 +1,92 @@
+import {
+  configureYarn,
+  copyAssets,
+  createTempDir,
+  installPackages,
+  packLocalPackage,
+  removeTempDir,
+  sh,
+} from '@griffel/e2e-utils';
+import fs from 'fs';
+import path from 'path';
+import prettier from 'prettier';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
+const SNAPSHOT_FILE = path.resolve(import.meta.dirname, 'snapshot.css');
+
+/** A build of the example project measures ~2s on CI; anything near 30s is a hung bundler. */
+const VITE_BUILD_TIMEOUT = 30_000;
+
+const GRIFFEL_PACKAGES = [
+  '@griffel/style-types',
+  '@griffel/core',
+  '@griffel/react',
+  '@griffel/transform-shaker',
+  '@griffel/transform',
+  '@griffel/css-extraction-utils',
+  '@griffel/vite-plugin',
+];
+
+// `@griffel/transform` embeds the absolute path of resolved assets into the CSS rule before the
+// class-name hash is computed, so any rule with a `url()` ends up with a class name that depends on
+// the build's absolute temp directory. Redact those class names to a fixed placeholder so the
+// snapshot survives across machines and tempdirs.
+function redactPathDependentClasses(css: string): string {
+  return css.replace(/\.f[a-z0-9]+(?=\s*\{[^}]*\burl\()/g, '.PATH_DEPENDANT_REDACTED');
+}
+
+async function readCSSFiles(distDir: string): Promise<string[]> {
+  const entries = await fs.promises.readdir(distDir, { recursive: true, withFileTypes: true });
+
+  return entries
+    .filter(entry => entry.isFile() && entry.name.endsWith('.css'))
+    .map(entry => path.relative(distDir, path.resolve(entry.parentPath, entry.name)))
+    .sort();
+}
+
+describe('@griffel/vite-plugin', () => {
+  let tempDir: string;
+  let distDir: string;
+
+  beforeAll(async () => {
+    tempDir = createTempDir('vite');
+    distDir = path.resolve(tempDir, 'dist');
+
+    await copyAssets({ assetsPath: path.resolve(import.meta.dirname, 'fixture'), tempDir });
+    await configureYarn({ tempDir, rootDir: ROOT_DIR });
+
+    const resolutions = await Promise.all(GRIFFEL_PACKAGES.map(pkg => packLocalPackage(ROOT_DIR, tempDir, pkg)));
+
+    await installPackages({
+      packages: ['vite', 'react', 'react-dom'],
+      resolutions,
+      tempDir,
+      rootDir: ROOT_DIR,
+    });
+  });
+
+  afterAll(() => removeTempDir(tempDir));
+
+  it('builds an application', async () => {
+    await expect(sh('yarn vite build', tempDir, { timeout: VITE_BUILD_TIMEOUT })).resolves.toBeTypeOf('string');
+  });
+
+  // Griffel rules can only be overridden by rules from the same or a later style bucket, so they
+  // must not be spread over stylesheets that load in an arbitrary order. The plugin moves them all
+  // into the stylesheet of an entrypoint, which for this app means a single emitted CSS file.
+  it('emits all Griffel rules into a single stylesheet', async () => {
+    await expect(readCSSFiles(distDir)).resolves.toHaveLength(1);
+  });
+
+  it('emits CSS matching the snapshot', async () => {
+    const [cssFile] = await readCSSFiles(distDir);
+
+    const contents = await fs.promises.readFile(path.resolve(distDir, cssFile), 'utf8');
+    const formatted = (await prettier.format(contents, { parser: 'css' })).trim();
+
+    // `toMatchFileSnapshot` compares against the raw file contents, so the trailing newline every
+    // text file ends with has to be part of the value being asserted.
+    await expect(redactPathDependentClasses(formatted) + '\n').toMatchFileSnapshot(SNAPSHOT_FILE);
+  });
+});

--- a/e2e/vite/tsconfig.json
+++ b/e2e/vite/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "target": "es2020",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true,
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/e2e/vite/tsconfig.lib.json
+++ b/e2e/vite/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "environment", "static-assets"]
+  },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js"]
+}

--- a/e2e/vite/vitest.config.mts
+++ b/e2e/vite/vitest.config.mts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/e2e/vite',
+  plugins: [nxViteTsPaths()],
+  test: {
+    watch: false,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    // Each command these suites run carries its own timeout (see `sh()` in `@griffel/e2e-utils`),
+    // which is what actually bounds them: it kills the process instead of only abandoning the
+    // promise, and reports which command hung. These are the backstop for anything outside a
+    // command, so they sit above the largest of those budgets rather than below it — a 120s hook
+    // was killing installs that were merely slow, not stuck.
+    testTimeout: 120_000,
+    hookTimeout: 420_000,
+    // Concurrent `yarn install`s contend on the shared Yarn cache and concurrent bundler builds are
+    // memory hungry. Keep the strictly sequential behaviour the custom runner had.
+    fileParallelism: false,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3755,6 +3755,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@griffel/e2e-vite@workspace:e2e/vite":
+  version: 0.0.0-use.local
+  resolution: "@griffel/e2e-vite@workspace:e2e/vite"
+  dependencies:
+    "@griffel/css-extraction-utils": "npm:^1.0.0"
+    "@griffel/e2e-utils": "npm:*"
+    "@griffel/react": "npm:^1.7.6"
+    "@griffel/vite-plugin": "npm:^0.1.16"
+  languageName: unknown
+  linkType: soft
+
 "@griffel/eslint-plugin@workspace:packages/eslint-plugin":
   version: 0.0.0-use.local
   resolution: "@griffel/eslint-plugin@workspace:packages/eslint-plugin"
@@ -3852,7 +3863,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@griffel/vite-plugin@workspace:packages/vite-plugin":
+"@griffel/vite-plugin@npm:^0.1.16, @griffel/vite-plugin@workspace:packages/vite-plugin":
   version: 0.0.0-use.local
   resolution: "@griffel/vite-plugin@workspace:packages/vite-plugin"
   dependencies:


### PR DESCRIPTION
## Overview

Adds `@griffel/e2e-vite`, an end to end suite for `@griffel/vite-plugin`. Split out of #1058 to keep that PR reviewable, now rebased on `main`.

It mirrors `@griffel/e2e-rspack`: the local Griffel packages are packed with `npm pack`, installed into a temporary project together with Vite, then a **real** `vite build` runs and the emitted CSS is compared against a snapshot. This is the coverage the in-package tests cannot give — it exercises the published artifacts (`exports` map, dependency ranges, the built output rather than sources).

## Implementation

The app under test, in `src/fixture`, is a copy of the one `@griffel/e2e-rspack` uses — `makeStyles()` with a media query & a pseudo class, `makeResetStyles()`, and an `url()` asset — so the two bundlers are compared on identical input. It is driven from an `index.html` entry, which is the idiomatic Vite setup.

Three assertions:

1. `vite build` succeeds
2. **exactly one** CSS file is emitted
3. its contents match `src/snapshot.css`

The second one is the interesting one. Griffel rules may only be overridden by rules from the same or a later style bucket, so they must not be spread across stylesheets that load in an arbitrary order — the plugin's whole job in `generateBundle` is to pull them out of every chunk asset and merge them into the entrypoint stylesheet. Counting the emitted files pins that invariant directly.

The resulting snapshot is **byte identical** to `@griffel/e2e-rspack`'s `modern-rspack-2.css` apart from the asset URL, which is a nice cross bundler check on rule generation and bucket ordering.

### `@griffel/react` is deliberately not externalized

The Webpack & Rspack suites set `externals: { '@griffel/react': 'Griffel' }`. This one does not, so `node_modules/@griffel/react` is transformed as part of the build.

That is on purpose: the plugin excludes nothing by default, and `@griffel/react`'s style function wrappers only survive the transform thanks to the `griffel-css-extraction-disable` marker added in #1063. Verified that they are genuinely reached — with `collectStats` the build reports 30 processed files including `node_modules/@griffel/react/src/makeStyles.js`, which is exactly one of the three marked files. Removing the marker breaks this suite.

### Asset inlining

`build.assetsInlineLimit: 0` — Vite would otherwise inline the 140 byte SVG as a data URI and the rewriting of `url()` references in the extracted CSS would never run.

## Test plan

```sh
yarn nx run @griffel/e2e-vite:test
```

3 tests pass. `lint`, `type-check` and `syncpack` pass, and the full `lint,type-check,build,test` run is green across all 25 projects.

> [!NOTE]
> `e2e/vite/eslint.config.mjs` widens the harness override to `.mjs` so the fixture's `vite.config.mjs` may import `vite` from the workspace root devDependencies, the same allowance the Rspack suite has for its `.js` configs.
