### PR TITLE
refactor: share the transform resolver via `@griffel/css-extraction-utils`

### DIFF
--- a/change/@griffel-css-extraction-utils-shared-resolver.json
+++ b/change/@griffel-css-extraction-utils-shared-resolver.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add \"createTransformResolver()\" shared by bundler integrations",
+  "packageName": "@griffel/css-extraction-utils",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-vite-plugin-shared-resolver.json
+++ b/change/@griffel-vite-plugin-shared-resolver.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use the resolver shared via \"@griffel/css-extraction-utils\"",
+  "packageName": "@griffel/vite-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@griffel-webpack-plugin-shared-resolver.json
+++ b/change/@griffel-webpack-plugin-shared-resolver.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use the resolver shared via \"@griffel/css-extraction-utils\"",
+  "packageName": "@griffel/webpack-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/css-extraction-utils/package.json
+++ b/packages/css-extraction-utils/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@griffel/core": "^1.21.3",
     "@griffel/transform": "^3.0.7",
+    "oxc-resolver": "^11.24.2",
     "stylis": "^4.4.0"
   }
 }

--- a/packages/css-extraction-utils/src/createTransformResolver.mts
+++ b/packages/css-extraction-utils/src/createTransformResolver.mts
@@ -1,0 +1,62 @@
+import { ResolverFactory, type NapiResolveOptions } from 'oxc-resolver';
+import type { TransformResolver } from '@griffel/transform';
+import * as path from 'node:path';
+
+/**
+ * These packages ship helpers as CommonJS only, resolving them with the "import" condition picks an entry that cannot
+ * be evaluated.
+ */
+function isCJSOnlyPackage(id: string): boolean {
+  return id === 'tslib' || id.startsWith('@babel/runtime') || id.startsWith('@swc/helpers');
+}
+
+const RESOLVE_OPTIONS_DEFAULTS: NapiResolveOptions = {
+  conditionNames: ['require'],
+  extensions: ['.js', '.jsx', '.cjs', '.mjs', '.ts', '.tsx', '.json'],
+};
+
+export type TransformResolverOptions = {
+  /** Aliases applied while resolving, mirrors the `alias` option of a bundler. */
+  alias?: NapiResolveOptions['alias'];
+};
+
+/**
+ * Creates a resolver for imports inside modules that are evaluated during the transform.
+ *
+ * ⚠ Bundlers expose their own resolvers, but they are asynchronous while the Griffel transform is synchronous, so an
+ * independent resolver is used instead.
+ */
+export function createTransformResolver(options: TransformResolverOptions = {}): TransformResolver {
+  const { alias } = options;
+
+  const cjsResolver = new ResolverFactory({
+    ...RESOLVE_OPTIONS_DEFAULTS,
+    ...(alias ? { alias } : null),
+  });
+
+  // Clone shares the underlying cache; extensions must be re-specified as cloneWithOptions does not persist them
+  const esmResolver = cjsResolver.cloneWithOptions({
+    ...RESOLVE_OPTIONS_DEFAULTS,
+    ...(alias ? { alias } : null),
+    conditionNames: ['import'],
+    mainFields: ['module', 'main'],
+  });
+
+  return function resolveModule(id, { filename }) {
+    const resolver = isCJSOnlyPackage(id) ? cjsResolver : esmResolver;
+    const resolved = resolver.sync(path.dirname(filename), id);
+
+    if (resolved.error) {
+      throw resolved.error;
+    }
+
+    if (!resolved.path) {
+      throw new Error(`oxc-resolver: Failed to resolve module "${id}"`);
+    }
+
+    return {
+      path: resolved.path,
+      builtin: !!resolved.builtin,
+    };
+  };
+}

--- a/packages/css-extraction-utils/src/createTransformResolver.test.mts
+++ b/packages/css-extraction-utils/src/createTransformResolver.test.mts
@@ -2,11 +2,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import type { Compilation } from 'webpack';
 
-import { createResolverFactory } from './createResolverFactory.mjs';
-
-const compilationStub = {} as Compilation;
+import { createTransformResolver } from './createTransformResolver.mjs';
 
 /**
  * Creates a temporary directory with a fake node_modules structure.
@@ -106,8 +103,14 @@ beforeAll(() => {
   );
 
   // @babel/runtime — CJS-only exception
-  writeFile(path.join(tmpDir, 'node_modules', '@babel', 'runtime', 'helpers', 'interopRequireDefault.js'), 'module.exports = {};');
-  writeFile(path.join(tmpDir, 'node_modules', '@babel', 'runtime', 'helpers', 'esm', 'interopRequireDefault.js'), 'export {};');
+  writeFile(
+    path.join(tmpDir, 'node_modules', '@babel', 'runtime', 'helpers', 'interopRequireDefault.js'),
+    'module.exports = {};',
+  );
+  writeFile(
+    path.join(tmpDir, 'node_modules', '@babel', 'runtime', 'helpers', 'esm', 'interopRequireDefault.js'),
+    'export {};',
+  );
   writeFile(
     path.join(tmpDir, 'node_modules', '@babel', 'runtime', 'package.json'),
     JSON.stringify({
@@ -148,21 +151,20 @@ function makeContext(id: string) {
   return { id, filename: path.join(tmpDir, 'src', 'app.js'), paths: [] };
 }
 
-describe('createResolverFactory', () => {
-  it('returns a factory function', () => {
-    const factory = createResolverFactory();
-    expect(typeof factory).toBe('function');
+describe('createTransformResolver', () => {
+  it('returns a resolver function', () => {
+    expect(typeof createTransformResolver()).toBe('function');
   });
 
   it('throws for unresolvable modules', () => {
-    const resolve = createResolverFactory()(compilationStub);
+    const resolve = createTransformResolver();
     expect(() => resolve('__nonexistent_package__', makeContext('__nonexistent_package__'))).toThrow();
   });
 });
 
 describe('resolver selection', () => {
   it('resolves packages with ESM conditions by default', () => {
-    const resolve = createResolverFactory()(compilationStub);
+    const resolve = createTransformResolver();
     const resolved = resolve('@fluentui/react-button', makeContext('@fluentui/react-button'));
 
     expect(resolved.path).toContain(path.join('lib-esm', 'index.js'));
@@ -171,7 +173,7 @@ describe('resolver selection', () => {
 
 describe('CJS-only exceptions', () => {
   it('resolves tslib with CJS conditions', () => {
-    const resolve = createResolverFactory()(compilationStub);
+    const resolve = createTransformResolver();
     const resolved = resolve('tslib', makeContext('tslib'));
 
     expect(resolved.path).toContain('tslib.js');
@@ -179,17 +181,40 @@ describe('CJS-only exceptions', () => {
   });
 
   it('resolves @babel/runtime with CJS conditions', () => {
-    const resolve = createResolverFactory()(compilationStub);
-    const resolved = resolve('@babel/runtime/helpers/interopRequireDefault', makeContext('@babel/runtime/helpers/interopRequireDefault'));
+    const resolve = createTransformResolver();
+    const resolved = resolve(
+      '@babel/runtime/helpers/interopRequireDefault',
+      makeContext('@babel/runtime/helpers/interopRequireDefault'),
+    );
 
     expect(resolved.path).toContain(path.join('helpers', 'interopRequireDefault.js'));
     expect(resolved.path).not.toContain('esm');
   });
 
   it('resolves @swc/helpers with CJS conditions', () => {
-    const resolve = createResolverFactory()(compilationStub);
+    const resolve = createTransformResolver();
     const resolved = resolve('@swc/helpers', makeContext('@swc/helpers'));
 
     expect(resolved.path).toContain(path.join('cjs', 'index.cjs'));
+  });
+});
+
+describe('alias', () => {
+  it('resolves an aliased module', () => {
+    const resolve = createTransformResolver({
+      alias: { '#alias': [path.join(tmpDir, 'node_modules', 'some-lib')] },
+    });
+    const resolved = resolve('#alias', makeContext('#alias'));
+
+    expect(resolved.path).toContain(path.join('some-lib', 'index.js'));
+  });
+
+  it('does not affect modules that are not aliased', () => {
+    const resolve = createTransformResolver({
+      alias: { '#alias': [path.join(tmpDir, 'node_modules', 'some-lib')] },
+    });
+    const resolved = resolve('tslib', makeContext('tslib'));
+
+    expect(resolved.path).toContain('tslib.js');
   });
 });

--- a/packages/css-extraction-utils/src/index.mts
+++ b/packages/css-extraction-utils/src/index.mts
@@ -1,5 +1,6 @@
 export { CSS_START_MARKER } from './constants.mjs';
 export { createStatsCollector, type StatsCollectorOptions, type TransformStats } from './createStatsCollector.mjs';
+export { createTransformResolver, type TransformResolverOptions } from './createTransformResolver.mjs';
 export { generateCSSRules } from './generateCSSRules.mjs';
 export { parseCSSRules } from './parseCSSRules.mjs';
 export { resolveAssetPathsInCSSRules } from './resolveAssetPaths.mjs';

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -20,8 +20,7 @@
   "dependencies": {
     "@griffel/core": "^1.21.3",
     "@griffel/css-extraction-utils": "^1.0.0",
-    "@griffel/transform": "^3.0.7",
-    "oxc-resolver": "^11.24.2"
+    "@griffel/transform": "^3.0.7"
   },
   "peerDependencies": {
     "vite": "^8.0.0"

--- a/packages/vite-plugin/src/resolver/createResolverFactory.mts
+++ b/packages/vite-plugin/src/resolver/createResolverFactory.mts
@@ -1,60 +1,11 @@
-import { ResolverFactory, type NapiResolveOptions } from 'oxc-resolver';
+import { createTransformResolver, type TransformResolverOptions } from '@griffel/css-extraction-utils';
 import type { TransformResolver } from '@griffel/transform';
-import * as path from 'node:path';
 
-function isCJSOnlyPackage(id: string): boolean {
-  return id === 'tslib' || id.startsWith('@babel/runtime') || id.startsWith('@swc/helpers');
-}
+export type ResolverFactoryOptions = TransformResolverOptions;
+export type TransformResolverFactory = (options: ResolverFactoryOptions) => TransformResolver;
 
-const RESOLVE_OPTIONS_DEFAULTS: NapiResolveOptions = {
-  conditionNames: ['require'],
-  extensions: ['.js', '.jsx', '.cjs', '.mjs', '.ts', '.tsx', '.json'],
-};
-
-/**
- * Creates a resolver used to resolve imports inside modules that are evaluated during the transform.
- *
- * ⚠ Vite's own resolver (`this.resolve()`) is asynchronous, while the Griffel transform is synchronous, so an
- * independent resolver is used instead. `alias` from the Vite config is passed in to keep custom aliases working.
- */
 export function createResolverFactory(): TransformResolverFactory {
   return function (options: ResolverFactoryOptions = {}): TransformResolver {
-    const cjsResolver = new ResolverFactory({
-      ...RESOLVE_OPTIONS_DEFAULTS,
-      ...(options.alias ? { alias: options.alias } : null),
-    });
-
-    // Clone shares the underlying cache; extensions must be re-specified as cloneWithOptions does not persist them
-    const esmResolver = cjsResolver.cloneWithOptions({
-      ...RESOLVE_OPTIONS_DEFAULTS,
-      ...(options.alias ? { alias: options.alias } : null),
-      conditionNames: ['import'],
-      mainFields: ['module', 'main'],
-    });
-
-    return function resolveModule(id, { filename }) {
-      const resolver = isCJSOnlyPackage(id) ? cjsResolver : esmResolver;
-      const resolved = resolver.sync(path.dirname(filename), id);
-
-      if (resolved.error) {
-        throw resolved.error;
-      }
-
-      if (!resolved.path) {
-        throw new Error(`oxc-resolver: Failed to resolve module "${id}"`);
-      }
-
-      return {
-        path: resolved.path,
-        builtin: !!resolved.builtin,
-      };
-    };
+    return createTransformResolver(options);
   };
 }
-
-export type ResolverFactoryOptions = {
-  /** Aliases derived from `resolve.alias` of the Vite config. */
-  alias?: NapiResolveOptions['alias'];
-};
-
-export type TransformResolverFactory = (options: ResolverFactoryOptions) => TransformResolver;

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@griffel/core": "^1.21.3",
     "@griffel/css-extraction-utils": "^1.0.0",
-    "@griffel/transform": "^3.0.7",
-    "oxc-resolver": "^11.24.2"
+    "@griffel/transform": "^3.0.7"
   },
   "peerDependencies": {
     "webpack": "^5"

--- a/packages/webpack-plugin/src/resolver/createResolverFactory.mts
+++ b/packages/webpack-plugin/src/resolver/createResolverFactory.mts
@@ -1,16 +1,6 @@
-import { ResolverFactory, type NapiResolveOptions } from 'oxc-resolver';
+import { createTransformResolver } from '@griffel/css-extraction-utils';
 import type { TransformResolver } from '@griffel/transform';
 import type { Compilation } from 'webpack';
-import * as path from 'node:path';
-
-function isCJSOnlyPackage(id: string): boolean {
-  return id === 'tslib' || id.startsWith('@babel/runtime') || id.startsWith('@swc/helpers');
-}
-
-const RESOLVE_OPTIONS_DEFAULTS: NapiResolveOptions = {
-  conditionNames: ['require'],
-  extensions: ['.js', '.jsx', '.cjs', '.mjs', '.ts', '.tsx', '.json'],
-};
 
 export type TransformResolverFactory = (compilation: Compilation) => TransformResolver;
 
@@ -22,33 +12,6 @@ export function createResolverFactory(): TransformResolverFactory {
     // for programmatic usage. This API is used by many loaders/plugins, so hope we're safe for a while
     // const resolveOptionsFromWebpackConfig = (compilation?.options.resolve ?? {}) as NapiResolveOptions;
 
-    const cjsResolver = new ResolverFactory({
-      ...RESOLVE_OPTIONS_DEFAULTS,
-      // ...resolveOptionsFromWebpackConfig,
-    });
-
-    // Clone shares the underlying cache; extensions must be re-specified as cloneWithOptions does not persist them
-    const esmResolver = cjsResolver.cloneWithOptions({
-      ...RESOLVE_OPTIONS_DEFAULTS,
-      conditionNames: ['import'],
-      mainFields: ['module', 'main'],
-    });
-
-    return function resolveModule(id, { filename }) {
-      const resolver = isCJSOnlyPackage(id) ? cjsResolver : esmResolver;
-      const resolved = resolver.sync(path.dirname(filename), id);
-
-      if (resolved.error) {
-        throw resolved.error;
-      }
-      if (!resolved.path) {
-        throw new Error(`oxc-resolver: Failed to resolve module "${id}"`);
-      }
-
-      return {
-        path: resolved.path,
-        builtin: !!resolved.builtin,
-      };
-    };
+    return createTransformResolver();
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,6 +3706,7 @@ __metadata:
   dependencies:
     "@griffel/core": "npm:^1.21.3"
     "@griffel/transform": "npm:^3.0.7"
+    oxc-resolver: "npm:^11.24.2"
     stylis: "npm:^4.4.0"
   languageName: unknown
   linkType: soft
@@ -3859,7 +3860,6 @@ __metadata:
     "@griffel/core": "npm:^1.21.3"
     "@griffel/css-extraction-utils": "npm:^1.0.0"
     "@griffel/transform": "npm:^3.0.7"
-    oxc-resolver: "npm:^11.24.2"
   peerDependencies:
     vite: ^8.0.0
   languageName: unknown
@@ -3900,7 +3900,6 @@ __metadata:
     "@griffel/core": "npm:^1.21.3"
     "@griffel/css-extraction-utils": "npm:^1.0.0"
     "@griffel/transform": "npm:^3.0.7"
-    oxc-resolver: "npm:^11.24.2"
   peerDependencies:
     webpack: ^5
   languageName: unknown


### PR DESCRIPTION
## Overview

Follow up to #1064, which shared the CSS extraction utils between the Webpack & Vite plugins but left one duplicate behind.

`packages/webpack-plugin/src/resolver/` and `packages/vite-plugin/src/resolver/` held near identical copies of the resolver used for imports inside modules that are evaluated during the transform — ~35 of 58 lines were the same. Only the factory argument differed.

## Implementation

The shared core lands as `createTransformResolver()` in `@griffel/css-extraction-utils`:

```ts
export function createTransformResolver(options?: { alias?: NapiResolveOptions['alias'] }): TransformResolver;
```

It owns what was duplicated: the CJS-only package list (`tslib`, `@babel/runtime`, `@swc/helpers`), `RESOLVE_OPTIONS_DEFAULTS`, the CJS & ESM resolver pair and the `resolveModule` closure.

Each plugin keeps a thin wrapper, so **no public API changes**:

| Plugin | Public factory type | Unchanged |
| --- | --- | --- |
| `@griffel/webpack-plugin` | `(compilation: Compilation) => TransformResolver` | ✅ |
| `@griffel/vite-plugin` | `(options: ResolverFactoryOptions) => TransformResolver` | ✅ |

`ResolverFactoryOptions` is now an alias of the shared `TransformResolverOptions`, and both plugins still export `createResolverFactory` from their entry points. The Webpack wrapper keeps its commented out `resolveOptionsFromWebpackConfig` note, that decision is untouched here.

`oxc-resolver` is dropped from both plugins' dependencies — neither imports it anymore.

## Test plan

`createResolverFactory.test.mts` was the only suite covering this code and lived in `@griffel/webpack-plugin`. It is `git mv`'d to `@griffel/css-extraction-utils` and retargeted at the shared function, so the Webpack plugin no longer needs a `webpack` type import just to build a stub `Compilation`.

Two cases are added for `alias`. It was implemented in the Vite copy with **no coverage at all**, so this is net new:

- an aliased specifier resolves to the aliased path
- a non aliased specifier is unaffected

```sh
yarn nx run @griffel/css-extraction-utils:test
```

31 tests pass (8 in the resolver suite). `lint`, `type-check`, `build`, `test`, `prettier` and `syncpack` are green across all 24 projects.
